### PR TITLE
Bump version for level prop change

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",


### PR DESCRIPTION
## Description
Accidentally chose an already existing version for the previous AlertBox change

## Definition of done
- [x] Changes have been tested in vets-website
- [x] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
