### PR TITLE
Fix the paths to team repo pages

### DIFF
--- a/packages/documentation/plugins/github-api-pages/github-pages.json
+++ b/packages/documentation/plugins/github-api-pages/github-pages.json
@@ -2,7 +2,7 @@
   "owner": "department-of-veterans-affairs",
   "repo": "vets.gov-team",
   "directoryPaths": [
-    "Work Practices/Engineering/Writing_Small_PRs.md",
-    "Work Practices/Engineering/Code Review Norms.md"
+    "Practice Areas/Engineering/Writing_Small_PRs.md",
+    "Practice Areas/Engineering/Code Review Norms.md"
   ]
 }

--- a/packages/documentation/src/layouts/external-layout.js
+++ b/packages/documentation/src/layouts/external-layout.js
@@ -2,21 +2,19 @@
 import React, { Component } from 'react';
 import { graphql } from 'gatsby';
 
-import Layout from './Layout';
+import SidebarLayout from './SidebarLayout';
 
 export default class ExternalLayout extends Component {
   render() {
     const { data, location } = this.props;
 
     return (
-      <Layout location={location}>
-        <h2>{data.markdownRemark.fields.slug}</h2>
-
+      <SidebarLayout location={location}>
         <div
           className="blog-post-content"
           dangerouslySetInnerHTML={{ __html: data.markdownRemark.html }}
         />
-      </Layout>
+      </SidebarLayout>
     );
   }
 }


### PR DESCRIPTION
With the team repo re-org, some of the paths changed, which breaks some pages we're trying to pull in.