### PR TITLE
create contextual hub variable names

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/base/_b-variables.scss
+++ b/packages/formation/sass/base/_b-variables.scss
@@ -90,6 +90,19 @@ $green-warm-50: #6f7a41;
 $blue-50: #357ab2;
 $violet-warm-60: #864381;
 
+// Contextual variable names
+$color-hub-health-care: $indigo-cool-60;
+$color-hub-education: $mint-cool-50;
+$color-hub-disability: $red-60;
+$color-hub-careers: $orange-warm-50;
+$color-hub-pension: $green-cool-50;
+$color-hub-housing: $gold-50;
+$color-hub-life-insurance: $green-warm-50;
+$color-hub-burials: $blue-50;
+$color-hub-records: $violet-warm-60;
+$color-hub-family-member: $color-primary-darker;
+$color-hub-service-member: $color-primary-darker;
+
 //===================================
 // Deprecated Colors;
 // Please avoid using.

--- a/packages/formation/sass/utilities/_background-color.scss
+++ b/packages/formation/sass/utilities/_background-color.scss
@@ -212,37 +212,45 @@
 */
 
 .vads-u-background-color--hub-health-care {
-  background-color: $indigo-cool-60 !important;
+  background-color: $color-hub-health-care !important;
 }
 
 .vads-u-background-color--hub-education {
-  background-color: $mint-cool-50 !important;
+  background-color: $color-hub-education !important;
 }
 
 .vads-u-background-color--hub-disability {
-  background-color: $red-60 !important;
+  background-color: $color-hub-disability !important;
 }
 
 .vads-u-background-color--hub-careers {
-  background-color: $orange-warm-50 !important;
+  background-color: $color-hub-careers !important;
 }
 
 .vads-u-background-color--hub-pension {
-  background-color: $green-cool-50 !important;
+  background-color: $color-hub-pension !important;
 }
 
 .vads-u-background-color--hub-housing {
-  background-color: $gold-50 !important;
+  background-color: $color-hub-housing !important;
 }
 
 .vads-u-background-color--hub-life-insurance {
-  background-color: $green-warm-50 !important;
+  background-color: $color-hub-life-insurance !important;
 }
 
 .vads-u-background-color--hub-burials {
-  background-color: $blue-50 !important;
+  background-color: $color-hub-burials !important;
 }
 
 .vads-u-background-color--hub-records {
-  background-color: $violet-warm-60 !important;
+  background-color: $color-hub-records !important;
+}
+
+.vads-u-background-color--hub-family-member {
+  background-color: $color-hub-family-member !important;
+}
+
+.vads-u-background-color--hub-service-member {
+  background-color: $color-hub-service-member !important;
 }

--- a/packages/formation/sass/utilities/_border.scss
+++ b/packages/formation/sass/utilities/_border.scss
@@ -286,37 +286,45 @@ $border_styles: (
 */
 
 .vads-u-border-color--hub-health-care {
-  border-color: $indigo-cool-60 !important;
+  border-color: $color-hub-health-care !important;
 }
 
 .vads-u-border-color--hub-education {
-  border-color: $mint-cool-50 !important;
+  border-color: $color-hub-education !important;
 }
 
 .vads-u-border-color--hub-disability {
-  border-color: $red-60 !important;
+  border-color: $color-hub-disability !important;
 }
 
 .vads-u-border-color--hub-careers {
-  border-color: $orange-warm-50 !important;
+  border-color: $color-hub-careers !important;
 }
 
 .vads-u-border-color--hub-pension {
-  border-color: $green-cool-50 !important;
+  border-color: $color-hub-pension !important;
 }
 
 .vads-u-border-color--hub-housing {
-  border-color: $gold-50 !important;
+  border-color: $color-hub-housing !important;
 }
 
 .vads-u-border-color--hub-life-insurance {
-  border-color: $green-warm-50 !important;
+  border-color: $color-hub-life-insurance !important;
 }
 
 .vads-u-border-color--hub-burials {
-  border-color: $blue-50 !important;
+  border-color: $color-hub-burials !important;
 }
 
 .vads-u-border-color--hub-records {
-  border-color: $violet-warm-60 !important;
+  border-color: $color-hub-records !important;
+}
+
+.vads-u-border-color--hub-family-member {
+  border-color: $color-hub-family-member !important;
+}
+
+.vads-u-border-color--hub-service-member {
+  border-color: $color-hub-service-member !important;
 }

--- a/packages/formation/sass/utilities/_color.scss
+++ b/packages/formation/sass/utilities/_color.scss
@@ -212,37 +212,45 @@
 */
 
 .vads-u-color--hub-health-care {
-  color: $indigo-cool-60 !important;
+  color: $color-hub-health-care !important;
 }
 
 .vads-u-color--hub-education {
-  color: $mint-cool-50 !important;
+  color: $color-hub-education !important;
 }
 
 .vads-u-color--hub-disability {
-  color: $red-60 !important;
+  color: $color-hub-disability !important;
 }
 
 .vads-u-color--hub-careers {
-  color: $orange-warm-50 !important;
+  color: $color-hub-careers !important;
 }
 
 .vads-u-color--hub-pension {
-  color: $green-cool-50 !important;
+  color: $color-hub-pension !important;
 }
 
 .vads-u-color--hub-housing {
-  color: $gold-50 !important;
+  color: $color-hub-housing !important;
 }
 
 .vads-u-color--hub-life-insurance {
-  color: $green-warm-50 !important;
+  color: $color-hub-life-insurance !important;
 }
 
 .vads-u-color--hub-burials {
-  color: $blue-50 !important;
+  color: $color-hub-burials !important;
 }
 
 .vads-u-color--hub-records {
-  color: $violet-warm-60 !important;
+  color: $color-hub-records !important;
+}
+
+.vads-u-color--hub-family-member {
+  color: $color-hub-family-member !important;
+}
+
+.vads-u-color--hub-service-member {
+  color: $color-hub-service-member !important;
 }


### PR DESCRIPTION
This PR will create a set of Sass variables for Hub colors that align with the naming conventions of all other colors in the design system. With this addition, front end developers will be able to use `color: $color-hub-healthcare` instead of `color: $indigo-cool-60`. 