### PR TITLE
Fix sidebar errors that break accordion

### DIFF
--- a/packages/formation/js/sidenav.js
+++ b/packages/formation/js/sidenav.js
@@ -151,12 +151,16 @@ function addActiveState() {
     '#va-detailpage-sidebar[data-drupal-sidebar]',
   );
   if (sideNav) {
-    const current = document.getElementsByClassName('usa-current')[0];
-    const parent = current.closest('.usa-accordion-content')
-      .previousElementSibling;
-    const ariaExpanded =
-      parent.getAttribute('aria-expanded') === 'false' ? 'true' : 'false';
-    parent.setAttribute('aria-expanded', ariaExpanded);
+    const current = sideNav.getElementsByClassName('usa-current')[0];
+    if (current) {
+      const accordionContent = current.closest('.usa-accordion-content');
+      if (accordionContent) {
+        const parent = accordionContent.previousElementSibling;
+        const ariaExpanded =
+          parent.getAttribute('aria-expanded') === 'false' ? 'true' : 'false';
+        parent.setAttribute('aria-expanded', ariaExpanded);
+      }
+    }
   }
 }
 

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.3.4",
+  "version": "6.3.5",
   "description": "The VA design system",
   "keywords": [
     "va",


### PR DESCRIPTION
After moving to formation.js for the sidebar, sidebar errors now break accordions, because they happen after the sidenav code.

This PR fixes a couple of the common errors:
http://sentry.vetsgov-internal/vets-gov/website-production/issues/60387/?query=is:unresolved
http://sentry.vetsgov-internal/vets-gov/website-production/issues/59485/?query=is:unresolved