### PR TITLE
[Loading Indicator] Switch from SVG to CSS

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.4.0",
+  "version": "6.5.0",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/modules/_m-loading-indicator.scss
+++ b/packages/formation/sass/modules/_m-loading-indicator.scss
@@ -15,7 +15,7 @@
       border-radius: 50%;
       border: 8px solid #0071BB;
       border-color: #0071BB transparent #0071BB transparent;
-      animation: lds-dual-ring 1.2s linear infinite;
+      animation: spin 1.2s linear infinite;
     }
 
     &:focus {
@@ -28,7 +28,7 @@
   padding-bottom: 1em;
 }
 
-@keyframes lds-dual-ring {
+@keyframes spin {
   0% {
     transform: rotate(0deg);
   }

--- a/packages/formation/sass/modules/_m-loading-indicator.scss
+++ b/packages/formation/sass/modules/_m-loading-indicator.scss
@@ -3,18 +3,18 @@
 
   .loading-indicator {
     display: block;
-    height: 8em;
-    margin-top: 2em;
+    height: units(8);
+    margin-top: units(2);
 
     &:after {
       content: " ";
       display: inline-block;
-      width: 7em;
-      height: 7em;
+      width: units(7);
+      height: units(7);
       margin: 1px;
       border-radius: 50%;
-      border: 8px solid #0071BB;
-      border-color: #0071BB transparent #0071BB transparent;
+      border: 8px solid  $color-primary;
+      border-color:  $color-primary transparent  $color-primary transparent;
       animation: spin 1.2s linear infinite;
     }
 
@@ -25,7 +25,7 @@
 }
 
 .async-loader {
-  padding-bottom: 1em;
+  padding-bottom: units(1);
 }
 
 @keyframes spin {

--- a/packages/formation/sass/modules/_m-loading-indicator.scss
+++ b/packages/formation/sass/modules/_m-loading-indicator.scss
@@ -2,10 +2,22 @@
   text-align: center;
 
   .loading-indicator {
-    min-height: 8em;
-    background: url('#{$formation-image-path}/loading-state.svg') center center no-repeat;
-    background-size: contain;
-    text-align: center;
+    display: block;
+    height: 8em;
+    margin-top: 2em;
+
+    &:after {
+      content: " ";
+      display: inline-block;
+      width: 7em;
+      height: 7em;
+      margin: 1px;
+      border-radius: 50%;
+      border: 8px solid #0071BB;
+      border-color: #0071BB transparent #0071BB transparent;
+      animation: lds-dual-ring 1.2s linear infinite;
+    }
+
     &:focus {
       outline: none;
     }
@@ -14,4 +26,13 @@
 
 .async-loader {
   padding-bottom: 1em;
+}
+
+@keyframes lds-dual-ring {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }


### PR DESCRIPTION
## Description
Currently, the loading-indicator uses an animated SVG as its spinner. This isn't friendly with Internet Explorer or Edge - in those browsers, it's just a blue outline of a circle. This wasn't an issue before because most of the time the spinner was only shown for a split second. However, the new Community Cares functionality can take a full minute to load, and the broken SVG makes it appears that much more broken.

This PR proposes we switch to a CSS spinner. [transition](https://caniuse.com/#feat=css-transitions) appears to be supported by all of the browsers VA.gov supports.

Ticket - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/18818

## Testing done
Tested UX of Facility Locator
- Tested app booting up
- Tested queries

## Screenshots

![ezgif-4-a6dea2f77764](https://user-images.githubusercontent.com/1915775/58988986-ea83a280-87b0-11e9-931d-39f22ee7af52.gif)

![ezgif-4-5139dc256428](https://user-images.githubusercontent.com/1915775/58988547-f4f16c80-87af-11e9-84c0-2d788f25dbd0.gif)


## Acceptance criteria
- [x] Spinner works in IE/Edge
- [x] HTML Is not changed

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
