### PR TITLE
correct font-weight value for font utility

### DIFF
--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -4,7 +4,7 @@
   "description": "Developer Document Site for VA.gov",
   "version": "0.1.0",
   "dependencies": {
-    "@department-of-veterans-affairs/formation": "^6.5.1",
+    "@department-of-veterans-affairs/formation": "^6.6.3",
     "@fortawesome/fontawesome-free": "^5.8.1",
     "@gatsby-contrib/gatsby-plugin-elasticlunr-search": "^2.2.1",
     "@mdx-js/mdx": "^0.16.6",

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.6.2",
+  "version": "6.6.3",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/utilities/_font-weight.scss
+++ b/packages/formation/sass/utilities/_font-weight.scss
@@ -7,5 +7,5 @@ Font weight
 }
 
 .vads-u-font-weight--normal {
-  font-weight: 300 !important;
+  font-weight: 400 !important;
 }


### PR DESCRIPTION
This will set the font-weight utility to be `400` instead of `300`. `300` is incorrect, and the but was not discovered most likely because of design.va.gov does not using the light version of Source Sans Pro, but VA.gov is using it.

Visible here: https://staging.va.gov/pittsburgh-health-care/health-services/