### PR TITLE
Set Babel to transpile modules

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,7 @@ pipeline {
   }
   environment {
     BABEL_CACHE_PATH = '${env.WORKSPACE}'
+    BABEL_DISABLE_CACHE = 1
     NODE_ENV = 'production'
   }
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -57,7 +57,6 @@ module.exports = function(api) {
             ],
           },
           useBuiltIns: 'entry',
-          modules: false,
           debug: false,
         },
       ],

--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/scripts/build.js
+++ b/packages/formation-react/scripts/build.js
@@ -19,9 +19,9 @@ function flattenRequires(bufferString) {
     recast.print(
       recast.visit(recast.parse(bufferString), {
         visitCallExpression: function(path) {
+          this.traverse(path);
           var expr = path.node;
           if (expr.callee.name == 'require') {
-            this.traverse(path);
             if (
               expr.arguments.length &&
               expr.arguments[0].value.charAt(0) == '.'

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12426,7 +12426,7 @@ uuid@^3.0.1, uuid@^3.3.2:
     eslint-plugin-react "^7.12.4"
     eslint-plugin-react-hooks "^1.6.0"
     eslint-plugin-scanjs-rules "^0.1.4"
-    eslint-plugin-va-enzyme "file:../../Library/Caches/Yarn/v4/npm-vagov-eslint-1.0.0-4e4c7dca-961b-4a86-a8d1-85502669dab7-1555430367307/node_modules/vagov-eslint/custom-eslint/va-enzyme"
+    eslint-plugin-va-enzyme "file:../../Library/Caches/Yarn/v4/npm-vagov-eslint-1.0.0-502d90db-d4ff-4ec6-9676-2b8486c70c63-1556302093236/node_modules/vagov-eslint/custom-eslint/va-enzyme"
     prettier "^1.16.4"
     shelljs "0.8.3"
     window-or-global "^1.0.1"


### PR DESCRIPTION
When we updated the Babel config I accidentally carried over the `modules: false` option from the vets-website config, which is not what we want in this repo. That caused `imports` to stop being converted to `require`s.

To test this locally, you'll need to run the build command once with `BABEL_DISABLE_CACHE=1` set as an env variable.