### PR TITLE
[Promo Banner] Always allow padding around close button

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.6.1",
+  "version": "6.6.2",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/modules/_m-promo-banner.scss
+++ b/packages/formation/sass/modules/_m-promo-banner.scss
@@ -54,6 +54,5 @@
   @include media($medium-screen) {
     text-align: right;
     border: none;
-    padding: 0;
   }
 }


### PR DESCRIPTION
## Description
On medium-large screen sizes it looked like the close button was too close to the edge. This PR fixes that by just always allowing the padding around the close button. 


## Testing done
Resizing the browser over and over again

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/1915775/59880466-1723e680-937b-11e9-9a34-6f695e8cba85.png)

### After
![image](https://user-images.githubusercontent.com/1915775/59880641-826db880-937b-11e9-8a46-cccfa696f8fa.png)

## Acceptance criteria
- [ ] Close button is no longer too close to the edge

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
