### PR TITLE
add fix for sidebar scrolling and multiple open accordions

### DIFF
--- a/packages/formation/js/accordion.js
+++ b/packages/formation/js/accordion.js
@@ -26,18 +26,12 @@ const addAriasExpandedAttr = () => {
 };
 
 const addAriaHiddenAttr = () => {
-  document
-    .querySelectorAll('.usa-accordion-content:not([aria-hidden])')
-    .forEach(el => {
-      const buttonElement = document.querySelector(
-        `[aria-controls="${el.id}"]`,
-      );
-      const hiddenValue = !toBoolean(
-        buttonElement.getAttribute('aria-expanded'),
-      );
+  document.querySelectorAll('.usa-accordion-content').forEach(el => {
+    const buttonElement = document.querySelector(`[aria-controls="${el.id}"]`);
+    const hiddenValue = !toBoolean(buttonElement.getAttribute('aria-expanded'));
 
-      el.setAttribute('aria-hidden', hiddenValue);
-    });
+    el.setAttribute('aria-hidden', hiddenValue);
+  });
 };
 
 const getOtherButtons = (element, target) =>

--- a/packages/formation/js/accordion.js
+++ b/packages/formation/js/accordion.js
@@ -28,10 +28,37 @@ const addAriasExpandedAttr = () => {
 const addAriaHiddenAttr = () => {
   document.querySelectorAll('.usa-accordion-content').forEach(el => {
     const buttonElement = document.querySelector(`[aria-controls="${el.id}"]`);
-    const hiddenValue = !toBoolean(buttonElement.getAttribute('aria-expanded'));
 
-    el.setAttribute('aria-hidden', hiddenValue);
+    if (buttonElement) {
+      const hiddenValue = !toBoolean(
+        buttonElement.getAttribute('aria-expanded'),
+      );
+
+      el.setAttribute('aria-hidden', hiddenValue);
+    }
   });
+};
+
+const getParents = (elem, selector) => {
+  // Setup parents array
+  const parents = [];
+
+  // Get matching parent elements
+  for (let i = 0; elem && elem !== document; elem = elem.parentNode) { // eslint-disable-line
+    // Add matching parents to array
+    if (i !== 0) {
+      if (selector) {
+        if (elem.matches(selector)) {
+          parents.push(elem);
+        }
+      } else {
+        parents.push(elem);
+      }
+    }
+    i++;
+  }
+
+  return parents;
 };
 
 const getOtherButtons = (element, target) =>
@@ -43,57 +70,61 @@ const addAccordionClickHandler = () => {
   document
     .querySelectorAll('.usa-accordion, .usa-accordion-bordered')
     .forEach(element => {
-      element.addEventListener('click', e => {
-        const accordionButton = e.target.closest('.usa-accordion-button');
+      const parents = getParents(element, '.usa-accordion');
 
-        // Checks whether the button has a click event already assigned to it.
-        // and if it is a .usa-accordion-button.
-        // Specifically React Components.
-        if (accordionButton && !accordionButton.onclick) {
-          const multiSelectable = toBoolean(
-            element.getAttribute('aria-multiselectable'),
-          );
+      if (parents.length === 0) {
+        element.addEventListener('click', e => {
+          const accordionButton = e.target.closest('.usa-accordion-button');
 
-          const hasAriaControlsAttr = accordionButton.getAttribute(
-            'aria-controls',
-          );
-
-          if (hasAriaControlsAttr && !multiSelectable) {
-            getOtherButtons(element, accordionButton).forEach(el => {
-              const contentEl = el.getAttribute('aria-controls');
-
-              el.setAttribute('aria-expanded', 'false');
-
-              document
-                .getElementById(contentEl)
-                .setAttribute('aria-hidden', 'true');
-            });
-          }
-
-          if (hasAriaControlsAttr) {
-            const dropDownElement = document.getElementById(
-              accordionButton.getAttribute('aria-controls'),
-            );
-            const accordionButtonExpandedAttr = toBoolean(
-              accordionButton.getAttribute('aria-expanded'),
+          // Checks whether the button has a click event already assigned to it.
+          // and if it is a .usa-accordion-button.
+          // Specifically React Components.
+          if (accordionButton && !accordionButton.onclick) {
+            const multiSelectable = toBoolean(
+              element.getAttribute('aria-multiselectable'),
             );
 
-            dropDownElement.setAttribute(
-              'aria-hidden',
-              accordionButtonExpandedAttr,
+            const hasAriaControlsAttr = accordionButton.getAttribute(
+              'aria-controls',
             );
 
-            accordionButton.setAttribute(
-              'aria-expanded',
-              !accordionButtonExpandedAttr,
-            );
+            if (hasAriaControlsAttr && !multiSelectable) {
+              getOtherButtons(element, accordionButton).forEach(el => {
+                const contentEl = el.getAttribute('aria-controls');
 
-            if (!isElementInViewport(accordionButton)) {
-              element.scrollIntoView();
+                el.setAttribute('aria-expanded', 'false');
+
+                document
+                  .getElementById(contentEl)
+                  .setAttribute('aria-hidden', 'true');
+              });
+            }
+
+            if (hasAriaControlsAttr) {
+              const dropDownElement = document.getElementById(
+                accordionButton.getAttribute('aria-controls'),
+              );
+              const accordionButtonExpandedAttr = toBoolean(
+                accordionButton.getAttribute('aria-expanded'),
+              );
+
+              dropDownElement.setAttribute(
+                'aria-hidden',
+                accordionButtonExpandedAttr,
+              );
+
+              accordionButton.setAttribute(
+                'aria-expanded',
+                !accordionButtonExpandedAttr,
+              );
+
+              if (!isElementInViewport(accordionButton)) {
+                element.scrollIntoView();
+              }
             }
           }
-        }
-      });
+        });
+      }
     });
 };
 

--- a/packages/formation/js/index.js
+++ b/packages/formation/js/index.js
@@ -6,11 +6,11 @@ if (
   document.readyState === 'complete' &&
   (document.readyState !== 'loading' && !document.documentElement.doScroll)
 ) {
-  loadAccordionHandler();
   addSidenavListeners();
+  loadAccordionHandler();
 } else {
   domready(() => {
-    loadAccordionHandler();
     addSidenavListeners();
+    loadAccordionHandler();
   });
 }

--- a/packages/formation/js/sidenav.js
+++ b/packages/formation/js/sidenav.js
@@ -15,6 +15,7 @@ class SideBarMenu {
     this.getMenu = this.getMenu.bind(this);
     this.openMenu = this.openMenu.bind(this);
     this.closeMenu = this.closeMenu.bind(this);
+    this.addCloseMenuListener = this.addCloseMenuListener.bind(this);
     this.captureFocus = this.captureFocus.bind(this);
     this.checkAccordionFocus = this.checkAccordionFocus.bind(this);
     this.findKeyNodes = this.loadKeyNodes.bind(this);
@@ -100,7 +101,7 @@ class SideBarMenu {
       .getElementsByClassName('va-btn-sidebarnav-trigger')[0]
       .setAttribute('hidden', 'true');
     document.getElementsByTagName('body')[0].style.overflow = 'hidden';
-    this.closeMenu(trigger);
+    this.addCloseMenuListener();
     if (trigger.className.includes('va-btn-sidebarnav-trigger')) {
       // main trigger, switch focus to close button
       this.closeControl.focus();
@@ -126,17 +127,21 @@ class SideBarMenu {
     this.lastTabbableElement.removeEventListener('keydown', this.captureFocus);
   }
 
-  closeMenu() {
+  addCloseMenuListener() {
     const close = this.menu.querySelector('.va-sidebarnav-close');
     close.addEventListener('click', () => {
-      this.menu.classList.remove('va-sidebarnav--opened');
-      this.menu.setAttribute('aria-hidden', 'true');
-      document.getElementsByTagName('body')[0].style.overflow = 'initial';
-      document
-        .getElementsByClassName('va-btn-sidebarnav-trigger')[0]
-        .removeAttribute('hidden');
+      this.closeMenu();
       this.removeListeners();
     });
+  }
+
+  closeMenu() {
+    this.menu.classList.remove('va-sidebarnav--opened');
+    this.menu.setAttribute('aria-hidden', 'true');
+    document.getElementsByTagName('body')[0].style.overflow = 'initial';
+    document
+      .getElementsByClassName('va-btn-sidebarnav-trigger')[0]
+      .removeAttribute('hidden');
   }
 }
 


### PR DESCRIPTION
This is the same fix for https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/106. I found a bug. This should fix the issue with going from mobile to desktop. I also found a bug regarding multiple sidebar accordions being open when they shouldn't be.

Bug:
<img width="942" alt="Screen Shot 2019-05-14 at 7 31 21 PM" src="https://user-images.githubusercontent.com/5377648/57744660-f7641900-767e-11e9-962c-b55cf1eb0393.png">

Fix:
<img width="1009" alt="Screen Shot 2019-05-14 at 7 38 55 PM" src="https://user-images.githubusercontent.com/5377648/57744912-f1226c80-767f-11e9-9020-f08b47c85daa.png">
