### PR TITLE
[Promo-Banner] Remove padding-left on large screens

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.6.0",
+  "version": "6.6.1",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/modules/_m-promo-banner.scss
+++ b/packages/formation/sass/modules/_m-promo-banner.scss
@@ -23,6 +23,9 @@
 .vads-c-promo-banner__content {
   padding: units(1);
   line-height: units(2.5);
+  @include media($medium-screen) {
+    padding-left: 0;
+  }
 }
 
 .vads-c-promo-banner__content-icon {


### PR DESCRIPTION
## Description
Follow-up to https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/137 based on vets-website comment, https://github.com/department-of-veterans-affairs/vets-website/pull/10269#issuecomment-504101042.

This PR removes some padding-left on large/medium screens.

## Testing done
tested different screen sizes

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/59868237-6c053400-935e-11e9-9622-ee5d838ae3ba.png)


## Acceptance criteria
- [ ] comment is addressed

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
