### PR TITLE
Kelsonic 3725 update sortabletable

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "4.10.3",
+  "version": "5.0.0",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/SortableTable/SortableTable.jsx
+++ b/packages/formation-react/src/components/SortableTable/SortableTable.jsx
@@ -58,7 +58,7 @@ class SortableTable extends Component {
     this.props.onHeaderClick(value, order);
   }
 
-  makeHeader = (field) => {
+  renderHeader = (field) => {
     if (field.nonSortable) {
       return <th key={field.value}>{field.label}</th>;
     }
@@ -97,7 +97,7 @@ class SortableTable extends Component {
     );
   }
 
-  makeRow(item) {
+  renderRow = (item) => {
     return (
       <tr key={item.id} className={item.rowClass}>
         {this.props.fields.map(field => (
@@ -108,8 +108,8 @@ class SortableTable extends Component {
   }
 
   render() {
-    const headers = this.props.fields.map(this.makeHeader);
-    const rows = this.props.data.map(this.makeRow);
+    const headers = this.props.fields.map(this.renderHeader);
+    const rows = this.props.data.map(this.renderRow);
     const tableClass = classNames('va-sortable-table', this.props.className);
 
     return (

--- a/packages/formation-react/src/components/SortableTable/SortableTable.jsx
+++ b/packages/formation-react/src/components/SortableTable/SortableTable.jsx
@@ -56,13 +56,10 @@ class SortableTable extends Component {
       onSort(value, order);
     }
 
-    // Escape early if no `onHeaderClick` prop is provided.
-    if (!onHeaderClick) {
-      return;
-    }
-
     // This replaces `this.props.onSort`.
-    onHeaderClick(value, order);
+    if (onHeaderClick) {
+      onHeaderClick(value, order);
+    }
   }
 
   renderHeader = (field) => {
@@ -104,27 +101,14 @@ class SortableTable extends Component {
     );
   }
 
-  renderCell = (item, field) => {
-    const renderCustomCell = get(item, 'renderCustomCell');
-
-    // If the item has a `renderCustomCell` property, execute it.
-    if (renderCustomCell) {
-      return renderCustomCell(field);
-    }
-
-    // Otherwise, return the field value in the item.
-    return item[field.value];
-  }
-
   renderRow = (item) => {
-    const { renderCell } = this;
     const { fields } = this.props;
 
     return (
       <tr key={item.id} className={item.rowClass}>
         {fields.map(field => (
           <td key={`${item.id}-${field.value}`}>
-            {renderCell(item, field)}
+            {item[field.value]}
           </td>
         ))}
       </tr>

--- a/packages/formation-react/src/components/SortableTable/SortableTable.jsx
+++ b/packages/formation-react/src/components/SortableTable/SortableTable.jsx
@@ -38,16 +38,10 @@ class SortableTable extends Component {
       }),
     ).isRequired,
 
-    // DEPRECATING: A callback for when a header is clicked.
-    onSort: PropTypes.func,
     // A callback for when a header is clicked.
     onHeaderClick: PropTypes.func,
-
-    /**
-     * Each object represents data for a row.
-     * An optional class may be provided to style specific rows.
-     */
-    renderCell: PropTypes.func,
+    // DEPRECATING in favor of onHeaderClick: A callback for when a header is clicked.
+    onSort: PropTypes.func,
   };
 
   onHeaderClick = (value, order) => () => {

--- a/packages/formation-react/src/components/SortableTable/SortableTable.jsx
+++ b/packages/formation-react/src/components/SortableTable/SortableTable.jsx
@@ -42,13 +42,13 @@ class SortableTable extends Component {
     onHeaderClick: PropTypes.func,
   };
 
-  onHeaderClick = (value, order) => () => {
-    const { onHeaderClick } = this.props;
+  static defaultProps = {
+    onHeaderClick: () => {},
+  };
 
+  onHeaderClick = (value, order) => () => {
     // This replaces `this.props.onSort`.
-    if (onHeaderClick) {
-      onHeaderClick(value, order);
-    }
+    this.props.onHeaderClick(value, order);
   }
 
   renderHeader = (field) => {

--- a/packages/formation-react/src/components/SortableTable/SortableTable.jsx
+++ b/packages/formation-react/src/components/SortableTable/SortableTable.jsx
@@ -45,11 +45,6 @@ class SortableTable extends Component {
   onHeaderClick = (value, order) => () => {
     const { onHeaderClick } = this.props;
 
-    // This is a legacy prop that is being renamed to `onHeaderClick`.
-    if (onSort) {
-      console.error('WARNING: The `onSort` prop is now deprecated in favor of the `onHeaderClick` prop for <SortableTable />.');
-    }
-
     // This replaces `this.props.onSort`.
     if (onHeaderClick) {
       onHeaderClick(value, order);

--- a/packages/formation-react/src/components/SortableTable/SortableTable.jsx
+++ b/packages/formation-react/src/components/SortableTable/SortableTable.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import get from 'lodash/get';
 
 class SortableTable extends Component {
   static propTypes = {
@@ -47,7 +48,7 @@ class SortableTable extends Component {
   };
 
   onHeaderClick = (value, order) => () => {
-    const { onSort } = this.props;
+    const { onHeaderClick, onSort } = this.props;
 
     // This is a legacy prop that is being renamed to `onHeaderClick`.
     if (onSort) {
@@ -55,8 +56,13 @@ class SortableTable extends Component {
       onSort(value, order);
     }
 
+    // Escape early if no `onHeaderClick` prop is provided.
+    if (!onHeaderClick) {
+      return;
+    }
+
     // This replaces `this.props.onSort`.
-    this.props.onHeaderClick(value, order);
+    onHeaderClick(value, order);
   }
 
   renderHeader = (field) => {

--- a/packages/formation-react/src/components/SortableTable/SortableTable.jsx
+++ b/packages/formation-react/src/components/SortableTable/SortableTable.jsx
@@ -40,18 +40,14 @@ class SortableTable extends Component {
 
     // A callback for when a header is clicked.
     onHeaderClick: PropTypes.func,
-
-    // DEPRECATING in favor of onHeaderClick: A callback for when a header is clicked.
-    onSort: PropTypes.func,
   };
 
   onHeaderClick = (value, order) => () => {
-    const { onHeaderClick, onSort } = this.props;
+    const { onHeaderClick } = this.props;
 
     // This is a legacy prop that is being renamed to `onHeaderClick`.
     if (onSort) {
-      console.warn('WARNING: The `onSort` prop is being deprecated in favor of the `onHeaderClick` prop for <SortableTable />.');
-      onSort(value, order);
+      console.error('WARNING: The `onSort` prop is now deprecated in favor of the `onHeaderClick` prop for <SortableTable />.');
     }
 
     // This replaces `this.props.onSort`.

--- a/packages/formation-react/src/components/SortableTable/SortableTable.jsx
+++ b/packages/formation-react/src/components/SortableTable/SortableTable.jsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 
 class SortableTable extends Component {
   static propTypes = {
+    // Used to pass custom classes.
     className: PropTypes.string,
 
     /**
@@ -15,15 +16,14 @@ class SortableTable extends Component {
       order: PropTypes.oneOf(['ASC', 'DESC']),
     }).isRequired,
 
-    /**
-     * Mappings of header labels to properties on the objects in `data`.
-     */
+    // Mappings of header labels to properties on the objects in `data`.
     fields: PropTypes.arrayOf(
       PropTypes.shape({
         label: PropTypes.string.isRequired,
         value: PropTypes.string.isRequired,
       }),
     ).isRequired,
+
     /**
      * Each object represents data for a row.
      * An optional class may be provided to style specific rows.
@@ -40,6 +40,7 @@ class SortableTable extends Component {
 
     // A callback for when a header is clicked.
     onHeaderClick: PropTypes.func,
+
     // DEPRECATING in favor of onHeaderClick: A callback for when a header is clicked.
     onSort: PropTypes.func,
   };

--- a/packages/formation-react/src/components/SortableTable/SortableTable.jsx
+++ b/packages/formation-react/src/components/SortableTable/SortableTable.jsx
@@ -31,10 +31,11 @@ class SortableTable extends Component {
     data: PropTypes.arrayOf(
       PropTypes.shape({
         id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+        renderCustomCell: PropTypes.func,
+        rowClass: PropTypes.string,
         values: PropTypes.arrayOf(
           PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
         ),
-        rowClass: PropTypes.string,
       }),
     ).isRequired,
 
@@ -43,9 +44,6 @@ class SortableTable extends Component {
 
     // DEPRECATING in favor of onHeaderClick: A callback for when a header is clicked.
     onSort: PropTypes.func,
-
-    // A function that returns JSX to be rendered within a cell.
-    renderCustomCell: PropTypes.func,
   };
 
   onHeaderClick = (value, order) => () => {
@@ -101,11 +99,11 @@ class SortableTable extends Component {
   }
 
   renderCell = (item, field) => {
-    const { renderCustomCell } = this.props;
+    const renderCustomCell = get(item, 'renderCustomCell');
 
-    // If they provided a `renderCustomCell` prop, execute it.
+    // If the item has a `renderCustomCell` property, execute it.
     if (renderCustomCell) {
-      return renderCustomCell(item, field);
+      return renderCustomCell(field);
     }
 
     // Otherwise, return the field value in the item.

--- a/packages/formation-react/src/components/SortableTable/SortableTable.jsx
+++ b/packages/formation-react/src/components/SortableTable/SortableTable.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 class SortableTable extends Component {
@@ -43,6 +43,9 @@ class SortableTable extends Component {
 
     // DEPRECATING in favor of onHeaderClick: A callback for when a header is clicked.
     onSort: PropTypes.func,
+
+    // A function that returns JSX to be rendered within a cell.
+    renderCustomCell: PropTypes.func,
   };
 
   onHeaderClick = (value, order) => () => {
@@ -97,20 +100,39 @@ class SortableTable extends Component {
     );
   }
 
+  renderCell = (item, field) => {
+    const { renderCustomCell } = this.props;
+
+    // If they provided a `renderCustomCell` prop, execute it.
+    if (renderCustomCell) {
+      return renderCustomCell(item, field);
+    }
+
+    // Otherwise, return the field value in the item.
+    return item[field.value];
+  }
+
   renderRow = (item) => {
+    const { renderCell } = this;
+    const { fields } = this.props;
+
     return (
       <tr key={item.id} className={item.rowClass}>
-        {this.props.fields.map(field => (
-          <td key={`${item.id}-${field.value}`}>{item[field.value]}</td>
+        {fields.map(field => (
+          <td key={`${item.id}-${field.value}`}>
+            {renderCell(item, field)}
+          </td>
         ))}
       </tr>
     );
   }
 
   render() {
-    const headers = this.props.fields.map(this.renderHeader);
-    const rows = this.props.data.map(this.renderRow);
-    const tableClass = classNames('va-sortable-table', this.props.className);
+    const { className, data, fields } = this.props;
+
+    const headers = fields.map(this.renderHeader);
+    const rows = data.map(this.renderRow);
+    const tableClass = classNames('va-sortable-table', className);
 
     return (
       <table className={tableClass}>

--- a/packages/formation-react/src/components/SortableTable/SortableTable.jsx
+++ b/packages/formation-react/src/components/SortableTable/SortableTable.jsx
@@ -55,7 +55,7 @@ class SortableTable extends Component {
 
     // This is a legacy prop that is being renamed to `onHeaderClick`.
     if (onSort) {
-      console.warn('WARNING: `onSort` is being deprecated in favor of `onHeaderClick` for <SortableTable />.');
+      console.warn('WARNING: The `onSort` prop is being deprecated in favor of the `onHeaderClick` prop for <SortableTable />.');
       onSort(value, order);
     }
 

--- a/packages/formation-react/src/components/SortableTable/SortableTable.jsx
+++ b/packages/formation-react/src/components/SortableTable/SortableTable.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import get from 'lodash/get';
 
 class SortableTable extends Component {
   static propTypes = {
@@ -32,7 +31,6 @@ class SortableTable extends Component {
     data: PropTypes.arrayOf(
       PropTypes.shape({
         id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
-        renderCustomCell: PropTypes.func,
         rowClass: PropTypes.string,
         values: PropTypes.arrayOf(
           PropTypes.oneOfType([PropTypes.number, PropTypes.string]),

--- a/packages/formation-react/src/components/SortableTable/SortableTable.mdx
+++ b/packages/formation-react/src/components/SortableTable/SortableTable.mdx
@@ -3,12 +3,12 @@ title: SortableTable
 name: SortableTable
 tags: sortable table
 ---
-
 import SortableTable from './SortableTable'
 
 ### Code:
 
 ```javascript
+import React from 'react'
 import SortableTable from '@department-of-veterans-affairs/formation-react/SortableTable'
 
 <SortableTable
@@ -37,21 +37,21 @@ import SortableTable from '@department-of-veterans-affairs/formation-react/Sorta
     [
       {
         id: 1,
-        name: 'Joe',
+        name: <span>Joe</span>,
         email: 'joe@joe.com',
         message:'Hello',
         rowClass: 'class'
       },
       {
         id: 2,
-        name: 'Bob',
+        name: <span>Bob</span>,
         email: 'bob@bob.com',
         message:'Hola',
         rowClass: 'class'
       },
       {
         id: 3,
-        name: 'Tom',
+        name: <span>Tom</span>,
         email: 'tom@tom.com',
         message:"What's Up",
         rowClass: 'class'

--- a/packages/formation-react/src/components/SortableTable/SortableTable.mdx
+++ b/packages/formation-react/src/components/SortableTable/SortableTable.mdx
@@ -58,6 +58,7 @@ import SortableTable from '@department-of-veterans-affairs/formation-react/Sorta
       }
     ]
   }
+  onHeaderClick={(value, order) => {}}
 />
 ```
 
@@ -111,5 +112,6 @@ import SortableTable from '@department-of-veterans-affairs/formation-react/Sorta
         }
       ]
     }
+    onHeaderClick={(value, order) => {}}
   />
 </div>


### PR DESCRIPTION
## Description
**WARNING: THIS PR INCLUDES [THIS PR](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/190).**

**Original Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/3701

This PR adds a new prop called `renderCustomCell` for the `<SortableTable />` component, which is a function that receives the row item as an argument and returns back custom JSX to render within the table cell.

## Testing done
Unit tests.

## Screenshots
N/A

## Acceptance criteria
- [x] Add a new `renderCustomCell` prop.

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
