### PR TITLE
Remove autocomplete attribute from checkboxes, radio buttons, and sel…

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/ErrorableCheckbox/ErrorableCheckbox.jsx
+++ b/packages/formation-react/src/components/ErrorableCheckbox/ErrorableCheckbox.jsx
@@ -51,7 +51,6 @@ class ErrorableCheckbox extends React.Component {
           </span>
         )}
         <input
-          autoComplete="false"
           aria-describedby={errorSpanId}
           checked={this.props.checked}
           id={this.inputId}

--- a/packages/formation-react/src/components/ErrorableCheckboxGroup/ErrorableCheckboxGroup.jsx
+++ b/packages/formation-react/src/components/ErrorableCheckboxGroup/ErrorableCheckboxGroup.jsx
@@ -92,7 +92,6 @@ class ErrorableCheckboxGroup extends React.Component {
           className="form-checkbox-buttons"
         >
           <input
-            autoComplete="false"
             checked={checked}
             id={`${this.inputId}-${index}`}
             name={this.props.name}

--- a/packages/formation-react/src/components/ErrorableDate/ErrorableDate.jsx
+++ b/packages/formation-react/src/components/ErrorableDate/ErrorableDate.jsx
@@ -99,7 +99,6 @@ class ErrorableDate extends React.Component {
             <div className="form-datefield-month">
               <ErrorableSelect
                 errorMessage={isValid ? undefined : ''}
-                autocomplete="false"
                 label="Month"
                 name={`${this.props.name}Month`}
                 options={months}
@@ -112,7 +111,6 @@ class ErrorableDate extends React.Component {
             <div className="form-datefield-day">
               <ErrorableSelect
                 errorMessage={isValid ? undefined : ''}
-                autocomplete="false"
                 label="Day"
                 name={`${this.props.name}Day`}
                 options={daysForSelectedMonth}
@@ -125,7 +123,6 @@ class ErrorableDate extends React.Component {
             <div className="usa-datefield usa-form-group usa-form-group-year">
               <ErrorableNumberInput
                 errorMessage={isValid ? undefined : ''}
-                autocomplete="false"
                 label="Year"
                 name={`${this.props.name}Year`}
                 max={moment()

--- a/packages/formation-react/src/components/ErrorableMonthYear/ErrorableMonthYear.jsx
+++ b/packages/formation-react/src/components/ErrorableMonthYear/ErrorableMonthYear.jsx
@@ -87,7 +87,6 @@ class ErrorableMonthYear extends React.Component {
             <div className="form-datefield-month">
               <ErrorableSelect
                 errorMessage={isValid ? undefined : ''}
-                autocomplete="false"
                 label="Month"
                 name={`${this.props.name}Month`}
                 options={months}
@@ -100,7 +99,6 @@ class ErrorableMonthYear extends React.Component {
             <div className="usa-datefield usa-form-group usa-form-group-year">
               <ErrorableNumberInput
                 errorMessage={isValid ? undefined : ''}
-                autocomplete="false"
                 label="Year"
                 name={`${this.props.name}Year`}
                 max={moment()

--- a/packages/formation-react/src/components/ErrorableNumberInput/ErrorableNumberInput.jsx
+++ b/packages/formation-react/src/components/ErrorableNumberInput/ErrorableNumberInput.jsx
@@ -68,7 +68,6 @@ class ErrorableNumberInput extends React.Component {
         </label>
         {errorSpan}
         <input
-          autoComplete={this.props.autocomplete}
           className={this.props.additionalClass}
           aria-describedby={errorSpanId}
           id={this.inputId}

--- a/packages/formation-react/src/components/ErrorableRadioButtons/ErrorableRadioButtons.jsx
+++ b/packages/formation-react/src/components/ErrorableRadioButtons/ErrorableRadioButtons.jsx
@@ -101,7 +101,6 @@ class ErrorableRadioButtons extends React.Component {
         >
           <div className="errorable-radio-button">
             <input
-              autoComplete="false"
               checked={checked}
               id={`${this.inputId}-${optionIndex}`}
               name={this.props.name}

--- a/packages/formation-react/src/components/ErrorableSelect/ErrorableSelect.jsx
+++ b/packages/formation-react/src/components/ErrorableSelect/ErrorableSelect.jsx
@@ -86,7 +86,6 @@ class ErrorableSelect extends React.Component {
           aria-describedby={errorSpanId}
           id={this.selectId}
           name={this.props.name}
-          autoComplete={this.props.autocomplete}
           value={selectedValue}
           onKeyDown={this.props.onKeyDown}
           onChange={this.handleChange}
@@ -112,11 +111,6 @@ ErrorableSelect.propTypes = {
    * Select name attribute.
    */
   name: PropTypes.string,
-
-  /**
-   * Select autocomplete attribute.
-   */
-  autocomplete: PropTypes.string,
 
   /**
    * Select field label.

--- a/packages/formation-react/src/components/ErrorableSelect/ErrorableSelect.mdx
+++ b/packages/formation-react/src/components/ErrorableSelect/ErrorableSelect.mdx
@@ -28,7 +28,6 @@ import ErrorableSelect from '@department-of-veterans-affairs/formation-react/Err
   options={['first option', 'second option', 'third option']}
   required={true}
   value={this.state.value}
-  autocomplete='true'
   includeBlankOption={true}
   onValueChange={value => this.setState({ value })}
   additionalClass='additional-class'
@@ -58,7 +57,6 @@ export class RenderedComponent extends React.Component {
           options={['first option', 'second option', 'third option']}
           required={true}
           value={this.state.value}
-          autocomplete='true'
           includeBlankOption={true}
           onValueChange={value => this.setState({ value })}
           additionalClass='additional-class'

--- a/packages/vagov-eslint/package.json
+++ b/packages/vagov-eslint/package.json
@@ -24,6 +24,6 @@
         "window-or-global": "^1.0.1"
     },
     "scripts": {
-        "postinstall" : "cp .eslintrc $INIT_CWD && cp .eslintignore $INIT_CWD && cp .prettierrc $INIT_CWD"
+        "postinstall": "cp .eslintrc $INIT_CWD && cp .eslintignore $INIT_CWD && cp .prettierrc $INIT_CWD"
     }
 }


### PR DESCRIPTION
…ects

PR for [vets-contrib#1609](https://github.com/department-of-veterans-affairs/vets-contrib/issues/1609). Completes some of the work scoped in [this ticket](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/15045).

Removes autocomplete from `input` elements with type `checkbox`, `radio`, and `number` and `select` elements. This will allow components to pass checks using `axe-core` with version > 3.0.