### PR TITLE
Updated lodash to resolve advisory 1065

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "4.9.1",
+  "version": "4.9.2",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.6",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "moment": "^2.23.0",
     "prop-types": "^15.6.2",
     "react-transition-group": "1"


### PR DESCRIPTION
## Description
We need to update lodash to version 4.17.12 or later to fix a [vulnerability](https://www.npmjs.com/advisories/1065).

Copy of original ticket
department-of-veterans-affairs/va.gov-team#589

Current ticket with summary of necessary changes
department-of-veterans-affairs/va.gov-team#841

## Testing done
Linked to local build of vets-website and ran unit and E2E tests.

## Acceptance criteria
- [x] Lodash needs to be updated to a version that does not have the security vulnerability identified by npm advisory 1065.

## Definition of done
- [x] Changes have been tested in vets-website
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs