### PR TITLE
Tweaks to alerts and alert modals

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -34,7 +34,7 @@
     "window-or-global": "^1.0.1"
   },
   "peerDependencies": {
-    "@department-of-veterans-affairs/formation": "^4.0.0",
+    "@department-of-veterans-affairs/formation": "^5.4.0",
     "react": "^15.5.4||^16.7.0"
   }
 }

--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/alerts/AlertBox/AlertBox.jsx
+++ b/packages/formation-react/src/components/alerts/AlertBox/AlertBox.jsx
@@ -38,17 +38,17 @@ class AlertBox extends React.Component {
     const alertClass = classNames(
       'usa-alert',
       `usa-alert-${this.props.status}`,
-      this.props.className
+      this.props.className,
     );
 
-    let closeButton;
-    if (this.props.onCloseAlert) {
-      closeButton = (
-        <button className="va-alert-close" aria-label="Close notification" onClick={this.props.onCloseAlert}>
-          <i className="fas fa-times-circle" aria-label="Close icon"></i>
-        </button>
-      );
-    }
+    const closeButton = this.props.onCloseAlert && (
+      <button
+        className="va-alert-close"
+        aria-label="Close notification"
+        onClick={this.props.onCloseAlert}>
+        <i className="fas fa-times-circle" aria-label="Close icon" />
+      </button>
+    );
 
     const alertHeading = this.props.headline;
     const alertText = this.props.content || this.props.children;

--- a/packages/formation-react/src/components/alerts/AlertBox/AlertBox.jsx
+++ b/packages/formation-react/src/components/alerts/AlertBox/AlertBox.jsx
@@ -46,7 +46,7 @@ class AlertBox extends React.Component {
         className="va-alert-close"
         aria-label="Close notification"
         onClick={this.props.onCloseAlert}>
-        <i className="fas fa-times-circle" aria-label="Close icon" />
+        <i className="fas fa-times-circle" aria-label="Close icon"/>
       </button>
     );
 

--- a/packages/formation-react/src/components/modal/Modal.jsx
+++ b/packages/formation-react/src/components/modal/Modal.jsx
@@ -2,6 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
+import AlertBox from '../alerts/AlertBox/AlertBox';
+
 const ESCAPE_KEY = 27;
 
 class Modal extends React.Component {
@@ -97,39 +99,43 @@ class Modal extends React.Component {
   render() {
     if (!this.props.visible) return null;
 
-    const { id, status, title } = this.props;
+    const { contents, id, status, title } = this.props;
     const titleId = title && `${id || 'va-modal'}-title`;
+    const content = contents || this.props.children;
 
-    const modalClass = classNames(
-      'va-modal',
-      { 'va-modal-alert': status },
-      { [`va-modal-${status}`]: status },
-      this.props.cssClass,
-    );
+    const modalClass = classNames('va-modal', this.props.cssClass);
 
-    let closeButton;
-    if (!this.props.hideCloseButton) {
-      closeButton = (<button
+    const wrapperClass = classNames('va-modal-inner', {
+      'usa-alert': status,
+      [`usa-alert-${status}`]: status,
+      'va-modal-alert': status,
+    });
+
+    const bodyClass = status ? 'usa-alert-body' : 'va-modal-body';
+    const titleClass = status ? 'usa-alert-heading' : 'va-modal-title';
+    const contentClass = classNames({ 'usa-alert-text': status });
+
+    const closeButton = !this.props.hideCloseButton && (
+      <button
         className="va-modal-close"
         type="button"
         aria-label="Close this modal"
         onClick={this.handleClose}>
-        <i className="fas fa-times-circle" aria-hidden="true"></i>
-      </button>);
-    }
+        <i className="fas fa-times-circle" aria-hidden="true" />
+      </button>
+    );
 
     return (
       <div className={modalClass} id={id} role="alertdialog" aria-labelledby={titleId}>
-        <div className="va-modal-inner" ref={el => { this.element = el; }}>
+        <div className={wrapperClass} ref={el => { this.element = el; }}>
           {closeButton}
-          <div className="va-modal-body" role="document">
-            {title && <h3 id={titleId} className="va-modal-title">{title}</h3>}
-            <div>
-              {this.props.contents || this.props.children}
+          <div className={bodyClass}>
+            <div role="document">
+              {title && <h3 id={titleId} className={titleClass}>{title}</h3>}
+              {content && <div className={contentClass}>{content}</div>}
             </div>
             {this.renderAlertActions()}
           </div>
-
         </div>
       </div>
     );
@@ -182,7 +188,8 @@ Modal.propTypes = {
     'info',
     'error',
     'success',
-    'warning'
+    'warning',
+    'continue',
   ]),
   /**
    * Title/header text for the modal

--- a/packages/formation-react/src/components/modal/Modal.jsx
+++ b/packages/formation-react/src/components/modal/Modal.jsx
@@ -99,9 +99,9 @@ class Modal extends React.Component {
   render() {
     if (!this.props.visible) return null;
 
-    const { contents, id, status, title } = this.props;
+    const { id, status, title } = this.props;
     const titleId = title && `${id || 'va-modal'}-title`;
-    const content = contents || this.props.children;
+    const content = this.props.contents || this.props.children;
 
     const modalClass = classNames('va-modal', this.props.cssClass);
 

--- a/packages/formation-react/src/components/modal/Modal.jsx
+++ b/packages/formation-react/src/components/modal/Modal.jsx
@@ -2,8 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-import AlertBox from '../alerts/AlertBox/AlertBox';
-
 const ESCAPE_KEY = 27;
 
 class Modal extends React.Component {
@@ -121,7 +119,7 @@ class Modal extends React.Component {
         type="button"
         aria-label="Close this modal"
         onClick={this.handleClose}>
-        <i className="fas fa-times-circle" aria-hidden="true" />
+        <i className="fas fa-times-circle" aria-hidden="true"/>
       </button>
     );
 

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/base/_b-mixins.scss
+++ b/packages/formation/sass/base/_b-mixins.scss
@@ -156,7 +156,7 @@
   font-size: 2.25rem;
   padding: 0;
   position: absolute;
-  margin: 2rem;
+  margin: 1.5rem;
   right: 0;
   top: 0;
   width: auto;

--- a/packages/formation/sass/base/_b-mixins.scss
+++ b/packages/formation/sass/base/_b-mixins.scss
@@ -156,7 +156,7 @@
   font-size: 2.25rem;
   padding: 0;
   position: absolute;
-  margin: 1.5rem;
+  margin: units(2);
   right: 0;
   top: 0;
   width: auto;

--- a/packages/formation/sass/base/_b-mixins.scss
+++ b/packages/formation/sass/base/_b-mixins.scss
@@ -150,7 +150,28 @@
   }
 }
 
+@mixin close-button {
+  background-color: transparent;
+  color: $color-primary;
+  font-size: 2.25rem;
+  padding: 0;
+  position: absolute;
+  margin: 2rem;
+  right: 0;
+  top: 0;
+  width: auto;
+  z-index: 9;
 
+  &:hover {
+    background-color: transparent;
+    color: $color-primary-darker;
+  }
+
+  &:active {
+    background-color: transparent;
+    color: $color-primary-darkest;
+  }
+}
 
 // Flexbox columns
 @mixin flexbox-col($size) {

--- a/packages/formation/sass/base/_b-mixins.scss
+++ b/packages/formation/sass/base/_b-mixins.scss
@@ -150,7 +150,7 @@
   }
 }
 
-@mixin close-button {
+@mixin modal-close-button {
   background-color: transparent;
   color: $color-primary;
   font-size: 2.25rem;

--- a/packages/formation/sass/modules/_m-alert.scss
+++ b/packages/formation/sass/modules/_m-alert.scss
@@ -187,23 +187,3 @@ p.usa-alert-heading {
     flex-direction: row;
   }
 }
-
-// this can probably be removed
-.edu-benefits-alert {
-  margin-top: 0;
-  margin-bottom: 23px;
-}
-
-.edu-warning-single-line {
-  margin-top: 0;
-}
-
-@media screen and (min-width: 600px) {
-  .edu-warning-single-line {
-    > .usa-alert-body {
-      /*background-size: 4.2rem;
-      background-position: 1.3rem 1.5rem;*/
-    //  padding-left: 5rem;
-    }
-  }
-}

