### PR TITLE
add heading levels to font size utilities

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/utilities/_font-size.scss
+++ b/packages/formation/sass/utilities/_font-size.scss
@@ -4,7 +4,13 @@ $font-sizes: (
   md: 1.7rem,
   lg: 2rem,
   xl: 3rem,
-  2xl: 4rem
+  2xl: 4rem,
+  h1: 4rem,
+  h2: 3rem,
+  h3: 2rem,
+  h4: 1.7rem,
+  h5: 1.5rem,
+  h6: 1.5rem
 );
 
 // Standard classes


### PR DESCRIPTION
This will add some extra classes to the font-size utility. The classes are redundant, but @1Copenut mentioned it would help developers choose the right utility class when change font sizes on headings while maintaining correct semantic level.