### PR TITLE
Update the CMS feature flags documentation

### DIFF
--- a/packages/documentation/src/pages/platform/tools/feature-flags.mdx
+++ b/packages/documentation/src/pages/platform/tools/feature-flags.mdx
@@ -55,7 +55,7 @@ localhost: false
   - Making code that's easy to delete ensures that deprecated code is quickly removed once a feature is released.
 - Making features or applications available in production should done only as needed for testing with users.
 
-## Feature flags for Metalsmith code
+## CMS feature flags
 
 Va.gov creates some pages based on content from the VA's Drupal CMS. The CMS has its own content model, which can sometimes change. When those changes modify the existing structure of the content model, the queries and templates in vets-website that expect a different model may break. And because the CMS and vets-website are separate systems with different deployment processes, we can't push up changes in both systems simultaneously. In order to keep the two systems in sync, we need to be able to turn features on and off in vets-website depending on what environment we're in, and update that feature state whenever a cms deployment happens.
 
@@ -64,57 +64,16 @@ We've created some infrastructure to make this a little easier to do.
 
 ### Creating a flag and turning it on or off
 
-In src/site/utilities/featureFlags.js, you'll see a list of current flags and their state:
+When running a new vets-website build, the script will fetch all CMS feature flags from Drupal. This allows the flags to be controlled from within Drupal.
 
-```js
-// Edit this to add new flags
-const featureFlags = {
-  FEATURE1: 'feature1',
-};
+Before writing any code to use a new feature flag, it must first be created from within Drupal for all three environments. The feature flags can be found at https://dev.cms.va.gov/admin/config/system/feature_toggle for dev. Staging and production have similar pages.
 
-// Edit this to turn flags on or off
-const flagsByBuildtype = {
-  // localhost: [],
-  localhost: [featureFlags.FEATURE1],
-  // vagovdev: [flags.FEATURE1],
-  vagovdev: [],
-  // vagovstaging: [flags.FEATURE1],
-  vagovstaging: [],
-  // vagovprod: [flags.FEATURE1],
-  vagovprod: [],
-};
-```
+**Important:** The new feature flag _must_ be in _every_ Drupal environment or vets-website builds will fail when we try to use it! This is intentional so we don't have "accidentally" false feature flags when Drupal doesn't have a flag that vets-website is trying to use.
 
-In these two objects, you can create a new feature flag and set which web environments it is turned on in. Whenever you need to change what environment has a particular feature, you would add the flag to the array associate with that build type.
+### Using flags in GraphQL queries
+Because the flags are fetched dynamically, they aren't stored in a file that we can `require` from a GraphQL query file. The build script puts the current flags are put into `global.cmsFeatureFlags` after it either fetches the most recent flags or uses the cache.
 
-### Using flags in Node code
-
-There are a couple ways to use the flag in Node Javascript code. One way is to use the `applyFeatureFlags` helper in a file that you would like to create a feature flagged variant of:
-
-```js
-const someQuery = 'some query info';
-
-module.exports = someQuery;
-applyFeatureFlags(module);
-```
-
-This helper looks through all of the enabled feature flags and checks to see if there are files with the same name as the current file, but with a feature flag in the file path before the extension.
-
-So, for example, if your file is `healthCarePage.graphql.js` and there's a feature flag called `feature1`, the helper will look for `healthCarePage.graphql.feature1.js`. If `feature1` is turned on, then it will replace the exported module data with the export from the file with the `feature1` suffix.
-
-If you want to make a smaller conditional logic change than creating a whole new file, you can import the featureFlags file and check the flags directly:
-
-```js
-const { featureFlags, enabledFeatureFlags } = require('./src/site/utilities/featureFlags');
-
-...
-
-if (enabledFeatureFlags[featureFlags.FEATURE1]) {
-  // do something when the flag is on
-}
-```
-
-Keep in mind the advice in the [Writing good feature flags](#writing-good-feature-flags) section. You should write the logic in a way that is easy to remove later. It's often easier to change some logic and then add a conditional that modifies something with the flag is _not_ enabled. That lets you simply remove the conditional later.
+Keep in mind the advice in the [writing good feature flags](#writing-good-feature-flags) section. You should write the logic in a way that is easy to remove later. It's often easier to change some logic and then add a conditional that modifies something with the flag is not enabled. That lets you simply remove the conditional later.
 
 ### Using feature flags in Liquid templates
 
@@ -125,6 +84,8 @@ All liquid templates have access to the current feature flag state:
   <div>Fancy new feature</div>
 {% endif %}
 ```
+
+**Note:** From within the JavaScript context, the feature flags are in `global.cmsFeatureFlags`, but within the Liquid template context, they can be found in `enabledFeatureFlags`.
 
 ## Release Toggles 
 


### PR DESCRIPTION
## Description
The documentation was out of date. This brings it back up to date.

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] The documentation accurately reflects the current state of the CMS feature flags

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