--- a/packages/formation/sass/modules/_m-alert.scss
+++ b/packages/formation/sass/modules/_m-alert.scss
@@ -4,7 +4,7 @@
   border-left-style: solid;
   border-left-width: 10px;
   display: table;
-  padding: 2rem 2rem 2rem 1.5rem;
+  padding: 3rem 6.5rem 3rem 2.5rem;
   width: 100%;
 
   &::before {

--- a/packages/formation/sass/modules/_m-alert.scss
+++ b/packages/formation/sass/modules/_m-alert.scss
@@ -188,20 +188,6 @@ p.usa-alert-heading {
   }
 }
 
-// rx
-
-.rx-app {
-
-  // TODO: Find a better way to write this that doesn't rely on nesting
-  .usa-alert {
-    & + .rx-app-title {
-      margin-top: 2.5rem;
-    }
-  }
-}
-
-// education benefits
-
 // this can probably be removed
 .edu-benefits-alert {
   margin-top: 0;
@@ -219,12 +205,5 @@ p.usa-alert-heading {
       background-position: 1.3rem 1.5rem;*/
     //  padding-left: 5rem;
     }
-  }
-}
-
-//messaging
-#messaging-app-header {
-  .usa-alert {
-    margin-bottom: 2em;
   }
 }

--- a/packages/formation/sass/modules/_m-alert.scss
+++ b/packages/formation/sass/modules/_m-alert.scss
@@ -4,14 +4,14 @@
   border-left-style: solid;
   border-left-width: 10px;
   display: table;
