### PR TITLE
Add optional `backgroundOnly` prop to AlertBox

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/AlertBox/AlertBox.jsx
+++ b/packages/formation-react/src/components/AlertBox/AlertBox.jsx
@@ -38,6 +38,7 @@ class AlertBox extends React.Component {
     const alertClass = classNames(
       'usa-alert',
       `usa-alert-${this.props.status}`,
+      { 'background-color-only': this.props.backgroundOnly },
       this.props.className,
     );
 
@@ -115,10 +116,17 @@ AlertBox.propTypes = {
    * Optional class name to add to the alert box.
    */
   className: PropTypes.string,
+
+  /**
+   * If true, renders an AlertBox with only a background color, without an
+   * accented left edge or an icon
+   */
+  backgroundOnly: PropTypes.bool,
 };
 
 AlertBox.defaultProps = {
   isVisible: true,
+  backgroundOnly: false,
 };
 
 export default AlertBox;

--- a/packages/formation-react/src/components/AlertBox/AlertBox.mdx
+++ b/packages/formation-react/src/components/AlertBox/AlertBox.mdx
@@ -46,6 +46,11 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox'
   <AlertBox
     content={<p>Content without heading.</p>}
     status="info"/>
+  <AlertBox
+    headline="Informational backgroundOnly alert"
+    content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id felis pulvinar ligula ultricies sollicitudin eget nec dui. Cras augue velit, pellentesque sit amet nisl ut, tristique suscipit sem. Cras sollicitudin auctor mattis."
+    status="info"
+    backgroundOnly />
 </div>
 ```
 
@@ -87,5 +92,10 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox'
     <AlertBox
       content={<p>Content without heading.</p>}
       status="info"/>
+    <AlertBox
+      headline="Background Only alert"
+      content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id felis pulvinar ligula ultricies sollicitudin eget nec dui. Cras augue velit, pellentesque sit amet nisl ut, tristique suscipit sem. Cras sollicitudin auctor mattis."
+      status="info"
+      backgroundOnly />
   </div>
 </div>

--- a/packages/formation-react/src/components/AlertBox/AlertBox.unit.spec.jsx
+++ b/packages/formation-react/src/components/AlertBox/AlertBox.unit.spec.jsx
@@ -81,4 +81,14 @@ describe('<AlertBox />', () => {
         isVisible
       />,
     ));
+
+  it('should pass aXe check when `backgroundOnly` is `true`', () =>
+    axeCheck(
+      <AlertBox
+        headline={Headline}
+        content={Content}
+        status="info"
+        backgroundOnly
+      />,
+    ));
 });

--- a/packages/formation-react/src/components/AlertBox/AlertBox.unit.spec.jsx
+++ b/packages/formation-react/src/components/AlertBox/AlertBox.unit.spec.jsx
@@ -21,13 +21,34 @@ describe('<AlertBox />', () => {
     wrapper.unmount();
   });
 
-  it('should have the expected classname', () => {
+  it('should have the expected classnames', () => {
     const wrapper = shallow(
       <AlertBox content={Content} status="info" isVisible />,
     );
     expect(wrapper.find('.usa-alert').hasClass('usa-alert-info')).to.equal(
       true,
     );
+    expect(
+      wrapper.find('.usa-alert').hasClass('background-color-only'),
+    ).to.equal(false);
+    wrapper.unmount();
+  });
+
+  it('should have have `background-color-only` class added when `backgroundOnly` is `true`', () => {
+    const wrapper = shallow(
+      <AlertBox content={Content} status="info" isVisible backgroundOnly />,
+    );
+    expect(
+      wrapper.find('.usa-alert').hasClass('background-color-only'),
+    ).to.equal(true);
+    wrapper.unmount();
+  });
+
+  it('should apply classes set via `className`', () => {
+    const wrapper = shallow(
+      <AlertBox content={Content} status="info" isVisible className="foo" />,
+    );
+    expect(wrapper.find('.usa-alert').hasClass('foo')).to.equal(true);
     wrapper.unmount();
   });
 


### PR DESCRIPTION
Seemed like it should be possible to turn an AlertBox into its 'background only' variant without resorting to passing in a class name like I've had to do [here](https://github.com/department-of-veterans-affairs/vets-website/blob/d1afbcd92d91d4892469277ca1b96163f2781946/src/applications/personalization/dashboard/components/ManageYourVAHealthCare.jsx#L73) and [here](https://github.com/department-of-veterans-affairs/vets-website/blob/3e7daca36ae04b7263eb12f0d889c75f305391ed/src/applications/hca/containers/IntroductionPageGated.jsx#L96)