### PR TITLE
Fix AdditionalInfo to handle aria-controls correctly - #1440

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/AdditionalInfo/AdditionalInfo.jsx
+++ b/packages/formation-react/src/components/AdditionalInfo/AdditionalInfo.jsx
@@ -7,7 +7,7 @@ import ExpandingGroup from '../ExpandingGroup/ExpandingGroup';
 export default class AdditionalInfo extends React.Component {
   constructor(props) {
     super(props);
-    this.expandedContentId = _.uniqueId('tooltip-');
+    this.expandedContentId = props.expandedContentId || _.uniqueId('tooltip-');
     this.state = { open: false };
   }
 
@@ -40,11 +40,11 @@ export default class AdditionalInfo extends React.Component {
     );
 
     return (
-      <ExpandingGroup
-        open={this.state.open}
-        expandedContentId={this.expandedContentId}>
+      <ExpandingGroup open={this.state.open}>
         {trigger}
-        <div className="additional-info-content">{children}</div>
+        <div id={this.expandedContentId} className="additional-info-content">
+          {children}
+        </div>
       </ExpandingGroup>
     );
   }
@@ -56,4 +56,5 @@ AdditionalInfo.propTypes = {
    */
   triggerText: PropTypes.string.isRequired,
   onClick: PropTypes.func,
+  expandedContentId: PropTypes.string,
 };

--- a/packages/formation-react/src/components/AdditionalInfo/AdditionalInfo.unit.spec.jsx
+++ b/packages/formation-react/src/components/AdditionalInfo/AdditionalInfo.unit.spec.jsx
@@ -39,4 +39,19 @@ describe('<AdditionalInfo/>', () => {
       </ExpandingGroup>
     );
   });
+  it('places the aria-controls element directly on the content', () => {
+    wrapper = mount(
+      <AdditionalInfo triggerText="test" expandedContentId="my-special-content">
+        Lorem ipsum whatever
+      </AdditionalInfo>
+    ).setState({ open: true });
+
+    expect(wrapper.find('button[aria-controls="my-special-content"]').length).to.equal(1);
+    const contentCheck = wrapper.contains(
+      <div id="my-special-content" className="additional-info-content">
+        Lorem ipsum whatever
+      </div>
+    );
+    expect(contentCheck).to.equal(true);
+  });
 });

--- a/packages/formation-react/src/components/ExpandingGroup/ExpandingGroup.jsx
+++ b/packages/formation-react/src/components/ExpandingGroup/ExpandingGroup.jsx
@@ -26,10 +26,16 @@ export default function ExpandingGroup({
       {children[0]}
       <ReactCSSTransitionGroup id={expandedContentId} transitionName="form-expanding-group-inner" transitionEnterTimeout={700} transitionLeave={false}>
         {open
-          ? <div key="removable-group" className={additionalClass}>
-            {children[1]}
-          </div>
-          : null}
+          ? (
+            <div key="removable-group" className={classnames('expanded-content', additionalClass)}>
+              {children[1]}
+            </div>
+          ) : (
+            <div className="collapsed-content" hidden aria-hidden="true">
+              {children[1]}
+            </div>
+          )
+        }
       </ReactCSSTransitionGroup>
     </div>
   );

--- a/packages/formation-react/src/components/ExpandingGroup/ExpandingGroup.unit.spec.jsx
+++ b/packages/formation-react/src/components/ExpandingGroup/ExpandingGroup.unit.spec.jsx
@@ -10,17 +10,32 @@ describe('<ExpandingGroup>', () => {
     const wrapper = shallow(<ExpandingGroup open={false}><first/><second/></ExpandingGroup>);
 
     const first = wrapper.find('first');
-    const second = wrapper.find('second');
     expect(first).to.have.lengthOf(1);
-    expect(second).to.have.lengthOf(0);
+
+    const expandingContainer = wrapper.find('.expanded-content');
+    expect(expandingContainer).to.have.lengthOf(0);
+    const collapsedContainer = wrapper.find('.collapsed-content');
+    expect(collapsedContainer).to.have.lengthOf(1);
+    expect(collapsedContainer.prop('hidden')).to.equal(true);
+    expect(collapsedContainer.prop('aria-hidden')).to.equal('true');
+
+    // check that collapsed content is still rendered in case calling components need it
+    const second = collapsedContainer.find('second');
+    expect(second).to.have.lengthOf(1);
   });
 
   it('renders both children when open is true', () => {
     const wrapper = shallow(<ExpandingGroup open><first/><second/></ExpandingGroup>);
 
     const first = wrapper.find('first');
-    const second = wrapper.find('second');
     expect(first).to.have.lengthOf(1);
+
+    const expandingContainer = wrapper.find('.expanded-content');
+    expect(expandingContainer).to.have.lengthOf(1);
+    const collapsedContainer = wrapper.find('.collapsed-content');
+    expect(collapsedContainer).to.have.lengthOf(0);
+
+    const second = expandingContainer.find('second');
     expect(second).to.have.lengthOf(1);
   });
 


### PR DESCRIPTION
## Overview

PR for ticket 1440: https://github.com/department-of-veterans-affairs/vets-contrib/issues/1440

* Puts the `expandedContentId` of the `AdditionalInfo` component directly on the expandable content rendered as the second child of `ExpandingGroup` rather than as the `expandedContentId` prop for `ExpandingGroup` to align with expected `aria-controls` use
* Renders the expandable content within a hidden div in `ExpandingGroup` when the expandable content is collapsed so that the above change to `AdditionalInfo` does not break when the `aria-controls` element of the button trigger is absent
* Updates tests for these changes

## Testing

- [ ] Run the tests in `veteran-facing-services-tools`
- [ ] Run vets-website locally with the changes and confirm that they work on the /account page

### Running `vets-website` locally with changes

See the instructions here: https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/master/previewing-changes.md

Verify the following changes on the "What is ID.me" button:

* The button's `aria-controls` should still be the generated element id.
* When the section is collapsed (default), there should be a div with class `collapsed-content` and the `hidden` attribute set (as well as `aria-hidden="true"`). The collapsed content should be within this div with the generated id and the class of `additional-info-content`.

<img width="779" alt="WhatIsIdmeCollapsed" src="https://user-images.githubusercontent.com/3241493/54229373-80719f00-44da-11e9-9e72-d10ca81a2e80.png">

* When the section is expanded, there should be a div with the class `expanded-content`. The expanded content should be in this div with the generate id and the class of `additional-info-content`.

<img width="772" alt="WhatIsIdmeExpanded" src="https://user-images.githubusercontent.com/3241493/54229682-29b89500-44db-11e9-9f53-8463273d1b75.png">

* On enter, the expandable section should have CSS transitions expanding down and going from opacity 0 => 1.