-  padding: 3rem 6.5rem 3rem 2.5rem;
+  padding: units(4) units(8) units(4) units(3);
   width: 100%;
 
   &::before {
     background: none;
     font-family: "Font Awesome 5 Free";
     font-size: 2rem;
-    margin-right: 1.5rem;
+    margin-right: units(2);
     position: static;
     font-weight: 900;
   }
@@ -32,7 +32,7 @@
   }
 
   &-text {
-    margin-top: 2rem;
+    margin-top: units(2.5);
 
     &:only-child {
       margin: 0;
@@ -49,11 +49,11 @@
 
     // should override :first-child
     .usa-alert-heading + p:only-of-type {
-      margin-top: 2rem;
+      margin-top: units(2.5);
     }
 
     ul {
-      padding-left: 2rem;
+      padding-left: units(2.5);
     }
   }
 

--- a/packages/formation/sass/modules/_m-alert.scss
+++ b/packages/formation/sass/modules/_m-alert.scss
@@ -127,7 +127,7 @@
 }
 
 .va-alert-close {
-  @include close-button;
+  @include modal-close-button;
 }
 
 // on post-9/11 GI Bill

--- a/packages/formation/sass/modules/_m-alert.scss
+++ b/packages/formation/sass/modules/_m-alert.scss
@@ -127,25 +127,7 @@
 }
 
 .va-alert-close {
-  font-family: "Font Awesome 5 Free";
-  background: transparent;
-  color: $color-base;
-  margin: 0;
-  padding: 0;
-  position: absolute;
-  right: 2rem;
-  top: 2rem;
-  width: auto;
-
-  &:hover {
-    background: transparent !important;
-    color: lighten($color-gray-dark, 30%);
-  }
-
-  .fa {
-    // Override fa font-size.
-    font-size: 1.45em !important;
-  }
+  @include close-button;
 }
 
 // on post-9/11 GI Bill

--- a/packages/formation/sass/modules/_m-modal.scss
+++ b/packages/formation/sass/modules/_m-modal.scss
@@ -52,6 +52,10 @@
     }
   }
 
+  &-alert {
+    max-width: 60rem;
+  }
+
   &-body {
     overflow-wrap: break-word;
     padding: 2rem;
@@ -83,67 +87,6 @@
         max-height: 95vh;
         overflow-y: auto;
       }
-    }
-  }
-
-  &-alert {
-    .va-modal-inner {
-      max-width: 60rem;
-    }
-
-    .va-modal-body {
-      border-left-style: solid;
-      border-left-width: 10px;
-      padding: 2rem 4rem;
-    }
-
-    .va-modal-title {
-      &::before {
-        font-family: "Font Awesome 5 Free";
-        margin-right: 1.5rem;
-      }
-    }
-  }
-
-  &-info {
-    .va-modal-body {
-      border-left-color: $color-primary-alt-dark;
-    }
-
-    .va-modal-title::before {
-      content: "\f05a";
-    }
-  }
-
-  &-error {
-    .va-modal-body {
-      border-left-color: $color-secondary-dark;
-    }
-
-    .va-modal-title::before {
-      color: $color-secondary-dark;
-      content: "\f06a"
-    }
-  }
-
-  &-success {
-    .va-modal-body {
-      border-left-color: $color-green;
-    }
-
-    .va-modal-title::before {
-      color: $color-green;
-      content: "\f00c";
-    }
-  }
-
-  &-warning {
-    .va-modal-body {
-      border-left-color: $color-gold;
-    }
-
-    .va-modal-title::before {
-      content: "\f071";
     }
   }
 }

