### PR TITLE
add h2 support in feature component

### DIFF
--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -4,7 +4,7 @@
   "description": "Developer Document Site for VA.gov",
   "version": "0.1.0",
   "dependencies": {
-    "@department-of-veterans-affairs/formation": "^6.3.3",
+    "@department-of-veterans-affairs/formation": "^6.3.7",
     "@fortawesome/fontawesome-free": "^5.8.1",
     "@gatsby-contrib/gatsby-plugin-elasticlunr-search": "^2.2.1",
     "@mdx-js/mdx": "^0.16.6",

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.3.6",
+  "version": "6.3.7",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -400,6 +400,10 @@ article > h1 {
     padding-bottom: 0.5em;
   }
 
+  h2 {
+    margin-top: 0;
+  }
+
   h3 {
     margin-top: 0;
   }


### PR DESCRIPTION
This PR will add support for styling `h2`s in featured content boxes. The styling simply removes the top margin. 

This should be included so that the proper semantic heading level can be applied.

Before:
<img width="647" alt="Screen Shot 2019-05-23 at 11 54 11 AM" src="https://user-images.githubusercontent.com/25435289/58267391-87762280-7d51-11e9-9b04-b48346e7674d.png">

After:
<img width="637" alt="Screen Shot 2019-05-23 at 11 54 20 AM" src="https://user-images.githubusercontent.com/25435289/58267406-8e9d3080-7d51-11e9-9ad9-5a3ba5dabe9f.png">
