### PR TITLE
Update 'ui:reviewField' documentation

### DIFF
--- a/packages/documentation/src/pages/forms/about-the-schema-and-uischema-objects.mdx
+++ b/packages/documentation/src/pages/forms/about-the-schema-and-uischema-objects.mdx
@@ -140,15 +140,16 @@ The VAFS code includes additional `uiSchema` functionality not found in the RJSF
   // Renders a custom review field on the review page. Only used when you specify a widget
   // component. The `children` parameter is a component from the `'ui:reviewWidget'`, but
   // is only rendered by this custom reviewField if the schema for it is not an `object`
-  // or `array`
+  // or `array`; NOTE: you must return a div with a "review-row" class name and include
+  // child <dt> and <dd> elements to maintain accessibility standards
   'ui:reviewField': ({ children, schema, uiSchema }) => (
-    <dl className="review-row">
+    <div className="review-row">
       <dt>
         {uiSchema['ui:title']}
         {uiSchema['ui:description]}
       </dt>
       <dd>{children}</dd>
-    </dl>
+    </div>
   ),
 
   // Provides a function to make a field conditionally required. The data in the whole form,


### PR DESCRIPTION
## Description

After adding the `'ui:reviewField'` documentation, the fix from the review page [a11y fix](https://github.com/department-of-veterans-affairs/vets-website/pull/11118) did not move the `<dl class="review-form">` inside the field element as I anticipated in the original fix.

The field now *must* return a `<div class="review-form">` wrapper containing both `<dt>` and `<dd>` elements as immediate children in order to maintain the accessibility standard.

The above comment and updated code example was added to the documentation  

Original ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/1943
Fix: https://github.com/department-of-veterans-affairs/vets-website/pull/11120
Previous doc addition: https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/189

## Testing done

Browser axe extension

## Screenshots

N/A

## Acceptance criteria
- [ ] Documentation updated to maintain a11y standards.

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
