### PR TITLE
Allow use of `data-multiselectable` in addition to incorrect aria attribute

### DIFF
--- a/packages/formation/__tests__/js/accordion/accordion.test.js
+++ b/packages/formation/__tests__/js/accordion/accordion.test.js
@@ -241,6 +241,27 @@ describe('accordion', () => {
     );
   });
 
+  it('should show both dropdown if data-multiselectable is true', () => {
+    document
+      .querySelector('.usa-accordion')
+      .setAttribute('data-multiselectable', true);
+
+    const a3BtnEl = document.querySelector('[aria-controls="a3"]');
+    const a4BtnEl = document.querySelector('[aria-controls="a4"]');
+
+    a3BtnEl.click();
+    a4BtnEl.click();
+
+    expect(a3BtnEl.getAttribute('aria-expanded')).toEqual('true');
+    expect(a4BtnEl.getAttribute('aria-expanded')).toEqual('true');
+    expect(document.getElementById('a3').getAttribute('aria-hidden')).toEqual(
+      'false',
+    );
+    expect(document.getElementById('a4').getAttribute('aria-hidden')).toEqual(
+      'false',
+    );
+  });
+
   it('.usa-accordion-bordered should show both dropdown if aria-multiselectable is true', () => {
     document
       .querySelector('.usa-accordion-bordered')

--- a/packages/formation/__tests__/js/accordion/accordion.test.js
+++ b/packages/formation/__tests__/js/accordion/accordion.test.js
@@ -220,27 +220,6 @@ describe('accordion', () => {
     );
   });
 
-  it('should show both dropdown if aria-multiselectable is true', () => {
-    document
-      .querySelector('.usa-accordion')
-      .setAttribute('aria-multiselectable', true);
-
-    const a3BtnEl = document.querySelector('[aria-controls="a3"]');
-    const a4BtnEl = document.querySelector('[aria-controls="a4"]');
-
-    a3BtnEl.click();
-    a4BtnEl.click();
-
-    expect(a3BtnEl.getAttribute('aria-expanded')).toEqual('true');
-    expect(a4BtnEl.getAttribute('aria-expanded')).toEqual('true');
-    expect(document.getElementById('a3').getAttribute('aria-hidden')).toEqual(
-      'false',
-    );
-    expect(document.getElementById('a4').getAttribute('aria-hidden')).toEqual(
-      'false',
-    );
-  });
-
   it('should show both dropdown if data-multiselectable is true', () => {
     document
       .querySelector('.usa-accordion')
@@ -262,10 +241,10 @@ describe('accordion', () => {
     );
   });
 
-  it('.usa-accordion-bordered should show both dropdown if aria-multiselectable is true', () => {
+  it('.usa-accordion-bordered should show both dropdown if data-multiselectable is true', () => {
     document
       .querySelector('.usa-accordion-bordered')
-      .setAttribute('aria-multiselectable', true);
+      .setAttribute('data-multiselectable', true);
 
     const a3BtnEl = document.querySelector('[aria-controls="b-a3"]');
     const a4BtnEl = document.querySelector('[aria-controls="b-a4"]');

--- a/packages/formation/js/accordion.js
+++ b/packages/formation/js/accordion.js
@@ -84,7 +84,6 @@ const addAccordionClickHandler = () => {
         // Specifically React Components.
         if (accordionButton && !accordionButton.onclick) {
           const multiSelectable =
-            // Don't use aria-multiselectable, it's not a valid use of that attribute
             toBoolean(element.getAttribute('aria-multiselectable')) ||
             toBoolean(element.getAttribute('data-multiselectable'));
 
@@ -130,6 +129,18 @@ const addAccordionClickHandler = () => {
       });
     }
   });
+
+  // Don't use aria-multiselectable, it's not a valid use of that attribute
+  if (
+    document.querySelectorAll(
+      '.usa-accordion[aria-multiselectable], .usa-accordion-bordered[aria-multiselectable]',
+    ).length
+  ) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'Accordion elements are not a valid context for aria-multiselectable, use data-multiselectable instead',
+    );
+  }
 };
 
 const loadAccordionHandler = () => {

--- a/packages/formation/js/accordion.js
+++ b/packages/formation/js/accordion.js
@@ -83,9 +83,10 @@ const addAccordionClickHandler = () => {
         // and if it is a .usa-accordion-button.
         // Specifically React Components.
         if (accordionButton && !accordionButton.onclick) {
-          const multiSelectable = toBoolean(
-            element.getAttribute('aria-multiselectable'),
-          );
+          const multiSelectable =
+            // Don't use aria-multiselectable, it's not a valid use of that attribute
+            toBoolean(element.getAttribute('aria-multiselectable')) ||
+            toBoolean(element.getAttribute('data-multiselectable'));
 
           const hasAriaControlsAttr = accordionButton.getAttribute(
             'aria-controls',

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.6.4",
+  "version": "6.7.0",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.6.3",
+  "version": "6.6.4",
   "description": "The VA design system",
   "keywords": [
     "va",


### PR DESCRIPTION
## Description
Currently you can make accordions multiselectable by using `aria-multiselectable` on the main element. This is invalid aria markup that aXe throws errors on. This PR adds another attribute to trigger the same behavior that won't cause accessibility issues.

## Testing done
Testing in vets-website

## Screenshots


## Acceptance criteria
- [x] Accordions work with `data-multiselectable` attribute

## Definition of done
- [x] Changes have been tested in vets-website
- [x] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
