### PR TITLE
set full-width grid container max width

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/layout/_flex-grid.scss
+++ b/packages/formation/sass/layout/_flex-grid.scss
@@ -14,6 +14,7 @@
 
 .vads-l-grid-container--full {
   padding: 0;
+  max-width: 100%;
 }
 
 .vads-l-row {


### PR DESCRIPTION
This PR addresses an issue with the full-width grid container using a `max-width` of `100rem`. 

This screenshot shows the change in effect in local development:
<img width="267" alt="Image 2019-04-10 at 3 01 36 PM" src="https://user-images.githubusercontent.com/25435289/55906485-617e2f80-5ba2-11e9-8c88-17a3f53343c6.png">
