### PR TITLE
[MegaMenu] Fix outline on focus of "View All in [hub name]"

### DIFF
--- a/packages/formation/sass/modules/_m-megamenu.scss
+++ b/packages/formation/sass/modules/_m-megamenu.scss
@@ -18,7 +18,6 @@ $marketing-container-height: 380px;
     a {
       padding: 20px 25px 20px 7px;
       font-weight: bold;
-      width: 111%;
 
       svg {
         width: 15px;


### PR DESCRIPTION
This PR fixes an issue with the focus outline of the "View All in [hub name]" stretching beyond the width of the MegaMenu.

Ticket - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14306

### Before fix
![image](https://user-images.githubusercontent.com/1915775/53520177-0a654500-3aa3-11e9-83a8-cb0e38800526.png)

### After fix
![image](https://user-images.githubusercontent.com/1915775/53520202-16e99d80-3aa3-11e9-8ba4-06e9a6c43b9b.png)
