### PR TITLE
Issue-161: add breakpoint name to "border-bottom" classes

### DIFF
--- a/packages/formation/sass/utilities/_border.scss
+++ b/packages/formation/sass/utilities/_border.scss
@@ -47,7 +47,7 @@ $border_sizes: (
         border-right: #{$size} solid !important;
       }
 
-      .vads-u-border-bottom--#{$size} {
+      .#{$bp_name}\:vads-u-border-bottom--#{$size} {
         border-bottom: #{$size} solid !important;
       }
 


### PR DESCRIPTION
## Description
- adds breakpoint name to "border-bottom" classes

## Testing done
locally by pointing to local formation build in vets-website's package.json

1. used `medium-screen:vads-u-border-bottom--1px` on element I was attempting to add this to

## Screenshots
![formation-fixed-border-bottom-targets](https://user-images.githubusercontent.com/19178435/64072334-8f433e00-cc41-11e9-94e8-43d29570eaad.jpg)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
