### PR TITLE
Refactor a bit and change onSort prop to onHeaderClick for accuracy

### DIFF
--- a/packages/formation-react/src/components/SortableTable/SortableTable.jsx
+++ b/packages/formation-react/src/components/SortableTable/SortableTable.jsx
@@ -58,7 +58,7 @@ class SortableTable extends Component {
     this.props.onHeaderClick(value, order);
   }
 
-  makeHeader = (field) => {
+  renderHeader = (field) => {
     if (field.nonSortable) {
       return <th key={field.value}>{field.label}</th>;
     }
@@ -97,7 +97,7 @@ class SortableTable extends Component {
     );
   }
 
-  makeRow(item) {
+  renderRow = (item) => {
     return (
       <tr key={item.id} className={item.rowClass}>
         {this.props.fields.map(field => (
@@ -108,8 +108,8 @@ class SortableTable extends Component {
   }
 
   render() {
-    const headers = this.props.fields.map(this.makeHeader);
-    const rows = this.props.data.map(this.makeRow);
+    const headers = this.props.fields.map(this.renderHeader);
+    const rows = this.props.data.map(this.renderRow);
     const tableClass = classNames('va-sortable-table', this.props.className);
 
     return (

--- a/packages/formation-react/src/components/SortableTable/SortableTable.jsx
+++ b/packages/formation-react/src/components/SortableTable/SortableTable.jsx
@@ -38,16 +38,10 @@ class SortableTable extends Component {
       }),
     ).isRequired,
 
-    // DEPRECATING: A callback for when a header is clicked.
-    onSort: PropTypes.func,
     // A callback for when a header is clicked.
     onHeaderClick: PropTypes.func,
-
-    /**
-     * Each object represents data for a row.
-     * An optional class may be provided to style specific rows.
-     */
-    renderCell: PropTypes.func,
+    // DEPRECATING in favor of onHeaderClick: A callback for when a header is clicked.
+    onSort: PropTypes.func,
   };
 
   onHeaderClick = (value, order) => () => {

--- a/packages/formation-react/src/components/SortableTable/SortableTable.jsx
+++ b/packages/formation-react/src/components/SortableTable/SortableTable.jsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 
 class SortableTable extends Component {
   static propTypes = {
+    // Used to pass custom classes.
     className: PropTypes.string,
 
     /**
@@ -15,15 +16,14 @@ class SortableTable extends Component {
       order: PropTypes.oneOf(['ASC', 'DESC']),
     }).isRequired,
 
-    /**
-     * Mappings of header labels to properties on the objects in `data`.
-     */
+    // Mappings of header labels to properties on the objects in `data`.
     fields: PropTypes.arrayOf(
       PropTypes.shape({
         label: PropTypes.string.isRequired,
         value: PropTypes.string.isRequired,
       }),
     ).isRequired,
+
     /**
      * Each object represents data for a row.
      * An optional class may be provided to style specific rows.
@@ -40,6 +40,7 @@ class SortableTable extends Component {
 
     // A callback for when a header is clicked.
     onHeaderClick: PropTypes.func,
+
     // DEPRECATING in favor of onHeaderClick: A callback for when a header is clicked.
     onSort: PropTypes.func,
   };

--- a/packages/formation-react/src/components/SortableTable/SortableTable.jsx
+++ b/packages/formation-react/src/components/SortableTable/SortableTable.jsx
@@ -55,7 +55,7 @@ class SortableTable extends Component {
 
     // This is a legacy prop that is being renamed to `onHeaderClick`.
     if (onSort) {
-      console.warn('WARNING: `onSort` is being deprecated in favor of `onHeaderClick` for <SortableTable />.');
+      console.warn('WARNING: The `onSort` prop is being deprecated in favor of the `onHeaderClick` prop for <SortableTable />.');
       onSort(value, order);
     }
 


### PR DESCRIPTION
## Description
This PR includes some backwards-compatible refactoring for the `<SortableTable />` component. I

It also introduces a deprecation warning when the prop called `onSort` is used, which is called whenever a header is clicked (it doesn't actually do any sorting). This prop is **not currently used in [vets-website](https://github.com/department-of-veterans-affairs/vets-website).

It also introduces a new prop called `onHeaderClick`, which is a more accurate name for the `onSort` prop and the intent is that this prop will replace `onSort` long-term.

## Testing done
Unit tests.

## Screenshots
N/A

## Acceptance criteria
- [x] Add deprecation warning for the `onSort` prop.
- [x] Add `onHeaderClick` prop to replace `onSort` eventually.

## Definition of done
- [x] Changes have been tested in vets-website
- [x] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
