### PR TITLE
19247 disability calculator analytics

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -33,7 +33,7 @@
     "react-transition-group": "1"
   },
   "peerDependencies": {
-    "@department-of-veterans-affairs/formation": "^6.7.2",
+    "@department-of-veterans-affairs/formation": "^6.7.3",
     "react": "^15.5.4||^16.7.0"
   }
 }

--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -33,7 +33,7 @@
     "react-transition-group": "1"
   },
   "peerDependencies": {
-    "@department-of-veterans-affairs/formation": "^6.7.1",
+    "@department-of-veterans-affairs/formation": "^6.7.2",
     "react": "^15.5.4||^16.7.0"
   }
 }

--- a/packages/formation/js/accordion.js
+++ b/packages/formation/js/accordion.js
@@ -124,6 +124,23 @@ const addAccordionClickHandler = () => {
             if (!isElementInViewport(accordionButton)) {
               element.scrollIntoView();
             }
+
+            // Fire event for subscription by any consuming apps that need to
+            // handle click further (e.g., for analytics).
+            const accordionClickEvent = new CustomEvent(
+              '@department-of-veterans-affairs/formation/accordion/button-clicked',
+              {
+                bubbles: true,
+                cancelable: true,
+                detail: {
+                  toggle:
+                    accordionButton.getAttribute('aria-expanded') === 'true'
+                      ? 'expand'
+                      : 'collapse',
+                },
+              },
+            );
+            accordionButton.dispatchEvent(accordionClickEvent);
           }
         }
       });

--- a/packages/formation/js/accordion.js
+++ b/packages/formation/js/accordion.js
@@ -127,6 +127,7 @@ const addAccordionClickHandler = () => {
 
             // Fire event for subscription by any consuming apps that need to
             // handle click further (e.g., for analytics).
+            // Cannot use new customEvent() method due to IE11 support.
             const accordionClickEvent = document.createEvent('Event');
             accordionClickEvent.initEvent(
               '@department-of-veterans-affairs/formation/accordion/button-clicked',

--- a/packages/formation/js/accordion.js
+++ b/packages/formation/js/accordion.js
@@ -127,19 +127,18 @@ const addAccordionClickHandler = () => {
 
             // Fire event for subscription by any consuming apps that need to
             // handle click further (e.g., for analytics).
-            const accordionClickEvent = new CustomEvent(
+            const accordionClickEvent = document.createEvent('Event');
+            accordionClickEvent.initEvent(
               '@department-of-veterans-affairs/formation/accordion/button-clicked',
-              {
-                bubbles: true,
-                cancelable: true,
-                detail: {
-                  toggle:
-                    accordionButton.getAttribute('aria-expanded') === 'true'
-                      ? 'expand'
-                      : 'collapse',
-                },
-              },
+              true,
+              true,
             );
+            accordionClickEvent.detail = {
+              toggle:
+                accordionButton.getAttribute('aria-expanded') === 'true'
+                  ? 'expand'
+                  : 'collapse',
+            };
             accordionButton.dispatchEvent(accordionClickEvent);
           }
         }

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.7.2",
+  "version": "6.7.3",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.7.1",
+  "version": "6.7.2",
   "description": "The VA design system",
   "keywords": [
     "va",


### PR DESCRIPTION
## Description
Add custom click event to formation’s accordion-wrapper, to support [19247](/department-of-veterans-affairs/vets.gov-team/issues/19247)’s analytics requirements.

An upcoming static-page update for Disability Ratings has Google Analytics events specified to fire on expand/collapse of the Combined ratings table accordions. See this [ticket comment](/department-of-veterans-affairs/vets.gov-team/issues/19247#issuecomment-520847648).

Insights Team has since decided to capture accordion expand/collapse analytics site-wide, not just for the Disability Ratings page.  See this [ticket comment](/department-of-veterans-affairs/vets.gov-team/issues/19247#issuecomment-521237700).

## Testing done
Using browser dev-tools, verified custom click-event pushed to Google Analytic’s window.dataLayer upon clicking any accordion widget-instance”s toggler.

## Acceptance criteria
- [ ]  An event named “@department-of-veterans-affairs/formation/accordion/button-clicked” should be pushed to windows.dataLayer, as seen in browser dev-tools.

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
