### PR TITLE
The Pagination component is writing "undefined" in the next/previous page aria-labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formation-monorepo",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formation-monorepo",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/Pagination/Pagination.jsx
+++ b/packages/formation-react/src/components/Pagination/Pagination.jsx
@@ -13,16 +13,12 @@ class Pagination extends React.Component {
     this.pageNumbers = this.pageNumbers.bind(this);
   }
 
-  getAriaLabelSuffix() {
-    return this.props.ariaLabelSuffix || '';
-  }
-
   next() {
     let nextPage;
     if (this.props.pages > this.props.page) {
       nextPage = (
         <a
-          aria-label={`Load next page ${this.getAriaLabelSuffix()}`}
+          aria-label={`Load next page ${this.props.ariaLabelSuffix}`}
           onClick={() => {this.props.onPageSelect(this.props.page + 1);}}
           onKeyDown={e => this.handleKeyDown(e, this.props.page + 1)}
           tabIndex="0">
@@ -38,7 +34,7 @@ class Pagination extends React.Component {
     if (this.props.page > 1) {
       prevPage = (
         <a
-          aria-label={`Load previous page ${this.getAriaLabelSuffix()}`}
+          aria-label={`Load previous page ${this.props.ariaLabelSuffix}`}
           onClick={() => {this.props.onPageSelect(this.props.page - 1);}}
           onKeyDown={e => this.handleKeyDown(e, this.props.page - 1)}
           tabIndex="0">
@@ -64,7 +60,7 @@ class Pagination extends React.Component {
           <a aria-label="...">
             ...
           </a>
-          <a aria-label={`Load last page ${this.getAriaLabelSuffix()}`} onClick={() => {this.props.onPageSelect(totalPages);}}>
+          <a aria-label={`Load last page ${this.props.ariaLabelSuffix}`} onClick={() => {this.props.onPageSelect(totalPages);}}>
             {totalPages}
           </a>
         </span>
@@ -134,7 +130,7 @@ class Pagination extends React.Component {
         <a
           key={pageNumber}
           className={pageClass}
-          aria-label={`Load page ${pageNumber} ${this.getAriaLabelSuffix()}`}
+          aria-label={`Load page ${pageNumber} ${this.props.ariaLabelSuffix}`}
           onClick={() => this.props.onPageSelect(pageNumber)}
           onKeyDown={e => this.handleKeyDown(e, pageNumber)}
           tabIndex="0">
@@ -166,6 +162,7 @@ Pagination.propTypes = {
 
 Pagination.defaultProps = {
   maxPageListLength: 10,
+  ariaLabelSuffix: '',
 };
 
 export default Pagination;

--- a/packages/formation-react/src/components/Pagination/Pagination.jsx
+++ b/packages/formation-react/src/components/Pagination/Pagination.jsx
@@ -13,12 +13,16 @@ class Pagination extends React.Component {
     this.pageNumbers = this.pageNumbers.bind(this);
   }
 
+  getAriaLabelSuffix() {
+    return this.props.ariaLabelSuffix || '';
+  }
+
   next() {
     let nextPage;
     if (this.props.pages > this.props.page) {
       nextPage = (
         <a
-          aria-label={`Load next page ${this.props.ariaLabelSuffix}`}
+          aria-label={`Load next page ${this.getAriaLabelSuffix()}`}
           onClick={() => {this.props.onPageSelect(this.props.page + 1);}}
           onKeyDown={e => this.handleKeyDown(e, this.props.page + 1)}
           tabIndex="0">
@@ -34,7 +38,7 @@ class Pagination extends React.Component {
     if (this.props.page > 1) {
       prevPage = (
         <a
-          aria-label={`Load previous page ${this.props.ariaLabelSuffix}`}
+          aria-label={`Load previous page ${this.getAriaLabelSuffix()}`}
           onClick={() => {this.props.onPageSelect(this.props.page - 1);}}
           onKeyDown={e => this.handleKeyDown(e, this.props.page - 1)}
           tabIndex="0">
@@ -60,7 +64,7 @@ class Pagination extends React.Component {
           <a aria-label="...">
             ...
           </a>
-          <a aria-label={`Load last page ${this.props.ariaLabelSuffix}`} onClick={() => {this.props.onPageSelect(totalPages);}}>
+          <a aria-label={`Load last page ${this.getAriaLabelSuffix()}`} onClick={() => {this.props.onPageSelect(totalPages);}}>
             {totalPages}
           </a>
         </span>
@@ -130,7 +134,7 @@ class Pagination extends React.Component {
         <a
           key={pageNumber}
           className={pageClass}
-          aria-label={`Load page ${pageNumber} ${this.props.ariaLabelSuffix}`}
+          aria-label={`Load page ${pageNumber} ${this.getAriaLabelSuffix()}`}
           onClick={() => this.props.onPageSelect(pageNumber)}
           onKeyDown={e => this.handleKeyDown(e, pageNumber)}
           tabIndex="0">


### PR DESCRIPTION
You can see this in the search app, or any other place that uses Pagination but does not use the ariaLabelSuffix prop. The component needs to print an empty string, not undefined, when that prop is not provided.