### PR TITLE
remove some uswds grid padding

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/_shame.scss
+++ b/packages/formation/sass/_shame.scss
@@ -241,16 +241,6 @@ form {
   }
 }
 
-// Overrides so that the left/right padding matches the Foundation grid.
-// Without this, using the USA grid causes alignment issues other components
-// on the page that use the Foundation grid.
-.va-l-detail-page {
-  > .usa-grid {
-    padding-left: 0.9375rem;
-    padding-right: 0.9375rem;
-  }
-}
-
 // .usa-alert shame moved to _m_alert.scss
 
 #top-of-page-alert-container {


### PR DESCRIPTION
I noticed there is a ~10px difference in some of the grid padding on my sandbox site using only formation and va.gov. It _looks_ like this CSS can be removed safely because it is overwritten here: https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/site-wide/sass/merger.scss#L566

This pull request will help get Formation one step closer to providing samples for full page layouts that are equal to what is on va.gov.