### PR TITLE
Implement PromoBanner

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "4.6.3",
+  "version": "4.7.0",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/PromoBanner/PromoBanner.jsx
+++ b/packages/formation-react/src/components/PromoBanner/PromoBanner.jsx
@@ -24,40 +24,37 @@ class PromoBanner extends React.Component {
 
     return (
       <div className="vads-c-promo-banner">
-        <div className="vads-l-grid-container">
-          <div className="vads-c-promo-banner__body">
-            <div className="vads-c-promo-banner__content">
-              <div className="vads-c-promo-banner__content-icon">
-                <span className="fa-stack fa-lg">
-                  <i className="vads-u-color--white fa fa-circle fa-stack-2x" />
-                  <i className={iconClasses} />
-                </span>
-              </div>
-
-              {this.props.render ? (
-                this.props.render()
-              ) : (
-                <a
-                  className="vads-c-promo-banner__content-link"
-                  href={this.props.href}
-                  onClick={this.props.onClose}
-                >
-                  {this.props.text}{' '}
-                  <i className="fas fa-angle-right vads-u-margin-left--1" />
-                </a>
-              )}
+        <div className="vads-c-promo-banner__body">
+          <div className="vads-c-promo-banner__content">
+            <div className="vads-c-promo-banner__content-icon">
+              <span className="fa-stack fa-lg">
+                <i className="vads-u-color--white fa fa-circle fa-stack-2x" />
+                <i className={iconClasses} />
+              </span>
             </div>
 
-            <div className="vads-c-promo-banner__close">
-              <button
-                type="button"
-                aria-label="Dismiss this announcement"
+            {this.props.render ? (
+              this.props.render()
+            ) : (
+              <a
+                className="vads-c-promo-banner__content-link"
+                href={this.props.href}
                 onClick={this.props.onClose}
-                className="va-button-link vads-u-margin-top--1"
               >
-                <i className="fas fa-times-circle vads-u-font-size--lg" />
-              </button>
-            </div>
+                {this.props.text} <i className="fas fa-angle-right" />
+              </a>
+            )}
+          </div>
+
+          <div className="vads-c-promo-banner__close">
+            <button
+              type="button"
+              aria-label="Dismiss this announcement"
+              onClick={this.props.onClose}
+              className="va-button-link vads-u-margin-top--1"
+            >
+              <i className="fas fa-times-circle vads-u-font-size--lg" />
+            </button>
           </div>
         </div>
       </div>

--- a/packages/formation-react/src/components/PromoBanner/PromoBanner.jsx
+++ b/packages/formation-react/src/components/PromoBanner/PromoBanner.jsx
@@ -23,11 +23,11 @@ class PromoBanner extends React.Component {
     );
 
     return (
-      <div className="va-promo-banner">
+      <div className="vads-c-promo-banner">
         <div className="usa-grid-full">
-          <div className="va-promo-banner-body">
-            <div className="va-promo-banner-content">
-              <div className="va-promo-banner-content-icon">
+          <div className="vads-c-promo-banner__body">
+            <div className="vads-c-promo-banner__content">
+              <div className="vads-c-promo-banner__content-icon">
                 <span className="fa-stack fa-lg">
                   <i className="vads-u-color--white fa fa-circle fa-stack-2x" />
                   <i className={iconClasses} />
@@ -38,7 +38,7 @@ class PromoBanner extends React.Component {
                 this.props.render()
               ) : (
                 <a
-                  className="va-promo-banner-content-link"
+                  className="vads-c-promo-banner__content-link"
                   href={this.props.href}
                   onClick={this.props.onClose}
                 >
@@ -48,7 +48,7 @@ class PromoBanner extends React.Component {
               )}
             </div>
 
-            <div className="va-promo-banner-close">
+            <div className="vads-c-promo-banner__close">
               <button
                 type="button"
                 aria-label="Dismiss this announcement"

--- a/packages/formation-react/src/components/PromoBanner/PromoBanner.jsx
+++ b/packages/formation-react/src/components/PromoBanner/PromoBanner.jsx
@@ -24,7 +24,7 @@ class PromoBanner extends React.Component {
 
     return (
       <div className="vads-c-promo-banner">
-        <div className="usa-grid-full">
+        <div className="vads-l-grid-container">
           <div className="vads-c-promo-banner__body">
             <div className="vads-c-promo-banner__content">
               <div className="vads-c-promo-banner__content-icon">

--- a/packages/formation-react/src/components/PromoBanner/PromoBanner.jsx
+++ b/packages/formation-react/src/components/PromoBanner/PromoBanner.jsx
@@ -23,7 +23,7 @@ class PromoBanner extends React.Component {
     );
 
     return (
-      <div className="vads-c-promo-banner">
+      <div className="vads-c-promo-banner vads-c-promo-banner--fixed-bottom">
         <div className="vads-c-promo-banner__body">
           <div className="vads-c-promo-banner__content">
             <div className="vads-c-promo-banner__content-icon">

--- a/packages/formation-react/src/components/PromoBanner/PromoBanner.jsx
+++ b/packages/formation-react/src/components/PromoBanner/PromoBanner.jsx
@@ -23,7 +23,7 @@ class PromoBanner extends React.Component {
     );
 
     return (
-      <div className="vads-c-promo-banner vads-c-promo-banner--fixed-bottom">
+      <div className="vads-c-promo-banner">
         <div className="vads-c-promo-banner__body">
           <div className="vads-c-promo-banner__content">
             <div className="vads-c-promo-banner__content-icon">

--- a/packages/formation-react/src/components/PromoBanner/PromoBanner.jsx
+++ b/packages/formation-react/src/components/PromoBanner/PromoBanner.jsx
@@ -8,27 +8,18 @@ const PROMO_BANNER_TYPES = {
   emailSignup: 'email-signup',
 };
 
+const PROMO_BANNER_ICONS = new Map([
+  [PROMO_BANNER_TYPES.announcement, 'fa-bullhorn'],
+  [PROMO_BANNER_TYPES.news, 'fa-newspaper'],
+  [PROMO_BANNER_TYPES.emailSignup, 'fa-envelope'],
+]);
+
 class PromoBanner extends React.Component {
-  static propTypes = {
-    type: PropTypes.oneOf(Object.values(PROMO_BANNER_TYPES)).isRequired,
-    onClose: PropTypes.func.isRequired,
-    render: PropTypes.func,
-    href: PropTypes.string,
-    text: PropTypes.string,
-    children: PropTypes.node,
-  };
-
-  static icons = new Map([
-    [PROMO_BANNER_TYPES.announcement, 'fas fa-bullhorn fa-stack-1x'],
-    [PROMO_BANNER_TYPES.news, 'fas fa-newspaper'],
-    [PROMO_BANNER_TYPES.emailSignup, 'fas fa-envelope'],
-  ]);
-
   render() {
     const iconClasses = classnames(
       'fas',
       'fa-stack-1x',
-      PromoBanner.icons.get(this.props.type),
+      PROMO_BANNER_ICONS.get(this.props.type),
     );
 
     return (
@@ -73,6 +64,15 @@ class PromoBanner extends React.Component {
     );
   }
 }
+
+PromoBanner.propTypes = {
+  type: PropTypes.oneOf(Object.values(PROMO_BANNER_TYPES)).isRequired,
+  onClose: PropTypes.func.isRequired,
+  render: PropTypes.func,
+  href: PropTypes.string,
+  text: PropTypes.string,
+  children: PropTypes.node,
+};
 
 export default PromoBanner;
 

--- a/packages/formation-react/src/components/PromoBanner/PromoBanner.jsx
+++ b/packages/formation-react/src/components/PromoBanner/PromoBanner.jsx
@@ -14,52 +14,50 @@ const PROMO_BANNER_ICONS = new Map([
   [PROMO_BANNER_TYPES.emailSignup, 'fa-envelope'],
 ]);
 
-class PromoBanner extends React.Component {
-  render() {
-    const iconClasses = classnames(
-      'fas',
-      'fa-stack-1x',
-      PROMO_BANNER_ICONS.get(this.props.type),
-    );
+function PromoBanner({ type, onClose, render, href, text }) {
+  const iconClasses = classnames(
+    'fas',
+    'fa-stack-1x',
+    PROMO_BANNER_ICONS.get(type),
+  );
 
-    return (
-      <div className="vads-c-promo-banner">
-        <div className="vads-c-promo-banner__body">
-          <div className="vads-c-promo-banner__content">
-            <div className="vads-c-promo-banner__content-icon">
-              <span className="fa-stack fa-lg">
-                <i className="vads-u-color--white fa fa-circle fa-stack-2x" />
-                <i className={iconClasses} />
-              </span>
-            </div>
-
-            {this.props.render ? (
-              this.props.render()
-            ) : (
-              <a
-                className="vads-c-promo-banner__content-link"
-                href={this.props.href}
-                onClick={this.props.onClose}
-              >
-                {this.props.text} <i className="fas fa-angle-right" />
-              </a>
-            )}
+  return (
+    <div className="vads-c-promo-banner">
+      <div className="vads-c-promo-banner__body">
+        <div className="vads-c-promo-banner__content">
+          <div className="vads-c-promo-banner__content-icon">
+            <span className="fa-stack fa-lg">
+              <i className="vads-u-color--white fa fa-circle fa-stack-2x" />
+              <i className={iconClasses} />
+            </span>
           </div>
 
-          <div className="vads-c-promo-banner__close">
-            <button
-              type="button"
-              aria-label="Dismiss this announcement"
-              onClick={this.props.onClose}
-              className="va-button-link vads-u-margin-top--1"
+          {render ? (
+            render()
+          ) : (
+            <a
+              className="vads-c-promo-banner__content-link"
+              href={href}
+              onClick={onClose}
             >
-              <i className="fas fa-times-circle vads-u-font-size--lg" />
-            </button>
-          </div>
+              {text} <i className="fas fa-angle-right" />
+            </a>
+          )}
+        </div>
+
+        <div className="vads-c-promo-banner__close">
+          <button
+            type="button"
+            aria-label="Dismiss this announcement"
+            onClick={onClose}
+            className="va-button-link vads-u-margin-top--1"
+          >
+            <i className="fas fa-times-circle vads-u-font-size--lg" />
+          </button>
         </div>
       </div>
-    );
-  }
+    </div>
+  );
 }
 
 PromoBanner.propTypes = {
@@ -68,7 +66,6 @@ PromoBanner.propTypes = {
   render: PropTypes.func,
   href: PropTypes.string,
   text: PropTypes.string,
-  children: PropTypes.node,
 };
 
 export default PromoBanner;

--- a/packages/formation-react/src/components/PromoBanner/PromoBanner.jsx
+++ b/packages/formation-react/src/components/PromoBanner/PromoBanner.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+const PROMO_BANNER_TYPES = {
+  announcement: 'announcement',
+  news: 'news',
+  emailSignup: 'email-signup',
+};
+
+class PromoBanner extends React.Component {
+  static propTypes = {
+    type: PropTypes.oneOf(Object.values(PROMO_BANNER_TYPES)).isRequired,
+    onClose: PropTypes.func.isRequired,
+    render: PropTypes.func,
+    href: PropTypes.string,
+    text: PropTypes.string,
+    children: PropTypes.node,
+  };
+
+  static icons = new Map([
+    [PROMO_BANNER_TYPES.announcement, 'fas fa-bullhorn fa-stack-1x'],
+    [PROMO_BANNER_TYPES.news, 'fas fa-newspaper'],
+    [PROMO_BANNER_TYPES.emailSignup, 'fas fa-envelope'],
+  ]);
+
+  render() {
+    const iconClasses = classnames(
+      'fas',
+      'fa-stack-1x',
+      PromoBanner.icons.get(this.props.type),
+    );
+
+    return (
+      <div className="va-promo-banner">
+        <div className="usa-grid-full">
+          <div className="va-promo-banner-body">
+            <div className="va-promo-banner-content">
+              <div className="va-promo-banner-content-icon">
+                <span className="fa-stack fa-lg">
+                  <i className="vads-u-color--white fa fa-circle fa-stack-2x" />
+                  <i className={iconClasses} />
+                </span>
+              </div>
+
+              {this.props.render ? (
+                this.props.render()
+              ) : (
+                <a
+                  className="va-promo-banner-content-link"
+                  href={this.props.href}
+                  onClick={this.props.onClose}
+                >
+                  {this.props.text}{' '}
+                  <i className="fas fa-angle-right fa-lg vads-u-margin-left--1" />
+                </a>
+              )}
+            </div>
+
+            <div className="va-promo-banner-close">
+              <button
+                type="button"
+                aria-label="Dismiss this announcement"
+                onClick={this.props.onClose}
+                className="va-button-link vads-u-margin-top--1"
+              >
+                <i className="fas fa-times-circle vads-u-font-size--lg" />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default PromoBanner;
+
+export { PROMO_BANNER_TYPES };

--- a/packages/formation-react/src/components/PromoBanner/PromoBanner.jsx
+++ b/packages/formation-react/src/components/PromoBanner/PromoBanner.jsx
@@ -43,7 +43,7 @@ class PromoBanner extends React.Component {
                   onClick={this.props.onClose}
                 >
                   {this.props.text}{' '}
-                  <i className="fas fa-angle-right fa-lg vads-u-margin-left--1" />
+                  <i className="fas fa-angle-right vads-u-margin-left--1" />
                 </a>
               )}
             </div>

--- a/packages/formation-react/src/components/PromoBanner/PromoBanner.mdx
+++ b/packages/formation-react/src/components/PromoBanner/PromoBanner.mdx
@@ -39,12 +39,16 @@ export class RenderedComponent extends React.Component {
   render () {
     return (
       <div className="site-c-reactcomp__rendered">
-        <PromoBanner
-          type={PROMO_BANNER_TYPES.announcement}
-          onClose={() => this.setState({ dismissed: true }}
-          href="https://missionact.va.gov/"
-          text="Learn how you can get easier access to health care with the MISSION Act"
-        />
+        {!this.state.dismissed ? (
+          <PromoBanner
+            type={PROMO_BANNER_TYPES.announcement}
+            onClose={() => this.setState({ dismissed: true }}
+            href="https://missionact.va.gov/"
+            text="Learn how you can get easier access to health care with the MISSION Act"
+          />
+        ) : (
+          <span>PromoBanner was dismissed!</span>
+        )}
       </div>
     );
   }

--- a/packages/formation-react/src/components/PromoBanner/PromoBanner.mdx
+++ b/packages/formation-react/src/components/PromoBanner/PromoBanner.mdx
@@ -1,7 +1,7 @@
 ---
 title: PromoBanner
 name: PromoBanner
-tags: promo banner, promobanner, announcement
+tags: promo banner, promo-banner, promobanner, announcement
 ---
 
 import PromoBanner from './PromoBanner'

--- a/packages/formation-react/src/components/PromoBanner/PromoBanner.mdx
+++ b/packages/formation-react/src/components/PromoBanner/PromoBanner.mdx
@@ -41,7 +41,7 @@ export class RenderedComponent extends React.Component {
       <div className="site-c-reactcomp__rendered">
         {!this.state.dismissed ? (
           <PromoBanner
-            type={PROMO_BANNER_TYPES.announcement}
+            type="announcement"
             onClose={() => this.setState({ dismissed: true })}
             href="https://missionact.va.gov/"
             text="Learn how you can get easier access to health care with the MISSION Act"

--- a/packages/formation-react/src/components/PromoBanner/PromoBanner.mdx
+++ b/packages/formation-react/src/components/PromoBanner/PromoBanner.mdx
@@ -42,7 +42,7 @@ export class RenderedComponent extends React.Component {
         {!this.state.dismissed ? (
           <PromoBanner
             type={PROMO_BANNER_TYPES.announcement}
-            onClose={() => this.setState({ dismissed: true }}
+            onClose={() => this.setState({ dismissed: true })}
             href="https://missionact.va.gov/"
             text="Learn how you can get easier access to health care with the MISSION Act"
           />

--- a/packages/formation-react/src/components/PromoBanner/PromoBanner.mdx
+++ b/packages/formation-react/src/components/PromoBanner/PromoBanner.mdx
@@ -1,0 +1,53 @@
+---
+title: PromoBanner
+name: PromoBanner
+tags: promo banner, promobanner, announcement
+---
+
+import PromoBanner from './PromoBanner'
+
+### Code:
+
+#### Example State
+```
+state = {
+  dismissed: false,
+}
+```
+
+#### Code Sample
+```javascript
+import PromoBanner, { PROMO_BANNER_TYPES } from '@department-of-veterans-affairs/formation-react/PromoBanner'
+
+<PromoBanner
+  type={PROMO_BANNER_TYPES.announcement}
+  onClose={() => this.setState({ dismissed: true }}
+  href="https://missionact.va.gov/"
+  text="Learn how you can get easier access to health care with the MISSION Act"
+/>
+```
+
+### Rendered Component
+
+export class RenderedComponent extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      dismissed: false,
+    }
+  }
+  render () {
+    return (
+      <div className="site-c-reactcomp__rendered">
+        <PromoBanner
+          type={PROMO_BANNER_TYPES.announcement}
+          onClose={() => this.setState({ dismissed: true }}
+          href="https://missionact.va.gov/"
+          text="Learn how you can get easier access to health care with the MISSION Act"
+        />
+      </div>
+    );
+  }
+}
+
+<RenderedComponent />

--- a/packages/formation-react/src/components/PromoBanner/PromoBanner.unit.spec.jsx
+++ b/packages/formation-react/src/components/PromoBanner/PromoBanner.unit.spec.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import { axeCheck } from '../../helpers/test-helpers';
+import PromoBanner, { PROMO_BANNER_TYPES } from './PromoBanner.jsx';
+
+const TEXT =
+  'Learn how you can get easier access to health care with the MISSION Act';
+
+describe('<PromoBanner>', () => {
+  let defaultProps = null;
+
+  beforeEach(() => {
+    defaultProps = {
+      type: PROMO_BANNER_TYPES.announcement,
+      onClose() {},
+      href: 'https://missionact.va.gov/',
+      text: TEXT,
+    };
+  });
+
+  it('should render', () => {
+    const tree = shallow(<PromoBanner {...defaultProps} />);
+    expect(tree.text()).to.contain(TEXT);
+    tree.unmount();
+  });
+
+  it('should pass aXe check', () =>
+    axeCheck(<PromoBanner {...defaultProps} />));
+});

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.5.1",
+  "version": "6.6.0",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/full.scss
+++ b/packages/formation/sass/full.scss
@@ -29,3 +29,4 @@ $image-path: "~uswds/src/img";
 @import "icons";
 @import "modules/m-megamenu";
 @import "modules/m-hub-page-link-list";
+@import "modules/m-promo-banner";

--- a/packages/formation/sass/modules/_m-promo-banner.scss
+++ b/packages/formation/sass/modules/_m-promo-banner.scss
@@ -9,19 +9,19 @@
   color: $color-link-default;
   font-weight: 700;
 
-  &-body {
+  .va-promo-banner-body {
     display: table;
     width: 100%;
   }
 
-  &-content, &-close {
+  .va-promo-banner-content, va-promo-banner-close {
     display: table-cell;
   }
 
-  &-content {
+  .va-promo-banner-content {
     padding: units(1);
 
-    &-icon {
+    .va-promo-banner-content-icon {
       margin-right: units(1);
       display: none;
       @include media($medium-screen) {
@@ -29,7 +29,7 @@
       }
     }
 
-    &-link {
+    .va-promo-banner-content-link {
       vertical-align: middle;
       display: inline-block;
       text-decoration: none;
@@ -40,7 +40,7 @@
     }
   }
 
-  &-close {
+  .va-promo-banner-close {
     text-align: center;
     vertical-align: middle;
     border-left: 1px solid $color-gray-lighter;

--- a/packages/formation/sass/modules/_m-promo-banner.scss
+++ b/packages/formation/sass/modules/_m-promo-banner.scss
@@ -49,7 +49,7 @@
     @include media($medium-screen) {
       text-align: right;
       border: none;
-      padding: none;
+      padding: 0;
     }
   }
 }

--- a/packages/formation/sass/modules/_m-promo-banner.scss
+++ b/packages/formation/sass/modules/_m-promo-banner.scss
@@ -14,12 +14,13 @@
     width: 100%;
   }
 
-  .vads-c-promo-banner__content, va-promo-banner-close {
+  .vads-c-promo-banner__content, .vads-c-promo-banner__close {
     display: table-cell;
   }
 
   .vads-c-promo-banner__content {
     padding: units(1);
+    line-height: units(2.5);
 
     .vads-c-promo-banner__content-icon {
       margin-right: units(1);

--- a/packages/formation/sass/modules/_m-promo-banner.scss
+++ b/packages/formation/sass/modules/_m-promo-banner.scss
@@ -1,0 +1,54 @@
+.va-promo-banner {
+  z-index: $base-layer + 1;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+
+  background-color: $color-gray-lightest;
+  color: $color-link-default;
+  font-weight: 700;
+
+  &-body {
+    display: table;
+    width: 100%;
+  }
+
+  &-content, &-close {
+    display: table-cell;
+  }
+
+  &-content {
+    padding: units(1);
+
+    &-icon {
+      margin-right: units(1);
+      display: none;
+      @include media($medium-screen) {
+        display: inline-block;
+      }
+    }
+
+    &-link {
+      vertical-align: middle;
+      display: inline-block;
+      text-decoration: none;
+      &:hover, &:visited {
+        background-color: transparent;
+        color: $color-link-default;
+      }
+    }
+  }
+
+  &-close {
+    text-align: center;
+    vertical-align: middle;
+    border-left: 1px solid $color-gray-lighter;
+    padding: 0 units(2);
+    @include media($medium-screen) {
+      text-align: right;
+      border: none;
+      padding: none;
+    }
+  }
+}

--- a/packages/formation/sass/modules/_m-promo-banner.scss
+++ b/packages/formation/sass/modules/_m-promo-banner.scss
@@ -1,4 +1,4 @@
-.va-promo-banner {
+.vads-c-promo-banner {
   z-index: $base-layer + 1;
   position: fixed;
   bottom: 0;
@@ -9,19 +9,19 @@
   color: $color-link-default;
   font-weight: 700;
 
-  .va-promo-banner-body {
+  .vads-c-promo-banner__body {
     display: table;
     width: 100%;
   }
 
-  .va-promo-banner-content, va-promo-banner-close {
+  .vads-c-promo-banner__content, va-promo-banner-close {
     display: table-cell;
   }
 
-  .va-promo-banner-content {
+  .vads-c-promo-banner__content {
     padding: units(1);
 
-    .va-promo-banner-content-icon {
+    .vads-c-promo-banner__content-icon {
       margin-right: units(1);
       display: none;
       @include media($medium-screen) {
@@ -29,7 +29,7 @@
       }
     }
 
-    .va-promo-banner-content-link {
+    .vads-c-promo-banner__content-link {
       vertical-align: middle;
       display: inline-block;
       text-decoration: none;
@@ -40,7 +40,7 @@
     }
   }
 
-  .va-promo-banner-close {
+  .vads-c-promo-banner__close {
     text-align: center;
     vertical-align: middle;
     border-left: 1px solid $color-gray-lighter;

--- a/packages/formation/sass/modules/_m-promo-banner.scss
+++ b/packages/formation/sass/modules/_m-promo-banner.scss
@@ -1,15 +1,12 @@
 .vads-c-promo-banner {
-  background-color: $color-gray-lightest;
-  color: $color-link-default;
-  font-weight: 700;
-}
-
-.vads-c-promo-banner--fixed-bottom {
   z-index: $base-layer + 1;
   position: fixed;
   bottom: 0;
   left: 0;
   width: 100%;
+  background-color: $color-gray-lightest;
+  color: $color-link-default;
+  font-weight: 700;
 }
 
 .vads-c-promo-banner__body {

--- a/packages/formation/sass/modules/_m-promo-banner.scss
+++ b/packages/formation/sass/modules/_m-promo-banner.scss
@@ -4,54 +4,53 @@
   bottom: 0;
   left: 0;
   width: 100%;
-
   background-color: $color-gray-lightest;
   color: $color-link-default;
   font-weight: 700;
+}
 
-  .vads-c-promo-banner__body {
-    display: table;
-    width: 100%;
-    max-width: $site-max-width;
-    margin: 0 auto;
+.vads-c-promo-banner__body {
+  display: table;
+  width: 100%;
+  max-width: $site-max-width;
+  margin: 0 auto;
+}
+
+.vads-c-promo-banner__content, .vads-c-promo-banner__close {
+  display: table-cell;
+}
+
+.vads-c-promo-banner__content {
+  padding: units(1);
+  line-height: units(2.5);
+}
+
+.vads-c-promo-banner__content-icon {
+  margin-right: units(1);
+  display: none;
+  @include media($medium-screen) {
+    display: inline-block;
   }
+}
 
-  .vads-c-promo-banner__content, .vads-c-promo-banner__close {
-    display: table-cell;
+.vads-c-promo-banner__content-link {
+  vertical-align: middle;
+  display: inline-block;
+  text-decoration: none;
+  &:hover, &:visited {
+    background-color: transparent;
+    color: $color-link-default;
   }
+}
 
-  .vads-c-promo-banner__content {
-    padding: units(1);
-    line-height: units(2.5);
-
-    .vads-c-promo-banner__content-icon {
-      margin-right: units(1);
-      display: none;
-      @include media($medium-screen) {
-        display: inline-block;
-      }
-    }
-
-    .vads-c-promo-banner__content-link {
-      vertical-align: middle;
-      display: inline-block;
-      text-decoration: none;
-      &:hover, &:visited {
-        background-color: transparent;
-        color: $color-link-default;
-      }
-    }
-  }
-
-  .vads-c-promo-banner__close {
-    text-align: center;
-    vertical-align: middle;
-    border-left: 1px solid $color-gray-lighter;
-    padding: 0 units(2);
-    @include media($medium-screen) {
-      text-align: right;
-      border: none;
-      padding: 0;
-    }
+.vads-c-promo-banner__close {
+  text-align: center;
+  vertical-align: middle;
+  border-left: 1px solid $color-gray-lighter;
+  padding: 0 units(2);
+  @include media($medium-screen) {
+    text-align: right;
+    border: none;
+    padding: 0;
   }
 }

--- a/packages/formation/sass/modules/_m-promo-banner.scss
+++ b/packages/formation/sass/modules/_m-promo-banner.scss
@@ -1,12 +1,15 @@
 .vads-c-promo-banner {
+  background-color: $color-gray-lightest;
+  color: $color-link-default;
+  font-weight: 700;
+}
+
+.vads-c-promo-banner--fixed-bottom {
   z-index: $base-layer + 1;
   position: fixed;
   bottom: 0;
   left: 0;
   width: 100%;
-  background-color: $color-gray-lightest;
-  color: $color-link-default;
-  font-weight: 700;
 }
 
 .vads-c-promo-banner__body {

--- a/packages/formation/sass/modules/_m-promo-banner.scss
+++ b/packages/formation/sass/modules/_m-promo-banner.scss
@@ -12,6 +12,8 @@
   .vads-c-promo-banner__body {
     display: table;
     width: 100%;
+    max-width: $site-max-width;
+    margin: 0 auto;
   }
 
   .vads-c-promo-banner__content, .vads-c-promo-banner__close {

--- a/packages/formation/sass/site/site.scss
+++ b/packages/formation/sass/site/site.scss
@@ -29,3 +29,4 @@ $image-path: "~uswds/src/img";
 @import "../icons";
 @import "../modules/m-megamenu";
 @import "../modules/m-hub-page-link-list";
+@import "../modules/m-promo-banner";


### PR DESCRIPTION
## Description
Formerly known in vets-website as an "announcement", this PR redesigns and implements a promo-banner component. 

There are three types of promo-banners, each with their own FA icon -

1. Announcement (this is why I changed the name)
2. News
3. Email Signup

Ticket - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/18175

Once this is ready, I'll update the vets-website PR to begin consuming the new `PromoBanner` component, https://github.com/department-of-veterans-affairs/vets-website/pull/10269.

## Testing done
- Locally tested in vets-website

## Screenshots

### Personalized Homepage

#### Large screen
![image](https://user-images.githubusercontent.com/1915775/59794025-fd649f80-92a5-11e9-9ab7-25299ed890e0.png)

#### Small screen
![image](https://user-images.githubusercontent.com/1915775/59794046-0fded900-92a6-11e9-989a-6f51c7fe9cb9.png)

### MISSION Act

#### Large screen
![image](https://user-images.githubusercontent.com/1915775/59793762-58e25d80-92a5-11e9-9997-deb6962dae99.png)


#### Small Screen
![image](https://user-images.githubusercontent.com/1915775/59790740-a0b1b680-929e-11e9-89d2-af4d39b6952f.png)

### News example
![image](https://user-images.githubusercontent.com/1915775/59793021-862e0c00-92a3-11e9-8cea-0663117cb849.png)



### Email Signup Example
![image](https://user-images.githubusercontent.com/1915775/59792958-60086c00-92a3-11e9-8664-4721f02d5dc8.png)


## Acceptance criteria
- [x] Component is implemented and up to standards

## Definition of done
- [x] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
