### PR TITLE
16114 dashboard homeless alert screenreader changes

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "4.4.3",
+  "version": "4.5.0",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/AlertBox/AlertBox.jsx
+++ b/packages/formation-react/src/components/AlertBox/AlertBox.jsx
@@ -45,7 +45,7 @@ class AlertBox extends React.Component {
     const closeButton = this.props.onCloseAlert && (
       <button
         className="va-alert-close"
-        aria-label={this.props.closeBtnAriaLabel || 'Close notification'}
+        aria-label={this.props.closeBtnAriaLabel}
         onClick={this.props.onCloseAlert}
       >
         <i className="fas fa-times-circle" aria-label="Close icon" />
@@ -131,6 +131,7 @@ AlertBox.propTypes = {
 AlertBox.defaultProps = {
   isVisible: true,
   backgroundOnly: false,
+  closeBtnAriaLabel: 'Close notification',
 };
 
 export default AlertBox;

--- a/packages/formation-react/src/components/AlertBox/AlertBox.jsx
+++ b/packages/formation-react/src/components/AlertBox/AlertBox.jsx
@@ -45,7 +45,7 @@ class AlertBox extends React.Component {
     const closeButton = this.props.onCloseAlert && (
       <button
         className="va-alert-close"
-        aria-label="Close notification"
+        aria-label={this.props.closeBtnAriaLabel || 'Close notification'}
         onClick={this.props.onCloseAlert}
       >
         <i className="fas fa-times-circle" aria-label="Close icon" />
@@ -57,7 +57,6 @@ class AlertBox extends React.Component {
 
     return (
       <div
-        aria-live="polite"
         className={alertClass}
         ref={ref => {
           this._ref = ref;
@@ -101,6 +100,11 @@ AlertBox.propTypes = {
    * Optional headline.
    */
   headline: PropTypes.node,
+
+  /**
+   * Optional Close button aria-label.
+   */
+  closeBtnAriaLabel: PropTypes.string,
 
   /**
    * Close event handler if the alert  can be dismissed or closed.

--- a/packages/formation-react/src/components/AlertBox/AlertBox.unit.spec.jsx
+++ b/packages/formation-react/src/components/AlertBox/AlertBox.unit.spec.jsx
@@ -8,6 +8,7 @@ import AlertBox from './AlertBox.jsx';
 // Placeholder for required "content" element
 const Content = <p />;
 const Headline = 'Headline';
+const CloseBtnAriaLabelOptional = 'Close notification optional';
 function closeAlert() {
   //
 }
@@ -76,6 +77,18 @@ describe('<AlertBox />', () => {
       <AlertBox
         headline={Headline}
         content={Content}
+        onCloseAlert={closeAlert()}
+        status="info"
+        isVisible
+      />,
+    ));
+
+  it('should pass aXe check when it has a close button with optional aria-label', () =>
+    axeCheck(
+      <AlertBox
+        headline={Headline}
+        content={Content}
+        closeBtnAriaLabel={CloseBtnAriaLabelOptional}
         onCloseAlert={closeAlert()}
         status="info"
         isVisible


### PR DESCRIPTION
\[Companion to vet-website [PR10024](/department-of-veterans-affairs/vets-website/pull/10024) (Pass more descriptive aria-label string to AlertBox)\]
[16114](/department-of-veterans-affairs/vets.gov-team/issues/16114) - Change AlertBox aria attributes:

- Refactor close button aria-label to optionally accept a more descriptive string-value.
- Remove the aria-live attribute from outer element.  React removes the entire alert element when User clicks the close button, so this attribute (which announces inner-content updates) is moot.

Also bumped formation-react version to 4.4.3.
