### PR TITLE
add doc on analytics

### DIFF
--- a/packages/documentation/src/pages/getting-started/common-tasks/analytics.mdx
+++ b/packages/documentation/src/pages/getting-started/common-tasks/analytics.mdx
@@ -1,0 +1,33 @@
+---
+title: Analytics
+tags: analytics, , google analytics, monitoring
+---
+
+# Analytics
+
+When creating a new page or new feature there might be a need to add analytics to
+capture events on page. In our code base you will find 2 files that relate to analytics.
+
+- /src/platform/startup/analytics-middleware.js
+- /src/platform/monitoring/record-event.js
+
+## analytics-middleware.js
+
+This file is a plugin for MetalSmith. This is where the google analytics is
+initialized. Events will get pushed to a `window.dataLayer` then evaluated then
+sent to our analytics service.
+
+## record-event.js
+
+This file is our utility functions for recording analytical events. You will
+want to use these functions for recording events on your page. The `recordEvent`
+function will take in an object with an event property like so.
+
+```javascript
+recordEvent({
+  event: 'your-event-name',
+})
+```
+
+The event name is determined by your analytics team, so please make sure you
+communicate with them to make sure you are using the correct event.

--- a/packages/documentation/src/sidebar.js
+++ b/packages/documentation/src/sidebar.js
@@ -70,6 +70,10 @@ module.exports = {
                   name: 'Content pages',
                   href: '/getting-started/common-tasks/new-page',
                 },
+                {
+                  name: 'Analytics',
+                  href: '/getting-started/common-tasks/analytics',
+                },
               ],
             },
             {


### PR DESCRIPTION
## Description
We need a document regarding adding analytics to our front end so that external developers can know what to do when adding analytics to their feature or page.

## Testing done
Local Test

## Screenshots
<img width="1226" alt="Screen Shot 2019-08-28 at 6 49 43 AM" src="https://user-images.githubusercontent.com/5377648/63861598-0afe6b80-c960-11e9-95da-236cf57dc7ac.png">


## Acceptance criteria
- [ ] The analytics page should be written correctly and located in the proper location in the site. 

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
