### PR TITLE
add missing uswds variables

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "5.4.2",
+  "version": "5.5.0",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/base/_b-breakpoints.scss
+++ b/packages/formation/sass/base/_b-breakpoints.scss
@@ -13,6 +13,16 @@
 // Based on the order of our imports, USWDS should override Foundation's declarations and everything should be fine.
 // However, USWDS defines its variables using the "!default" flag, so Foundation's take precedence anyway.
 // These next lines redeclare USWDS's variables without that flag, so that the override works as we would expect.
+
+$grid-columns-small: 1 !default;
+$grid-columns-medium: 6 !default;
+$grid-columns-large: 12 !default;
+
+// Breakpoint variables from USWDS 1.4.2
+$small-screen:  481px !default;
+$medium-screen: 600px !default;
+$large-screen:  1201px !default;
+
 $small: new-breakpoint(min-width $small-screen $grid-columns-small);
 $medium: new-breakpoint(min-width $medium-screen $grid-columns-medium);
 $large: new-breakpoint(min-width $large-screen $grid-columns-large);
@@ -36,6 +46,10 @@ $breakpoints: (
 
 // This is an override on Neat's media mixin to create media queries for both screen and print
 // https://github.com/thoughtbot/neat/blob/v1.8.0/app/assets/stylesheets/grid/_media.scss
+
+// Define default feature:
+$default-feature: min-width;
+
 @mixin media($query: $feature $value $columns, $total-columns: $grid-columns) {
   @if length($query) == 1 {
     @media screen and ($default-feature: nth($query, 1)), print and ($default-feature: nth($query, 1)) {

--- a/packages/formation/sass/base/_b-variables.scss
+++ b/packages/formation/sass/base/_b-variables.scss
@@ -12,8 +12,15 @@
 // ~uswds/src/stylesheets/core/defaults" or
 // ~uswds/src/stylesheets/core/variables"
 
-$base-font-size:      rem(16px);
+$georgia: "Georgia", "Cambria", "Times New Roman", "Times", serif;
+$helvetica: "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;
+$font-sans: 'Source Sans Pro', $helvetica !default;
 $font-serif:          "Bitter", $georgia;
+
+$base-font-size:      rem(16px);
+
+$font-normal:   400 !default;
+$font-bold:     700 !default;
 
 $h6-font-size:        1.5rem;
 
@@ -29,19 +36,56 @@ $site-max-width:      100rem; // Worksout to about 1000px. USWDS value is 1040px
 // Colors that override (or restate) USWDS values
 // Also see: https://standards.usa.gov/components/colors/
 //===================================
+$color-aqua:                 #02bfe7;
+$color-aqua-dark:            #00a6d2;
+$color-aqua-lightest:        #e1f3f8;
+$color-purple:               #4c2c92;
+$color-white:                #ffffff;
+$color-red:                  #e31c3d;
+$color-red-lightest:         #f9dede;
+$color-red-light:            #e59393;
+$color-red-dark:             #cd2026;
+$color-blue:                 #0071BB;
+$color-blue-darkest:         #112e51;
 
 $color-base:                 #212121;
-$color-blue:                 #0071BB;
+
 $color-primary:              $color-blue;
 $color-primary-darker:       #003E73;
 $color-primary-darkest:      #112e51;
+
+$color-primary-alt:          $color-aqua;
+$color-primary-alt-light:    #9bdaf1;
+$color-primary-alt-lightest: $color-aqua-lightest;
+$color-primary-alt-dark:     $color-aqua-dark;
+
+$color-secondary:            $color-red;
+$color-secondary-lightest:   $color-red-lightest;
+$color-secondary-light:      $color-red-light;
+$color-secondary-dark:       $color-red-dark;
 $color-secondary-darkest:    #981b1e;
-$color-focus:                #3e94cf;
+
+$color-gray:                 #5b616b;
 $color-gray-light:           #aeb0b5;
+$color-gray-lighter:         #d6d7d9;
+$color-gray-lightest:        #f1f1f1;
 $color-gray-medium:          #757575;
 $color-gray-dark:            #323a45;
-$color-primary-alt-light:    #9bdaf1;
-$color-white:                #fff;
+$color-gray-warm-light:      #e4e2e0;
+$color-gray-warm-dark:       #494440;
+$color-gray-cool-light:      #dce4ef;
+
+$color-green:                #2e8540;
+$color-green-lightest:       #e7f4e4;
+$color-green-lighter:        #94bfa2;
+$color-green-light:          #4aa564;
+
+$color-gold-lightest:        #fff1d2;
+$color-gold-lighter:         #fad980;
+$color-gold-light:           #f9c642;
+
+$color-visited:              $color-purple;
+$color-focus:                #3e94cf;
 
 //===================================
 // DSVA colors


### PR DESCRIPTION
This PR will add some USWDS variables to Formation. 

With these additions, you can use the Formation Sass variables and functions without requiring USWDS as a dependency.