### PR TITLE
fix lead line height

### DIFF
--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -4,7 +4,7 @@
   "description": "Developer Document Site for VA.gov",
   "version": "0.1.0",
   "dependencies": {
-    "@department-of-veterans-affairs/formation": "^6.3.7",
+    "@department-of-veterans-affairs/formation": "^6.5.1",
     "@fortawesome/fontawesome-free": "^5.8.1",
     "@gatsby-contrib/gatsby-plugin-elasticlunr-search": "^2.2.1",
     "@mdx-js/mdx": "^0.16.6",

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -365,6 +365,10 @@ article > h1 {
   font-weight: $font-normal;
   line-height: $lead-line-height;
   max-width: $lead-max-width;
+
+  p {
+    line-height: $lead-line-height;
+  }
 }
 
 .secondary {


### PR DESCRIPTION
## Description
This is a minor fix to the lead text `line-height` suggested by @rtwell.

What was happening is that the  `line-height` was computing to `30px` for this:
```
<div class="va-introtext">
   <p>Some text</p>
</div>
```

But it would be `34px` for this:
```
<p class="va-introtext">Some text</p>
```

We want the `line-height` to be `34px`.  Looks like the paragraph's base styles were overriding the CSS in `va-introtext`, so this patch just reinforces that with some extra specificity.