### PR TITLE
16156 - Add optional ariaLabelledBy prop to ErrorableCheckbox.

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "4.8.1",
+  "version": "4.9.0",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",
@@ -33,7 +33,7 @@
     "react-transition-group": "1"
   },
   "peerDependencies": {
-    "@department-of-veterans-affairs/formation": "^5.4.0",
+    "@department-of-veterans-affairs/formation": "^6.7.0",
     "react": "^15.5.4||^16.7.0"
   }
 }

--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -33,7 +33,7 @@
     "react-transition-group": "1"
   },
   "peerDependencies": {
-    "@department-of-veterans-affairs/formation": "^6.7.0",
+    "@department-of-veterans-affairs/formation": "^6.7.1",
     "react": "^15.5.4||^16.7.0"
   }
 }

--- a/packages/formation-react/src/components/ErrorableCheckbox/ErrorableCheckbox.jsx
+++ b/packages/formation-react/src/components/ErrorableCheckbox/ErrorableCheckbox.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import _ from 'lodash';
+import { isUndefined, uniqueId } from 'lodash';
 
 class ErrorableCheckbox extends React.Component {
   constructor() {
@@ -9,7 +9,7 @@ class ErrorableCheckbox extends React.Component {
   }
 
   UNSAFE_componentWillMount() {
-    this.inputId = _.uniqueId('errorable-checkbox-');
+    this.inputId = uniqueId('errorable-checkbox-');
   }
 
   handleChange(domEvent) {
@@ -39,7 +39,7 @@ class ErrorableCheckbox extends React.Component {
     let className = `form-checkbox${
       this.props.errorMessage ? ' usa-input-error' : ''
     }`;
-    if (!_.isUndefined(this.props.className)) {
+    if (!isUndefined(this.props.className)) {
       className = `${className} ${this.props.className}`;
     }
 
@@ -89,27 +89,56 @@ ErrorableCheckbox.propTypes = {
    */
   name: PropTypes.string,
   /**
-   * Label for the checkbox.
+   * Label [string or object] for the checkbox. Either this or ariaLabelledBy is required.
    * IF you have a SEPARATE HEADING (outside this component) that “labels” this
-   * checkbox, do NOT pass {<span class="usa-sr-only">...</span>} here to just
-   * visually hide this label.
-   * Instead, pass an empty string ("") here, and pass that external heading‘s
-   * ID to ariaLabelledBy prop.
+   * checkbox, use ariaLabelledBy instead of this.
    * Screen-readers read sr-only content, which would be redundant if you had a
    * separate, external heading also serving as this component‘s “label.”
    * E.g., see /src/applications/personalization/preferences/components/PreferenceOption.jsx
    */
-  label: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
+  /* eslint-disable consistent-return */
+  label: (props, propName, componentName) => {
+    const validTypes = ['string', 'object'];
+
+    if (!props.label && !props.ariaLabelledBy) {
+      return new Error(
+        `Either ${propName} or ariaLabelledBy property is required in ${componentName}, but both are missing.`,
+      );
+    }
+
+    if (props.label && !validTypes.includes(typeof props.label)) {
+      return new Error(
+        `${componentName}’s label property type is invalid -- should be one of
+        these types: ${validTypes.join(', ')}.`,
+      );
+    }
+  },
+  /* eslint-enable consistent-return */
   /**
    * Descriptive text to sit above the checkbox and label
    */
   labelAboveCheckbox: PropTypes.string,
   /**
-   * aria-labelledby attribute value (external heading ID).
-   * If you have a SEPARATE HEADING (outside this component) that “labels” this
-   * checkbox, pass that heading‘s ID value here (without '#'), and pass empty-string to label prop above.
+   * aria-labelledby attribute [string] (external-heading ID). Either this or label is required.
+   * IF you have a SEPARATE HEADING (outside this component) that “labels” this
+   * checkbox, pass that heading‘s ID value here, instead of using label.
    */
-  ariaLabelledBy: PropTypes.string,
+  /* eslint-disable consistent-return */
+  ariaLabelledBy: (props, propName, componentName) => {
+    if (!props.label && !props.ariaLabelledBy) {
+      return new Error(
+        `Either ${propName} or label property is required in ${componentName}, but both are missing.`,
+      );
+    }
+
+    if (props.ariaLabelledBy && typeof props.ariaLabelledBy !== 'string') {
+      return new Error(
+        `${componentName}’s ariaLabelledBy property type is invalid -- should be
+        string.`,
+      );
+    }
+  },
+  /* eslint-enable consistent-return */
   /**
    * Handler for when the checkbox is changed
    */

--- a/packages/formation-react/src/components/ErrorableCheckbox/ErrorableCheckbox.jsx
+++ b/packages/formation-react/src/components/ErrorableCheckbox/ErrorableCheckbox.jsx
@@ -51,6 +51,7 @@ class ErrorableCheckbox extends React.Component {
           </span>
         )}
         <input
+          aria-labelledby={this.props.ariaLabelledBy}
           aria-describedby={errorSpanId}
           checked={this.props.checked}
           id={this.inputId}
@@ -88,13 +89,27 @@ ErrorableCheckbox.propTypes = {
    */
   name: PropTypes.string,
   /**
-   * Label for the checkbox
+   * Label for the checkbox.
+   * IF you have a SEPARATE HEADING (outside this component) that “labels” this
+   * checkbox, do NOT pass {<span class="usa-sr-only">...</span>} here to just
+   * visually hide this label.
+   * Instead, pass an empty string ("") here, and pass that external heading‘s
+   * ID to ariaLabelledBy prop.
+   * Screen-readers read sr-only content, which would be redundant if you had a
+   * separate, external heading also serving as this component‘s “label.”
+   * E.g., see /src/applications/personalization/preferences/components/PreferenceOption.jsx
    */
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
   /**
    * Descriptive text to sit above the checkbox and label
    */
   labelAboveCheckbox: PropTypes.string,
+  /**
+   * aria-labelledby attribute value (external heading ID).
+   * If you have a SEPARATE HEADING (outside this component) that “labels” this
+   * checkbox, pass that heading‘s ID value here (without '#'), and pass empty-string to label prop above.
+   */
+  ariaLabelledBy: PropTypes.string,
   /**
    * Handler for when the checkbox is changed
    */

--- a/packages/formation-react/src/components/ErrorableCheckbox/ErrorableCheckbox.jsx
+++ b/packages/formation-react/src/components/ErrorableCheckbox/ErrorableCheckbox.jsx
@@ -90,11 +90,6 @@ ErrorableCheckbox.propTypes = {
   name: PropTypes.string,
   /**
    * Label [string or object] for the checkbox. Either this or ariaLabelledBy is required.
-   * IF you have a SEPARATE HEADING (outside this component) that “labels” this
-   * checkbox, use ariaLabelledBy instead of this.
-   * Screen-readers read sr-only content, which would be redundant if you had a
-   * separate, external heading also serving as this component‘s “label.”
-   * E.g., see /src/applications/personalization/preferences/components/PreferenceOption.jsx
    */
   /* eslint-disable consistent-return */
   label: (props, propName, componentName) => {
@@ -120,8 +115,6 @@ ErrorableCheckbox.propTypes = {
   labelAboveCheckbox: PropTypes.string,
   /**
    * aria-labelledby attribute [string] (external-heading ID). Either this or label is required.
-   * IF you have a SEPARATE HEADING (outside this component) that “labels” this
-   * checkbox, pass that heading‘s ID value here, instead of using label.
    */
   /* eslint-disable consistent-return */
   ariaLabelledBy: (props, propName, componentName) => {

--- a/packages/formation-react/src/components/ErrorableCheckbox/ErrorableCheckbox.mdx
+++ b/packages/formation-react/src/components/ErrorableCheckbox/ErrorableCheckbox.mdx
@@ -28,6 +28,17 @@ import ErrorableCheckbox from '@department-of-veterans-affairs/formation-react/E
     required={true}
     title='ErrorableCheckbox'
   />
+  <h4 id="checkboxTitle">External heading [label-substitute]</h4>
+  <ErrorableCheckbox
+    label=""
+    ariaLabelledBy="checkboxTitle"
+    labelAboveCheckbox="If a separate heading (like above) “labels” the checkbox, we do not want screen-readers to read both the heading and the checkbox’s own label.  In this case, an aria-labelledby attribute substitutes for the checkbox’s own label text, and references the external heading above."
+    onValueChange={(value) => value}
+    id='default'
+    errorMessage=''
+    required={true}
+    title='ErrorableCheckbox'
+  />
 </div>
 ```
 
@@ -47,6 +58,17 @@ import ErrorableCheckbox from '@department-of-veterans-affairs/formation-react/E
     onValueChange={(value) => value}
     id='default'
     errorMessage='Error message'
+    required={true}
+    title='ErrorableCheckbox'
+  />
+  <h4 id="checkboxTitle">External heading [label-substitute]</h4>
+  <ErrorableCheckbox
+    label=""
+    ariaLabelledBy="checkboxTitle"
+    labelAboveCheckbox="If a separate heading (like above) “labels” the checkbox, we do not want screen-readers to read both the heading and the checkbox’s own label.  In this case, an aria-labelledby attribute substitutes for the checkbox’s own label text, and references the external heading above."
+    onValueChange={(value) => value}
+    id='default'
+    errorMessage=''
     required={true}
     title='ErrorableCheckbox'
   />

--- a/packages/formation-react/src/components/ErrorableCheckbox/ErrorableCheckbox.mdx
+++ b/packages/formation-react/src/components/ErrorableCheckbox/ErrorableCheckbox.mdx
@@ -30,7 +30,6 @@ import ErrorableCheckbox from '@department-of-veterans-affairs/formation-react/E
   />
   <h4 id="checkboxTitle">External heading [label-substitute]</h4>
   <ErrorableCheckbox
-    label=""
     ariaLabelledBy="checkboxTitle"
     labelAboveCheckbox="If a separate heading (like above) “labels” the checkbox, we do not want screen-readers to read both the heading and the checkbox’s own label.  In this case, an aria-labelledby attribute substitutes for the checkbox’s own label text, and references the external heading above."
     onValueChange={(value) => value}
@@ -63,7 +62,6 @@ import ErrorableCheckbox from '@department-of-veterans-affairs/formation-react/E
   />
   <h4 id="checkboxTitle">External heading [label-substitute]</h4>
   <ErrorableCheckbox
-    label=""
     ariaLabelledBy="checkboxTitle"
     labelAboveCheckbox="If a separate heading (like above) “labels” the checkbox, we do not want screen-readers to read both the heading and the checkbox’s own label.  In this case, an aria-labelledby attribute substitutes for the checkbox’s own label text, and references the external heading above."
     onValueChange={(value) => value}

--- a/packages/formation-react/src/components/ErrorableCheckbox/ErrorableCheckbox.unit.spec.jsx
+++ b/packages/formation-react/src/components/ErrorableCheckbox/ErrorableCheckbox.unit.spec.jsx
@@ -143,7 +143,6 @@ describe('<ErrorableCheckbox/>', () => {
   it('adds aria-labelledby attribute', () => {
     const tree = shallow(
       <ErrorableCheckbox
-        label=""
         ariaLabelledBy="headingId"
         onValueChange={_update => {}}
       />,

--- a/packages/formation-react/src/components/ErrorableCheckbox/ErrorableCheckbox.unit.spec.jsx
+++ b/packages/formation-react/src/components/ErrorableCheckbox/ErrorableCheckbox.unit.spec.jsx
@@ -139,4 +139,25 @@ describe('<ErrorableCheckbox/>', () => {
     expect(inputs.prop('id')).to.equal(labels.prop('htmlFor'));
     tree.unmount();
   });
+
+  it('adds optional aria-labelledby attribute', () => {
+    const tree = shallow(
+      <ErrorableCheckbox
+        label=""
+        ariaLabelledBy="headingId"
+        onValueChange={_update => {}}
+      />,
+    );
+
+    // Ensure label text is empty string.
+    const labels = tree.find('label');
+    expect(labels).to.have.lengthOf(1);
+    expect(labels.text()).to.equal('');
+
+    // Ensure label aria-labelledby is attached to input id.
+    const inputs = tree.find('input');
+    expect(inputs).to.have.lengthOf(1);
+    expect(inputs.prop('aria-labelledby')).to.equal('headingId');
+    tree.unmount();
+  });
 });

--- a/packages/formation-react/src/components/ErrorableCheckbox/ErrorableCheckbox.unit.spec.jsx
+++ b/packages/formation-react/src/components/ErrorableCheckbox/ErrorableCheckbox.unit.spec.jsx
@@ -140,7 +140,7 @@ describe('<ErrorableCheckbox/>', () => {
     tree.unmount();
   });
 
-  it('adds optional aria-labelledby attribute', () => {
+  it('adds aria-labelledby attribute', () => {
     const tree = shallow(
       <ErrorableCheckbox
         label=""


### PR DESCRIPTION
## Description
[16156](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/16156) - Add optional screen-reader support to read an external-heading instead of checkbox-label.

formation-react version bumped to 4.9.0 [minor update].

## Testing done
New unit-test added; All still passing (now 184 tests).

## Acceptance criteria
- [ ] Via Gatsby docs dev-server, bottom checkbox on page http://localhost:8000/visual-design/components/errorablecheckbox/ reads the external-heading above it.

## Definition of done
- [x] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
