### PR TITLE
Fix url check in Sidebar

### DIFF
--- a/packages/documentation/src/components/sidebar/Sidebar.js
+++ b/packages/documentation/src/components/sidebar/Sidebar.js
@@ -10,7 +10,7 @@ import sidebarData from '../../sidebar';
  */
 
 export default function Sidebar({ location }) {
-  const sidebarSection = sidebarData.sections.find(section => location.pathname.startsWith(`/${section.href}`));
+  const sidebarSection = sidebarData.sections.find(section => location.pathname.includes(`/${section.href}`));
 
   return (
     <aside className="sidebar">


### PR DESCRIPTION
The url check in the Sidebar component doesn't work when there's a path prefix, so this loosens it in order to fix the live site.