### PR TITLE
Add disabled state for buttons that are styled as links

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.7.0",
+  "version": "6.7.1",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/base/_b-mixins.scss
+++ b/packages/formation/sass/base/_b-mixins.scss
@@ -154,7 +154,7 @@
   }
   &:disabled {
     text-decoration: none;
-    color: $color-gray !important;
+    color: $color-gray-light !important;
   }
 }
 

--- a/packages/formation/sass/base/_b-mixins.scss
+++ b/packages/formation/sass/base/_b-mixins.scss
@@ -152,6 +152,10 @@
     @include focus-gold-light-outline;
     outline-offset: 0;
   }
+  &:disabled {
+    text-decoration: none;
+    color: $color-gray !important;
+  }
 }
 
 @mixin modal-close-button {


### PR DESCRIPTION
## Description
This came up while working on disabled button-links on the disability calculator, mentioned in this [ticket](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19143).

Buttons that are styled to look like links should be gray when disabled.

## Testing done
I tested this on the [disability calculator](https://staging.va.gov/disability/about-disability-ratings-beta/).

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/61073680-f1bb5300-a3e3-11e9-9b86-2096d6c3ad91.png)


## Acceptance criteria
- [ ] Disabled button-links are styled correctly

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
