### PR TITLE
Add level prop to AlertBox

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "4.7.3",
+  "version": "4.7.0",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "4.6.3",
+  "version": "4.7.3",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/AlertBox/AlertBox.jsx
+++ b/packages/formation-react/src/components/AlertBox/AlertBox.jsx
@@ -73,6 +73,7 @@ class AlertBox extends React.Component {
   }
 }
 
+/* eslint-disable consistent-return */
 AlertBox.propTypes = {
   /**
    * Determines the color and icon of the alert box.
@@ -127,10 +128,20 @@ AlertBox.propTypes = {
   backgroundOnly: PropTypes.bool,
 
   /**
-   * The header level to use with the headline prop
+   * The header level to use with the headline prop, must be a number 1-6
    */
-  level: PropTypes.number,
+  level(props, propName) {
+    const level = parseInt(props[propName], 10);
+    if (Number.isNaN(level) || level < 1 || level > 6) {
+      return new Error(
+        `Invalid prop: AlertBox level must be a number from 1-6, was passed ${
+          props[propName]
+        }`,
+      );
+    }
+  },
 };
+/* eslint-enable consistent-return */
 
 AlertBox.defaultProps = {
   isVisible: true,

--- a/packages/formation-react/src/components/AlertBox/AlertBox.jsx
+++ b/packages/formation-react/src/components/AlertBox/AlertBox.jsx
@@ -54,6 +54,7 @@ class AlertBox extends React.Component {
 
     const alertHeading = this.props.headline;
     const alertText = this.props.content || this.props.children;
+    const H = `h${this.props.level}`;
 
     return (
       <div
@@ -63,9 +64,7 @@ class AlertBox extends React.Component {
         }}
       >
         <div className="usa-alert-body">
-          {alertHeading && (
-            <h3 className="usa-alert-heading">{alertHeading}</h3>
-          )}
+          {alertHeading && <H className="usa-alert-heading">{alertHeading}</H>}
           {alertText && <div className="usa-alert-text">{alertText}</div>}
         </div>
         {closeButton}
@@ -126,12 +125,18 @@ AlertBox.propTypes = {
    * accented left edge or an icon
    */
   backgroundOnly: PropTypes.bool,
+
+  /**
+   * The header level to use with the headline prop
+   */
+  level: PropTypes.number,
 };
 
 AlertBox.defaultProps = {
   isVisible: true,
   backgroundOnly: false,
   closeBtnAriaLabel: 'Close notification',
+  level: 3,
 };
 
 export default AlertBox;

--- a/packages/formation-react/src/components/AlertBox/AlertBox.unit.spec.jsx
+++ b/packages/formation-react/src/components/AlertBox/AlertBox.unit.spec.jsx
@@ -58,7 +58,7 @@ describe('<AlertBox />', () => {
       <AlertBox
         content={Content}
         status="info"
-        level="4"
+        level={4}
         headline="Testing"
         isVisible
         className="foo"

--- a/packages/formation-react/src/components/AlertBox/AlertBox.unit.spec.jsx
+++ b/packages/formation-react/src/components/AlertBox/AlertBox.unit.spec.jsx
@@ -53,6 +53,21 @@ describe('<AlertBox />', () => {
     wrapper.unmount();
   });
 
+  it('should use level prop for headline element', () => {
+    const wrapper = shallow(
+      <AlertBox
+        content={Content}
+        status="info"
+        level="4"
+        headline="Testing"
+        isVisible
+        className="foo"
+      />,
+    );
+    expect(wrapper.find('.usa-alert-heading').is('h4')).to.equal(true);
+    wrapper.unmount();
+  });
+
   it('should pass aXe check when visible', () =>
     axeCheck(<AlertBox content={Content} status="info" isVisible />));
 


### PR DESCRIPTION
## Description
This adds a level prop to the alert box, so that you can control the heading level directly and avoid axe errors related to skipping heading levels in an html page (e.g. following an `h1` with an `h3`, instead of an `h2`).

## Testing done
Unit testing

## Acceptance criteria
- [x] Component markup includes a `h` element that uses the level prop

## Definition of done
- [x] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
