### PR TITLE
Add docs for 'ui:reviewField'

### DIFF
--- a/packages/documentation/src/pages/forms/about-the-schema-and-uischema-objects.mdx
+++ b/packages/documentation/src/pages/forms/about-the-schema-and-uischema-objects.mdx
@@ -137,6 +137,20 @@ The VAFS code includes additional `uiSchema` functionality not found in the RJSF
   // component. Can also be used with regular widgets.
   'ui:reviewWidget': WidgetComponent,
 
+  // Renders a custom review field on the review page. Only used when you specify a widget
+  // component. The `children` parameter is a component from the `'ui:reviewWidget'`, but
+  // is only rendered by this custom reviewField if the schema for it is not an `object`
+  // or `array`
+  'ui:reviewField': ({ children, schema, uiSchema }) => (
+    <dl className="review-row">
+      <dt>
+        {uiSchema['ui:title']}
+        {uiSchema['ui:description]}
+      </dt>
+      <dd>{children}</dd>
+    </dl>
+  ),
+
   // Provides a function to make a field conditionally required. The data in the whole form,
   // with no page breaks, is the only parameter. Don't make a field required in the JSON
   // schema and in addition to using `ui:required` on that field. The index argument is

--- a/packages/documentation/src/pages/forms/available-features-and-usage-guidelines.mdx
+++ b/packages/documentation/src/pages/forms/available-features-and-usage-guidelines.mdx
@@ -410,6 +410,7 @@ The review page renders the form data in review mode automatically. However, you
 
 This property is nested directly under `uiSchema`:
 - `'ui:reviewWidget'`: takes a widget component to render on the review page for that field. Default review widgets are automatically rendered, so only use this if you need to customize the review widget that is used.
+- `'ui:reviewField'`: allows a custom review component to be built for each field on the review page. It is given the result of the `'ui:reviewWidget'` within the `children` parameter, so this value must be rendered within the custom function.
 
 These properties are nested under `uiSchema: { 'ui:options': {} }`:
 - `hideOnReview`: Hides the field on the review page; takes a `boolean`


### PR DESCRIPTION
## Description

Only adding documentation for the new `'ui:reviewField'` uiSchema entry I added in https://github.com/department-of-veterans-affairs/vets-website/pull/11120

## Testing done

Ran test & lint

## Acceptance criteria
- [ ] Documentation added for custom reviewField entry.

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
