### PR TITLE
bring CSS for external link into Formation css

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/core.scss
+++ b/packages/formation/sass/core.scss
@@ -54,6 +54,9 @@
 @import "base/va";
 @import "base/focus";
 
+// ----- VA MODULES ---- //
+@import "modules/m-external-link";
+
 // ----- Layout ---- //
 @import "layout/flex-grid";
 

--- a/packages/formation/sass/modules/_m-external-link.scss
+++ b/packages/formation/sass/modules/_m-external-link.scss
@@ -1,0 +1,8 @@
+.external-link-icon-black {
+  background-image: url(/img/icons/exit-icon.png);
+  background-position: 100% 50%;
+  background-repeat: no-repeat;
+  background-size: 1em auto;
+  padding-right: 1.2em;
+  position: relative;
+}


### PR DESCRIPTION
This PR will bring the CSS for the external link into Formation. 
<img width="294" alt="Screen Shot 2019-03-12 at 11 58 55 AM" src="https://user-images.githubusercontent.com/25435289/54215413-409cbe80-44be-11e9-98eb-562d5af58053.png">


After this PR is merged, there will be another PR for vets-website to remove the CSS and update the Formation version number.