--- a/packages/formation/sass/modules/_m-modal.scss
+++ b/packages/formation/sass/modules/_m-modal.scss
@@ -95,5 +95,5 @@
 }
 
 button.va-modal-close {
-  @include close-button;
+  @include modal-close-button;
 }

--- a/packages/formation/sass/modules/_m-modal.scss
+++ b/packages/formation/sass/modules/_m-modal.scss
@@ -27,10 +27,6 @@
     }
   }
 
-  .alert-actions {
-    margin-top: 1.5rem;
-  }
-
   &-title {
     margin: 0;
     margin-bottom: 1.5rem;
@@ -54,6 +50,18 @@
 
   &-alert {
     max-width: 60rem;
+
+    .alert-actions {
+      margin-top: 2.5rem;
+
+      button {
+        margin: 0;
+
+        + button {
+          margin-left: 2rem;
+        }
+      }
+    }
   }
 
   &-body {

--- a/packages/formation/sass/modules/_m-modal.scss
+++ b/packages/formation/sass/modules/_m-modal.scss
@@ -29,7 +29,7 @@
 
   &-title {
     margin: 0;
-    margin-bottom: 1.5rem;
+    margin-bottom: units(2);
   }
 
   &-inner {
@@ -52,13 +52,13 @@
     max-width: 60rem;
 
     .alert-actions {
-      margin-top: 2.5rem;
+      margin-top: units(3);
 
       button {
         margin: 0;
 
         + button {
-          margin-left: 2rem;
+          margin-left: units(2.5);
         }
       }
     }
@@ -66,7 +66,7 @@
 
   &-body {
     overflow-wrap: break-word;
-    padding: 2rem;
+    padding: units(2.5);
     word-break: break-word;
     word-wrap: break-word;
   }

--- a/packages/formation/sass/modules/_m-modal.scss
+++ b/packages/formation/sass/modules/_m-modal.scss
@@ -71,21 +71,6 @@
     word-wrap: break-word;
   }
 
-  &-button-group {
-    bottom: 0;
-    display: -webkit-flex;
-    display: flex;
-    -webkit-align-items: center;
-    align-items: center;
-    position: relative;
-    margin-top: 5rem;
-
-    button {
-      margin: 0 1rem 0 0;
-      width: auto;
-    }
-  }
-
   &-large {
     .va-modal-inner {
       max-width: 75rem;

--- a/packages/formation/sass/modules/_m-modal.scss
+++ b/packages/formation/sass/modules/_m-modal.scss
@@ -159,24 +159,5 @@
 }
 
 button.va-modal-close {
-  background-color: transparent;
-  color: $color-primary;
-  font-size: 2.25rem;
-  padding: 0;
-  position: absolute;
-  margin: 2rem;
-  right: 0;
-  top: 0;
-  width: auto;
-  z-index: 9;
-
-  &:hover {
-    background-color: transparent;
-    color: $color-primary-darker;
-  }
-
-  &:active {
-    background-color: transparent;
-    color: $color-primary-darkest;
-  }
+  @include close-button;
 }

--- a/packages/formation/sass/shared-variables.scss
+++ b/packages/formation/sass/shared-variables.scss
@@ -15,4 +15,5 @@ $image-path: "~uswds/src/img";
 @import "base/b-variables";
 @import "base/b-breakpoints";
 @import "base/b-mixins";
+@import "base/b-functions";
 @import "base/b-element-overrides";


### PR DESCRIPTION
* Refactored alert modals to use alert classes.
* Support for 'continue' status for alert modals.
* Alerts and modals share common close button.
* Spacing changes for alerts (and alert modals) to more closely match design.
* Corrected `formation` peer dep version for `formation-react`.

### Before changes
> <img width="647" alt="screen shot 2019-02-25 at 8 29 50 pm" src="https://user-images.githubusercontent.com/1067024/53665051-51d10a00-3c38-11e9-94ea-2c07e8a710df.png">
> <img width="617" alt="screen shot 2019-02-25 at 12 39 54 pm" src="https://user-images.githubusercontent.com/1067024/53665139-8fce2e00-3c38-11e9-8d67-7bfc521c60b3.png">


### After changes
> <img width="635" alt="screen shot 2019-02-25 at 8 29 26 pm" src="https://user-images.githubusercontent.com/1067024/53665099-73ca8c80-3c38-11e9-8402-7a9cf9ea9f11.png">
> <img width="609" alt="screen shot 2019-02-25 at 8 26 53 pm" src="https://user-images.githubusercontent.com/1067024/53665127-8a70e380-3c38-11e9-8bdb-f56b5434a5e7.png">
