### PR TITLE
add lowercase transform to matching query filter

### DIFF
--- a/packages/documentation/src/components/Search.jsx
+++ b/packages/documentation/src/components/Search.jsx
@@ -67,7 +67,11 @@ export default class Search extends React.Component {
               filteredTags: result.tags
                 .split(',')
                 .filter(tag =>
-                  query.split(' ').find(queryPart => tag.includes(queryPart)),
+                  query
+                    .split(' ')
+                    .find(queryPart =>
+                      tag.toLowerCase().includes(queryPart.toLowerCase()),
+                    ),
                 )
                 .map(tag => tag.trim()),
               query,


### PR DESCRIPTION
makes this work: 

![Screen Shot 2019-05-01 at 12 00 27](https://user-images.githubusercontent.com/4998130/57032954-c14b8180-6c08-11e9-8604-2842d04bf92c.png)
