### PR TITLE
add cool blue variables

### DIFF
--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -4,7 +4,7 @@
   "description": "Developer Document Site for VA.gov",
   "version": "0.1.0",
   "dependencies": {
-    "@department-of-veterans-affairs/formation": "^6.1.3",
+    "@department-of-veterans-affairs/formation": "^6.2.3",
     "@fortawesome/fontawesome-free": "^5.8.1",
     "@mdx-js/mdx": "^0.16.6",
     "@mdx-js/tag": "^0.16.6",

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/base/_b-variables.scss
+++ b/packages/formation/sass/base/_b-variables.scss
@@ -89,6 +89,10 @@ $color-focus:                #3e94cf;
 
 $focus-outline:              2px solid $color-gold-light;
 
+$color-cool-blue:           #205493;
+$color-cool-blue-light:     #4773aa;
+$color-cool-blue-lighter:   #8ba6ca;
+$color-cool-blue-lightest:  #dce4ef;
 //===================================
 // DSVA colors
 // Places where DSVA is going rogue!


### PR DESCRIPTION
Cool blue variables were missing and causing errors in projects using formation when attempting to work with the sass variables in project files. 