### PR TITLE
Remove megamenu "View all in" text

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "4.9.2",
+  "version": "4.9.3",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "4.9.3",
+  "version": "4.10.0",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/MegaMenu/SubMenu.jsx
+++ b/packages/formation-react/src/components/MegaMenu/SubMenu.jsx
@@ -55,7 +55,7 @@ const SubMenu = ({
               href={seeAllLink.href}
               onClick={linkClicked.bind(null, seeAllLink)}
             >
-              View all in {seeAllLink.text}
+              {seeAllLink.text}
               <ArrowRightBlueSVG />
             </a>
           </div>


### PR DESCRIPTION
## Description
Currently, the text "View all in" in the `seeAllLink` is hard-coded. This PR removes that hard-coded text so that it can be changed.

_Motivation:_ The header of va.gov will soon be generated by Drupal, and the links coming from Drupal will need to contain "View all in." Without this change, the text would be repeated: "View all in View all in."

There is also a PR to update the `vagov-content` repo so that the megamenu fragment contains "View all in," to match the future Drupal data: https://github.com/department-of-veterans-affairs/vagov-content/pull/555

## Testing done
- Updated code in this repo locally.
- Ran `yarn build`.
- Moved this code to local vets-website installation.
- Built vets-website with local Drupal data.
- Confirmed visually that "View all in ..." was present. (See screenshot below.)

## Screenshots
<img width="1073" alt="Screen Shot 2019-09-17 at 1 52 08 PM" src="https://user-images.githubusercontent.com/1181665/65069522-d4ad7e00-d958-11e9-80f3-23fb269398f3.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
