### PR TITLE
Remove greater than errorable radio mg

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/ErrorableRadioButtons/ErrorableRadioButtons.jsx
+++ b/packages/formation-react/src/components/ErrorableRadioButtons/ErrorableRadioButtons.jsx
@@ -116,7 +116,7 @@ class ErrorableRadioButtons extends React.Component {
               name={`${this.props.name}-${optionIndex}-label`}
               htmlFor={`${this.inputId}-${optionIndex}`}
             >
-              >{optionLabel}
+              {optionLabel}
             </label>
             {matchingSubSection}
             {option.content}


### PR DESCRIPTION
Found a bug where an extra `>` was getting prepended to labels in radio buttons.

Before:
![Screen Shot 2019-03-22 at 9 39 06 AM](https://user-images.githubusercontent.com/24251447/54830573-bfe07e00-4c86-11e9-9d9a-3808961fdc5c.png)

After:
![Screen Shot 2019-03-22 at 9 22 32 AM](https://user-images.githubusercontent.com/24251447/54830592-c66ef580-4c86-11e9-8b93-ce5e44eae65a.png)


