### PR TITLE
Fully enable shift-tabbing in Modal components

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "4.10.0",
+  "version": "4.10.1",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",


### PR DESCRIPTION
## Description
Previously shift-tab only worked until focus reached the first
focusable element in the modal. Hitting shift-tab when focus was on the
first element in the modal resulted in effectively a no-op as focus was
programmatically set to the first focusable element. With this change a
shift-tab while the first element on the modal has focus will move focus
to the _last_ element in the modal, as you would expect.

## Testing done
Local in vets-website

## Screenshots
**GIF showing ability to tab forwards and backwards within the modal correctly**
![modal-shift-tab](https://user-images.githubusercontent.com/20728956/65449395-c72c4400-ddef-11e9-9af7-9f7853733402.gif)


## Acceptance criteria
- [ ]

## Definition of done
- [x] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs