### PR TITLE
update readme to reflect design.va.gov

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,9 @@
 
 This repo contains front end code and documentation used by the Veteran facing services on VA.gov. It's a monorepo managed by Lerna, a tool for managing versioning and publishing for multiple modules located in a single repo.
 
-If you're looking for design system documentation:
+There is s[another repository for the documentation site](https://github.com/department-of-veterans-affairs/vets-design-system-documentation). The documentation site can be viewed at [design.va.gov](https://design.va.gov).
 
-Legacy URL: https://department-of-veterans-affairs.github.io/design-system
 
-Work in progress URL: https://department-of-veterans-affairs.github.io/vets-design-system-documentation/
 
 ## Repositories
 


### PR DESCRIPTION
This update will remove the github.io URLs for design.va.gov, as well as the link to the legacy site. 

New update links to the repo for the documentation site as well.