### PR TITLE
[PromoBanner] Add support for links to open in a new tab

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "4.10.2",
+  "version": "4.10.3",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/PromoBanner/PromoBanner.jsx
+++ b/packages/formation-react/src/components/PromoBanner/PromoBanner.jsx
@@ -14,7 +14,7 @@ const PROMO_BANNER_ICONS = new Map([
   [PROMO_BANNER_TYPES.emailSignup, 'fa-envelope'],
 ]);
 
-function PromoBanner({ type, onClose, render, href, text }) {
+function PromoBanner({ type, onClose, render, href, target, text }) {
   const iconClasses = classnames(
     'fas',
     'fa-stack-1x',
@@ -38,6 +38,7 @@ function PromoBanner({ type, onClose, render, href, text }) {
             <a
               className="vads-c-promo-banner__content-link"
               href={href}
+              target={target}
               onClick={onClose}
             >
               {text} <i className="fas fa-angle-right" />
@@ -65,6 +66,7 @@ PromoBanner.propTypes = {
   onClose: PropTypes.func.isRequired,
   render: PropTypes.func,
   href: PropTypes.string,
+  target: PropTypes.string,
   text: PropTypes.string,
 };
 


### PR DESCRIPTION
## Description
The Proclamation PromoBanner on the website now (use Incognito tab if you cleared it already) opens a PDF file in the same tab, which is not ideal. We need a new prop to open it in a new tab.

Ticket - https://github.com/department-of-veterans-affairs/va.gov-team/issues/3212

## Testing done
Tested locally

## Screenshots
N/A

## Acceptance criteria
- [ ] Support added for promo links to open in a new tab

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
