### PR TITLE
add full-width version of alerts css to Formation

### DIFF
--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -4,7 +4,7 @@
   "description": "Developer Document Site for VA.gov",
   "version": "0.1.0",
   "dependencies": {
-    "@department-of-veterans-affairs/formation": "^6.2.3",
+    "@department-of-veterans-affairs/formation": "^6.2.4",
     "@fortawesome/fontawesome-free": "^5.8.1",
     "@gatsby-contrib/gatsby-plugin-elasticlunr-search": "^2.2.1",
     "@mdx-js/mdx": "^0.16.6",

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/modules/_m-alert.scss
+++ b/packages/formation/sass/modules/_m-alert.scss
@@ -187,3 +187,67 @@ p.usa-alert-heading {
     flex-direction: row;
   }
 }
+
+.usa-alert-full-width {
+  background-color: $color-gray-lightest;
+  &.dismissable-option-header {
+    display: none;
+    &.show-alert {
+      display: block;
+    }
+    &.dismissed {
+      display: none;
+    }
+  }
+  .usa-alert-dismiss {
+    position: absolute;
+    right: 0;
+    top: 5px;
+    cursor: pointer;
+  }
+  > .usa-alert {
+    border-left: none;
+    max-width: 1000px;
+    margin: 0 auto;
+    .paragraph--type--expandable-text {
+      .field--name-field-text-expander {
+        .field__label {
+          display: none;
+        }
+        .field__item {
+          font-size: 2rem;
+          margin-top: 0;
+          padding-top: 0;
+          font-weight: 700;
+          text-decoration: underline;
+          color: #003e73;
+          cursor: pointer;
+        }
+      }
+      .field--type-text-long {
+        display: none;
+        .field__label {
+          display: none;
+        }
+        &.expander-content-open {
+          display: block;
+        }
+      }
+    }
+  }
+  &-warning {
+    border-top: 1rem solid $color-gold;
+  }
+  &-info,
+  &-information {
+    border-top: 1rem solid $color-primary-alt-dark;
+    .usa-alert:before {
+      content: "\F05A";
+      background: none;
+      font-size: 2rem;
+      margin-right: 1.5rem;
+      position: static;
+      font-weight: 900;
+    }
+  }
+}


### PR DESCRIPTION
This PR will add the full-width alert (that appears below the nav bar) CSS to Formation. 

After this PR is merged and published to NPM, another PR will be made to `vets-website` removing the CSS from the `shame.scss` file and updating the formation version. 

Here is a screenshot of the alert with this work in place on localhost:
<img width="1152" alt="Screen Shot 2019-05-01 at 5 28 21 PM" src="https://user-images.githubusercontent.com/25435289/57043848-b6a7e100-6c36-11e9-9e59-8db3e3a9f854.png">

These alerts are now able to be placed on design.va.gov (screenshot of localhost)
<img width="1093" alt="Screen Shot 2019-05-01 at 5 31 10 PM" src="https://user-images.githubusercontent.com/25435289/57043949-0090c700-6c37-11e9-8ec5-9f24394738fe.png">

