### PR TITLE
Fix deployment of documentation site

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,9 +1,9 @@
 {
   "packages": [
-    "packages/documentation/*",
-    "packages/formation/*",
-    "packages/formation-react/*",
-    "packages/vagov-eslint/*"
+    "packages/documentation",
+    "packages/formation",
+    "packages/formation-react",
+    "packages/vagov-eslint"
   ],
   "version": "independent",
   "npmClient": "yarn",


### PR DESCRIPTION
## Description
Reading the Lerna docs [here](https://github.com/lerna/lerna#concepts) about the `packages` filter, I learned that the glob pattern we were using was looking a directory deeper than it should have been, resulting in the deploy issues we see here - http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fveteran-facing-services-tools/detail/master/154/pipeline

```
> lerna run deploy --scope=vagov-documentation

lerna notice cli v3.13.2
lerna info versioning independent
lerna info ci enabled
lerna info filter [ 'vagov-documentation' ]
lerna ERR! EFILTER No packages remain after filtering [ 'vagov-documentation' ]
```


Ticket - https://github.com/department-of-veterans-affairs/va.gov-team/issues/4217
## Testing done
Ran `npm run deploy` locally

## Screenshots
N/A

## Acceptance criteria
- [ ] Our client docs site can deploy again

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
