### PR TITLE
Gatsby-remark-graph integration

### DIFF
--- a/packages/documentation/gatsby-config.js
+++ b/packages/documentation/gatsby-config.js
@@ -63,6 +63,20 @@ module.exports = {
       }
     },
     `gatsby-transformer-react-docgen`,
-    `gatsby-transformer-remark`,
+    {
+      resolve: 'gatsby-transformer-remark',
+      options: {
+        plugins: [
+          {
+            resolve: 'gatsby-remark-graph',
+            options: {
+              // this is the language in your code-block that triggers mermaid parsing
+              language: 'mermaid', // default
+              theme: 'default' // could also be dark, forest, or neutral
+            }
+          }
+        ]
+      }
+    }
   ],
 }

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -17,6 +17,7 @@
     "gatsby-plugin-sass": "^2.0.7",
     "gatsby-plugin-sharp": "^2.0.20",
     "gatsby-plugin-sitemap": "^2.0.6",
+    "gatsby-remark-graph": "^0.2.2",
     "gatsby-remark-images": "^3.0.3",
     "gatsby-source-filesystem": "^2.0.8",
     "gatsby-transformer-javascript-frontmatter": "^2.0.5",

--- a/packages/documentation/src/layouts/external-layout.js
+++ b/packages/documentation/src/layouts/external-layout.js
@@ -10,10 +10,9 @@ export default class ExternalLayout extends Component {
 
     return (
       <Layout location={location}>
-        <h2>{data.markdownRemark.fields.slug}</h2>
+        <h2>{data.markdownRemark.frontmatter.title || data.markdownRemark.fields.slug}</h2>
 
         <div
-          className="blog-post-content"
           dangerouslySetInnerHTML={{ __html: data.markdownRemark.html }}/>
       </Layout>
     );
@@ -26,6 +25,9 @@ export const pageQuery = graphql`
       html
       fields {
         slug
+      }
+      frontmatter {
+        title
       }
     }
   }

--- a/packages/documentation/src/layouts/layout.js
+++ b/packages/documentation/src/layouts/layout.js
@@ -56,6 +56,8 @@ class Layout extends React.Component {
                 },
               ]}>
               <html lang="en"/>
+              <script src="https://cdn.rawgit.com/knsv/mermaid/0.5.6/dist/mermaid.min.js"></script>
+              <link rel="stylesheet" href="https://cdn.rawgit.com/knsv/mermaid/0.5.6/dist/mermaid.css" />
             </Helmet>
             <Sidebar location={location}/>
             <div className="ContentArea docSearch-content">{children}</div>

--- a/packages/documentation/src/pages/getting-started/how-to.mdx
+++ b/packages/documentation/src/pages/getting-started/how-to.mdx
@@ -1,6 +1,7 @@
 ---
 title: How to Add Documents
 ---
+
 ## How to Add Documents
 This is the process of how you should add new pages and documents to this website.
 

--- a/packages/documentation/src/pages/getting-started/markdown-mermaid-graph.md
+++ b/packages/documentation/src/pages/getting-started/markdown-mermaid-graph.md
@@ -1,0 +1,31 @@
+---
+title: Add Graphs to Markdown
+---
+
+### Mermaid Library
+To use the graph generator for markdown we need to use the mermaid library. We are using [gatsby-remark-graph](https://github.com/konsumer/gatsby-remark-graph) to do this. We are limited to only be able to use this in .md file and it will not work in .mdx file. It might be possible to make this work with .mdx files in the future but it might take some time to implement.
+
+[https://mermaidjs.github.io/](https://mermaidjs.github.io/)
+
+This current file (src/pages/getting-started/markdown-mermaid-graph) is an example of how to implement it.
+
+### Example code
+**Markdown**
+````
+```mermaid
+graph LR
+    A[Square Rect] -- Link text --> B((Circle))
+    A --> C(Round Rect)
+    B --> D{Rhombus}
+    C --> D
+```
+````
+
+**HTML Output**
+```mermaid
+graph LR
+    A[Square Rect] -- Link text --> B((Circle))
+    A --> C(Round Rect)
+    B --> D{Rhombus}
+    C --> D
+```

--- a/packages/documentation/src/pages/getting-started/markdown-mermaid-graph.md
+++ b/packages/documentation/src/pages/getting-started/markdown-mermaid-graph.md
@@ -3,7 +3,7 @@ title: Add Graphs to Markdown
 ---
 
 ### Mermaid Library
-To use the graph generator for markdown we need to use the mermaid library. We are using [gatsby-remark-graph](https://github.com/konsumer/gatsby-remark-graph) to do this. We are limited to only be able to use this in .md file and it will not work in .mdx file. It might be possible to make this work with .mdx files in the future but it might take some time to implement.
+To use the graph generator for markdown we need to use the mermaid library. We are using [gatsby-remark-graph](https://github.com/konsumer/gatsby-remark-graph) to do this. We are limited to only using this with .md files and it will not work .mdx files. It might be possible to make this work with .mdx files in the future but it might take some time to implement.
 
 [https://mermaidjs.github.io/](https://mermaidjs.github.io/)
 

--- a/packages/documentation/src/sidebar.js
+++ b/packages/documentation/src/sidebar.js
@@ -25,6 +25,10 @@ module.exports = {
               name: 'How to Add Pages from Github',
               href: 'getting-started/add-external-pages'
             },
+            {
+              name: 'How to Add Graphs to your Markdown',
+              href: 'getting-started/markdown-mermaid-graph'
+            },
           ]
         },
         {
@@ -121,4 +125,3 @@ module.exports = {
     },
   ]
 };
-

--- a/packages/documentation/yarn.lock
+++ b/packages/documentation/yarn.lock
@@ -5394,6 +5394,13 @@ gatsby-react-router-scroll@^2.0.4:
     scroll-behavior "^0.9.9"
     warning "^3.0.0"
 
+gatsby-remark-graph@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-graph/-/gatsby-remark-graph-0.2.2.tgz#c18b956d85d5fe1db223dd287b5888a4a8e95fab"
+  integrity sha512-kugn+Gt++B+E5UWHx5/pT/SlwjIXPZR7sNrARjTuYD8GX9op5X04KtSNd7/PMKmRrZwzzuiRg19qf60aOElFsQ==
+  dependencies:
+    unist-util-visit "^1.1.3"
+
 gatsby-remark-images@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/gatsby-remark-images/-/gatsby-remark-images-3.0.3.tgz#d31790555a7b50f9b4f0860a294c845316846669"
@@ -12764,7 +12771,7 @@ unist-util-visit-parents@^2.0.0, unist-util-visit-parents@^2.0.1:
   dependencies:
     unist-util-is "^2.1.2"
 
-unist-util-visit@^1.0.0, unist-util-visit@^1.1.0, unist-util-visit@^1.3.0, unist-util-visit@^1.4.0:
+unist-util-visit@^1.0.0, unist-util-visit@^1.1.0, unist-util-visit@^1.1.3, unist-util-visit@^1.3.0, unist-util-visit@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.0.tgz#1cb763647186dc26f5e1df5db6bd1e48b3cc2fb1"
   integrity sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==


### PR DESCRIPTION
@rianfowler I was trying to make this work with .mdx files but I could not get it to behave correctly. I was able to make it work with just .md files. This PR will allow us to write .md files in our project also and use the mermaid code snippet for graphs. I added some documentation on it and the documentation is actually an example of how to do it. If this looks good you can merge it in. I had to change some setting in the gatsby-node file to create pages from .md file located in the pages directory. Everything works pretty good, so far.

I also took a look at the gatsby-remark-graph and saw how they implemented it. They get the markdown AST and then convert it to <div> with a mermaid class. Then they have some code to inject the mermaid script and initialize it on the actual DOM element. Which converts it into the graph.