### PR TITLE
[MegaMenu] Make the column title optional

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "4.9.2",
+  "version": "4.9.1",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "4.9.1",
+  "version": "4.9.2",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/MegaMenu/Column.jsx
+++ b/packages/formation-react/src/components/MegaMenu/Column.jsx
@@ -61,7 +61,11 @@ const Column = props => {
         keyName,
       )}${isPanelWhite(mobileMediaQuery, panelWhite)}`}
     >
-      <h3 id={`vetnav-${_.kebabCase(keyName)}-header`}>{data.title}</h3>
+      {data.title ? (
+        <h3 id={`vetnav-${_.kebabCase(keyName)}-header`}>{data.title}</h3>
+      ) : (
+        <span>&nbsp;</span>
+      )}
       <ul
         id={`vetnav-${_.kebabCase(keyName)}-col`}
         aria-labelledby={`vetnav-${_.kebabCase(keyName)}-header`}


### PR DESCRIPTION
## Description
The second column of the Records section of the MegaMenu should have an empty space instead of a title. So, this PR makes the title optional.

Ticket - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17695

## Testing done
Pointed local vets-website to MegaMenu of local design system

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/61236957-4d008480-a707-11e9-9a53-59ec39014129.png)


## Acceptance criteria
- [ ] Column heading is optional

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
