### PR TITLE
Keyboard-e2e proof of concept code

### DIFF
--- a/packages/formation-react/src/components/SortableTable/SortableTable.jsx
+++ b/packages/formation-react/src/components/SortableTable/SortableTable.jsx
@@ -30,7 +30,8 @@ class SortableTable extends Component {
      */
     data: PropTypes.arrayOf(
       PropTypes.shape({
-        id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+        id: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+          .isRequired,
         rowClass: PropTypes.string,
         values: PropTypes.arrayOf(
           PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
@@ -49,9 +50,9 @@ class SortableTable extends Component {
   onHeaderClick = (value, order) => () => {
     // This replaces `this.props.onSort`.
     this.props.onHeaderClick(value, order);
-  }
+  };
 
-  renderHeader = (field) => {
+  renderHeader = field => {
     if (field.nonSortable) {
       return <th key={field.value}>{field.label}</th>;
     }
@@ -88,21 +89,19 @@ class SortableTable extends Component {
         </a>
       </th>
     );
-  }
+  };
 
-  renderRow = (item) => {
+  renderRow = item => {
     const { fields } = this.props;
 
     return (
       <tr key={item.id} className={item.rowClass}>
         {fields.map(field => (
-          <td key={`${item.id}-${field.value}`}>
-            {item[field.value]}
-          </td>
+          <td key={`${item.id}-${field.value}`}>{item[field.value]}</td>
         ))}
       </tr>
     );
-  }
+  };
 
   render() {
     const { className, data, fields } = this.props;

--- a/packages/keyboard-e2e/.gitignore
+++ b/packages/keyboard-e2e/.gitignore
@@ -1,0 +1,8 @@
+/node_modules/
+/dist/
+/logs/
+/tests_output/
+
+.DS_Store
+chromedriver.log
+geckodriver.log

--- a/packages/keyboard-e2e/README.md
+++ b/packages/keyboard-e2e/README.md
@@ -1,0 +1,69 @@
+# Nightwatch Keyboard-e2e Test Helpers
+
+Keyboard-e2e is a suite of assertions and custom commands for simulating keyboard navigation
+in end-to-end (e2e) tests. It is designed to confirm basic interactions with focusable elements
+like buttons, links, and text inputs. It also includes helpers for testing checkboxes, radio groups,
+and select menus.
+
+**Table of Contents**
+
+- [Nightwatch Keyboard-e2e Test Helpers](#nightwatch-keyboard-e2e-test-helpers)
+  - [The Purpose of Keyboard-e2e](#the-purpose-of-keyboard-e2e)
+  - [Implementation Details](#implementation-details)
+  - [Getting Started](#getting-started)
+  - [Configuration](#configuration)
+    - [Nightwatch.json (global)](#nightwatchjson-global)
+    - [Globals file (local)](#globals-file-local)
+  - [Footnotes](#footnotes)
+
+## The Purpose of Keyboard-e2e
+
+Keyboard-e2e was built to simulate how keyboard users navigate web pages. Keyboard navigation is critical for users who do not prefer, or cannot use, a mouse input. Keyboard navigation is also required for screen reader users to navigate web pages.
+
+Keyboard-e2e offers reproducible, [happy path](https://en.wikipedia.org/wiki/Happy_path) tests for common keyboard navigation patterns:
+
+- Assert the correct number of [focusable and tabbable elements](https://allyjs.io/what-is-focusable.html) using [Ally.js](https://allyjs.io/)
+- Test [skip navigation links](https://webaim.org/techniques/skipnav/)
+- Set focus on native elements like links, buttons, and text inputs using the `TAB` key
+- Interact with checkbox groups using `TAB` and `SPACE`
+- Interact with radio groups using `ARROW` keys
+- Submit forms with `ENTER` or `SPACE`
+
+## Implementation Details
+
+Keyboard-e2e is built on [NightwatchJS](https://nightwatchjs.org/). Keyboard-e2e uses the
+[developer API](https://nightwatchjs.org/guide/extending-nightwatch/) to simulate keyboard navigation behavior.
+
+In the future, Keyboard-e2e may be ported to additional test runners, with [Cypress](https://www.cypress.io/)
+being the most likely candidate. Cypress contains several core methods that had to be approximated
+in Nightwatch.
+
+## Getting Started
+
+1. Clone the [Veteran-Facing Services Tools](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/) repository
+2. Open a terminal window and type everything after the `$`
+   - **\$** `cd packages/nightwatch-keyboard-e2e`
+   - **\$** `npm install`
+   - **\$** `npm run start`
+3. Open a web browser and type `localhost:8080` into the address bar. Verify the content pages are running correctly.
+4. Open a second terminal window.
+5. Type **\$** `npm run test` to run all tests
+6. Keyboard-e2e uses headless Chrome by default. No browser window will open, but this can be changed in the [Nightwatch.json](#nightwatchjson-global) file.
+
+## Configuration
+
+Keyboard-e2e uses two configuration files, **nightwatch.json** and **test/globals/index.js** to set and control tests.
+
+### Nightwatch.json (global)
+
+Global Nightwatch paths and settings can be adjusted in this file. Please read the [Nightwatch configuration docs](https://nightwatchjs.org/gettingstarted/configuration/) for more options and expected values.
+
+### Globals file (local)
+
+The Nightwatch globals index is located in **test/globals**. Keyboard-e2e uses a plain-old JavaScript object (POJO) to store custom data attributes for each input under test. This file can be modified to use CSS selectors, XPath selectors, or your own naming convention.
+
+The globals file makes it easy to change and refactor the test naming convention(s), instead of having to find and replace strings throughout your test suite.
+
+## Footnotes
+
+Keyboard-e2e was built on a question. Could we automate basic keyboard navigation testing? There weren't a lot of blueprints for this type of thing, so it was assembled one piece, one command, one assertion at a time. The [footnotes file](footnotes.md) contains links to all of the libraries, APIs, and resources used to build Keyboard-e2e.

--- a/packages/keyboard-e2e/footnotes.md
+++ b/packages/keyboard-e2e/footnotes.md
@@ -1,0 +1,30 @@
+# Keyboard e2e Testing Resources
+
+## Libraries and APIs
+
+- [NightwatchJS](https://nightwatchjs.org)
+- [Ally.js](https://allyjs.io/)
+- [Webdriver](https://www.w3.org/TR/webdriver1/)
+- [Chromedriver](https://chromedriver.chromium.org/)
+- [Webpack](https://webpack.js.org/)
+- [ESLint](https://eslint.org/)
+
+## Nightwatch Tutorials and Answers
+
+- [E2E Testing with Nightwatch: Part One](https://medium.com/front-end-hacking/e2e-testing-with-nightwatch-part-one-309c221b7a98)
+- [E2E Testing with Nightwatch: Part Two](https://blog.cloudboost.io/e2e-testing-with-nightwatch-part-two-aaa25a4dc033)
+- [End to End Testing fo React Apps with Nightwatch](https://blog.syncano.io/testing-syncano/)
+- [Custom commands and before(), after() hooks - Testing React apps with Nightwatch](https://blog.syncano.io/end-to-end-testing-of-react-apps-with-nightwatch-part-2/)
+- [How to simulate "enter" keypress in integration
+  test?](https://discuss.emberjs.com/t/how-simulate-enter-keypress-in-integration-test/13762)
+- [StackOverflow: How to write a Nightwatch custom command using jQuery](https://stackoverflow.com/questions/36830349/how-to-write-a-nightwatch-custom-command-using-jquery)
+
+## Global Variable Handling
+
+- [ProvidePlugin](https://webpack.js.org/plugins/provide-plugin/)
+- [Expose-Loader](https://webpack.js.org/loaders/expose-loader/)
+- [Getting Started with Ally.js](https://allyjs.io/getting-started.html)
+
+## Chromedriver Tutorials
+
+- [Getting Started With Headless Chrome](https://developers.google.com/web/updates/2017/04/headless-chrome)

--- a/packages/keyboard-e2e/footnotes.md
+++ b/packages/keyboard-e2e/footnotes.md
@@ -18,6 +18,7 @@
 - [How to simulate "enter" keypress in integration
   test?](https://discuss.emberjs.com/t/how-simulate-enter-keypress-in-integration-test/13762)
 - [StackOverflow: How to write a Nightwatch custom command using jQuery](https://stackoverflow.com/questions/36830349/how-to-write-a-nightwatch-custom-command-using-jquery)
+- [Github Issues: browser.execute doesn't accept arrow functions](https://github.com/nightwatchjs/nightwatch/issues/1920)
 
 ## Global Variable Handling
 

--- a/packages/keyboard-e2e/nightwatch.conf.js
+++ b/packages/keyboard-e2e/nightwatch.conf.js
@@ -1,0 +1,8 @@
+/* eslint no-param-reassign: "error" */
+
+require('babel-register')();
+
+module.exports = (settings => {
+  settings.test_workers = false;
+  return settings;
+})(require('./nightwatch.json'));

--- a/packages/keyboard-e2e/nightwatch.json
+++ b/packages/keyboard-e2e/nightwatch.json
@@ -1,0 +1,26 @@
+{
+  "src_folders": ["test/e2e"],
+  "custom_commands_path": "test/commands",
+  "custom_assertions_path": "test/assertions",
+  "globals_path": "test/globals",
+  "webdriver": {
+    "start_process": true,
+    "server_path": "node_modules/.bin/chromedriver",
+    "port": 9515,
+    "log_path": "logs"
+  },
+
+  "test_settings": {
+    "default": {
+      "webdriver": {
+        "cli_args": ["debug"]
+      },
+      "desiredCapabilities": {
+        "browserName": "chrome",
+        "chromeOptions": {
+          "args": ["--headless"]
+        }
+      }
+    }
+  }
+}

--- a/packages/keyboard-e2e/package.json
+++ b/packages/keyboard-e2e/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "vets-keyboard-e2e",
+  "version": "0.1.0",
+  "description": "A suite of tools for end-to-end keyboard accessibility",
+  "main": "index.js",
+  "author": "Trevor Pierce",
+  "license": "CC0-1.0",
+  "private": false,
+  "devDependencies": {
+    "@babel/core": "^7.7.2",
+    "@babel/preset-env": "^7.7.1",
+    "@babel/register": "^7.7.0",
+    "ally.js": "^1.4.1",
+    "babel-loader": "^7.1.5",
+    "babel-plugin-add-module-exports": "^1.0.2",
+    "babel-register": "^6.26.0",
+    "chromedriver": "^78.0.1",
+    "copy-webpack-plugin": "^5.1.1",
+    "css-loader": "^3.2.0",
+    "eslint": "^4.19.1",
+    "eslint-config-airbnb": "^16.1.0",
+    "eslint-plugin-import": "^2.10.0",
+    "eslint-plugin-jsx-a11y": "^6.0.3",
+    "eslint-plugin-react": "^7.7.0",
+    "events": "^2.0.0",
+    "expose-loader": "^0.7.5",
+    "jquery": "^3.3.1",
+    "mini-css-extract-plugin": "^0.4.0",
+    "nightwatch": "^1.0.8",
+    "rimraf": "^2.6.2",
+    "style-loader": "^0.20.3",
+    "webpack": "^4.41.2",
+    "webpack-cli": "^3.3.10",
+    "webpack-dev-server": "^3.1.1"
+  },
+  "scripts": {
+    "start": "rimraf dist/ && webpack --profile --progress --colors && webpack-dev-server",
+    "test": "./node_modules/.bin/nightwatch"
+  }
+}

--- a/packages/keyboard-e2e/src/content/content1.html
+++ b/packages/keyboard-e2e/src/content/content1.html
@@ -1,0 +1,249 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Content 1</title>
+    <link rel="stylesheet" href="../css/main.bundle.css" />
+  </head>
+
+  <body data-nwId="content-1-body">
+    <a href="#main-container" id="skip-nav">Skip to Content</a>
+    <header>
+      <h1>Hi, I'm Content One</h1>
+    </header>
+
+    <main id="main-container" tabindex="-1">
+      <form action="#">
+        <fieldset>
+          <legend>
+            <h2>
+              Basic Information
+              <span>All fields required unless marked optional</span>
+            </h2>
+          </legend>
+
+          <label for="name">
+            <span class="c-form__label">Your Name</span>
+            <span class="c-form__label--secondary"
+              >Include first and last name</span
+            >
+          </label>
+          <input
+            data-nwId="content-1-form-1-input-1"
+            type="text"
+            id="name"
+            name="name"
+            required
+          />
+
+          <label for="age">
+            <span class="c-form__label">Your Age In Years</span>
+            <span class="c-form__label--secondary">Two digits, 0-9 only</span>
+          </label>
+          <input
+            data-nwId="content-1-form-1-input-2"
+            type="text"
+            id="age"
+            name="age"
+            pattern="[0-9]{1,2}"
+            required
+          />
+        </fieldset>
+
+        <fieldset>
+          <legend>
+            <h2>
+              Methods of Contact
+              <span>All fields required unless marked optional</span>
+            </h2>
+          </legend>
+
+          <label for="email">
+            <span class="c-form__label">Your Email Address</span>
+            <span class="c-form__label--secondary"
+              >Must be a valid address</span
+            >
+          </label>
+          <input
+            data-nwId="content-1-form-1-input-3"
+            type="email"
+            id="email"
+            name="email"
+            required
+          />
+
+          <label for="telephone">
+            <span class="c-form__label">Your Telephone Number</span>
+            <span class="c-form__label--secondary">Optional</span>
+          </label>
+          <input
+            data-nwId="content-1-form-1-input-4"
+            type="tel"
+            id="telephone"
+            name="telephone"
+          />
+
+          <label for="twitter">
+            <span class="c-form__label">Your Twitter Username</span>
+            <span class="c-form__label--secondary">Optional</span>
+          </label>
+          <input
+            data-nwId="content-1-form-1-input-5"
+            type="text"
+            id="twitter"
+            name="twitter"
+          />
+
+          <label for="keybase">
+            <span class="c-form__label">Your Keybase Username</span>
+            <span class="c-form__label--secondary">Optional</span>
+          </label>
+          <input
+            data-nwId="content-1-form-1-input-6"
+            type="text"
+            id="keybase"
+            name="keybase"
+          />
+
+          <label for="textarea-optional">
+            <span class="c-form__label">Other Social Media Accounts</span>
+            <span class="c-form__label--secondary">Optional</span>
+          </label>
+          <textarea
+            cols="35"
+            data-nwId="content-1-form-textarea-1"
+            id="textarea-optional"
+            rows="5"
+          ></textarea>
+        </fieldset>
+
+        <fieldset>
+          <legend>
+            <h2>
+              Preferred Ways to Contact You
+              <span>If no boxes are checked, we will default to email</span>
+            </h2>
+          </legend>
+          <ul data-nwId="content-1-form-1-checkboxes">
+            <li>
+              <input
+                data-nwId="content-1-form-1-checkbox-1"
+                id="checkbox-email"
+                type="checkbox"
+                name="checkbox-contacts"
+                value="checkbox-email"
+              />
+              <label for="checkbox-email">Email</label>
+            </li>
+
+            <li>
+              <input
+                data-nwId="content-1-form-1-checkbox-2"
+                id="checkbox-telephone"
+                type="checkbox"
+                name="checkbox-contacts"
+                value="checkbox-telephone"
+              />
+              <label for="checkbox-telephone">Telephone</label>
+            </li>
+
+            <li>
+              <input
+                data-nwId="content-1-form-1-checkbox-3"
+                id="checkbox-twitter"
+                type="checkbox"
+                name="checkbox-contacts"
+                value="checkbox-twitter"
+              />
+              <label for="checkbox-twitter">Twitter</label>
+            </li>
+
+            <li>
+              <input
+                data-nwId="content-1-form-1-checkbox-4"
+                id="checkbox-keybase"
+                type="checkbox"
+                name="checkbox-contacts"
+                value="checkbox-keybase"
+              />
+              <label for="checkbox-keybase">Keybase</label>
+            </li>
+          </ul>
+        </fieldset>
+
+        <fieldset>
+          <legend>
+            <h2>
+              Would You Like to Receive Email Updates?
+              <span>You can change your mind any time</span>
+            </h2>
+          </legend>
+          <ul data-nwId="content-1-form-1-radio-buttons">
+            <li>
+              <input
+                data-nwId="content-1-form-1-radio-1"
+                id="radio-yes"
+                type="radio"
+                name="radio-subscribe"
+                value="radio-yes"
+                checked
+              />
+              <label for="radio-yes">Yes, please send me updates</label>
+            </li>
+
+            <li>
+              <input
+                data-nwId="content-1-form-1-radio-2"
+                id="radio-no"
+                type="radio"
+                name="radio-subscribe"
+                value="radio-no"
+              />
+              <label for="radio-no">No, I do not wish to receive updates</label>
+            </li>
+
+            <li>
+              <input
+                data-nwId="content-1-form-1-radio-3"
+                id="radio-maybe"
+                type="radio"
+                name="radio-subscribe"
+                value="radio-maybe"
+              />
+              <label for="radio-maybe">Maybe, ask me tomorrow</label>
+            </li>
+          </ul>
+        </fieldset>
+
+        <fieldset>
+          <legend>
+            <h2>Security Questions</h2>
+            <div>
+              <label class="c-form__label" for="sec-1">Question One</label>
+              <select data-nwId="content-1-form-1-select-1" id="sec-1">
+                <option value="value1">What is your favorite color?</option>
+                <option value="value2">What is your favorite car?</option>
+                <option value="value3"
+                  >What is your favorite sports team?</option
+                >
+                <option value="value4"
+                  >What is your favorite subject in school?</option
+                >
+                <option value="value5"
+                  >What is your favorite musician or band?</option
+                >
+              </select>
+            </div>
+          </legend>
+        </fieldset>
+
+        <div>
+          <button data-nwId="content-1-form-1-button-1">Submit</button>
+        </div>
+      </form>
+    </main>
+    <script src="https://cdn.jsdelivr.net/ally.js/1.4.1/ally.min.js"></script>
+  </body>
+</html>

--- a/packages/keyboard-e2e/src/css/ally.css
+++ b/packages/keyboard-e2e/src/css/ally.css
@@ -1,0 +1,8 @@
+.native-focusable {
+  background: #00DD00;
+}
+
+[type="checkbox"].native-focusable + label,
+[type="radio"].native-focusable + label {
+  color: #3f7ebd;
+}

--- a/packages/keyboard-e2e/src/css/forms.css
+++ b/packages/keyboard-e2e/src/css/forms.css
@@ -1,0 +1,51 @@
+form {
+  padding: 0 0 3rem;
+}
+
+fieldset {
+  margin-bottom: 2.5rem;
+}
+
+legend {
+  width: 100%;
+}
+
+legend h2 {
+  border-top: 2px solid #727272;
+  font-size: 1.5em;
+  font-weight: 700;
+  padding: 0.25rem 0 0 0.125rem;
+}
+
+legend span {
+  display: block;
+  font-size: 0.75em;
+  font-weight: 400;
+  margin: 0.25rem 0 1rem;
+}
+
+input[type="text"],
+input[type="email"],
+input[type="tel"],
+textarea {
+  border: 1px solid #727272;
+  font-size: 1em;
+  padding: 0.25rem 1rem;
+  width: 25rem;
+}
+
+.c-form__label,
+.c-form__label--secondary {
+  display: block;
+}
+
+.c-form__label {
+  font-weight: 700;
+  margin-top: 1.5rem;
+}
+
+.c-form__label--secondary {
+  font-style: italic;
+  font-weight: 400;
+  margin-bottom: 0.5rem;
+}

--- a/packages/keyboard-e2e/src/css/layout.css
+++ b/packages/keyboard-e2e/src/css/layout.css
@@ -1,0 +1,55 @@
+html {
+  -webkit-text-size-adjust: 100%;
+}
+
+html,
+body {
+  font-size: 100%;
+  line-height: 1.5;
+  margin: 0;
+  padding: 0;
+}
+
+*,
+*::after,
+*::before {
+  box-sizing: border-box;
+}
+
+body {
+  background: #fff;
+  color: #484848;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
+    Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  height: 100vh;
+  text-rendering: optimizeLegibility;
+}
+
+#colorBlindSVG {
+  display: none;
+}
+
+header,
+main {
+  margin: 0 auto;
+  width: 40rem;
+}
+
+header {
+  padding: 2rem 3rem 1rem;
+}
+
+main {
+  padding: 0 3rem;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p {
+  line-height: 1.5;
+  margin-bottom: 1rem;
+}

--- a/packages/keyboard-e2e/src/css/links.css
+++ b/packages/keyboard-e2e/src/css/links.css
@@ -1,0 +1,4 @@
+a:focus {
+  background-color: red;
+  color: white;
+}

--- a/packages/keyboard-e2e/src/css/main.css
+++ b/packages/keyboard-e2e/src/css/main.css
@@ -1,0 +1,5 @@
+@import "reset.css";
+@import "ally.css";
+@import "links.css";
+@import "forms.css";
+@import "layout.css";

--- a/packages/keyboard-e2e/src/css/reset.css
+++ b/packages/keyboard-e2e/src/css/reset.css
@@ -1,0 +1,48 @@
+/* http://meyerweb.com/eric/tools/css/reset/ 
+   v2.0 | 20110126
+   License: none (public domain)
+*/
+
+html, body, div, span, applet, object, iframe,
+h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+a, abbr, acronym, address, big, cite, code,
+del, dfn, em, img, ins, kbd, q, s, samp,
+small, strike, strong, sub, sup, tt, var,
+b, u, i, center,
+dl, dt, dd, ol, ul, li,
+fieldset, form, label, legend,
+table, caption, tbody, tfoot, thead, tr, th, td,
+article, aside, canvas, details, embed, 
+figure, figcaption, footer, header, hgroup, 
+menu, nav, output, ruby, section, summary,
+time, mark, audio, video {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article, aside, details, figcaption, figure, 
+footer, header, hgroup, menu, nav, section {
+	display: block;
+}
+body {
+	line-height: 1;
+}
+ol, ul {
+	list-style: none;
+}
+blockquote, q {
+	quotes: none;
+}
+blockquote:before, blockquote:after,
+q:before, q:after {
+	content: '';
+	content: none;
+}
+table {
+	border-collapse: collapse;
+	border-spacing: 0;
+}

--- a/packages/keyboard-e2e/src/index.html
+++ b/packages/keyboard-e2e/src/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Keyboard E2E React Index Page</title>
+    <link rel="stylesheet" href="./css/main.bundle.css" />
+  </head>
+
+  <body data-nwId="body-index">
+    <header>
+      <h1>E2E Keyboard Test Suite</h1>
+    </header>
+    <main id="content" tabindex="-1">
+      <article id="example-introduction">
+        <h2>Mocked Login Page</h2>
+        <p>
+          This page has one link to the first content page. It is intended as a
+          calibration and smoke test for our keyboard-specific tests that will
+          happen in the pages to follow.
+        </p>
+        <p>
+          This is only a second paragraph to get a sense for what may happen
+          when I query using the execute method.
+        </p>
+        <h3>Table of Contents</h3>
+        <a href="./content/content1.html" data-nwId="link-content-1"
+          >Content Page One</a
+        >
+      </article>
+    </main>
+    <script src="./js/main.bundle.js " type="text/javascript "></script>
+  </body>
+</html>

--- a/packages/keyboard-e2e/src/js/index.js
+++ b/packages/keyboard-e2e/src/js/index.js
@@ -1,0 +1,11 @@
+import ally from 'ally.js';
+import '../css/main.css';
+
+ally.query.focusable().forEach(el => {
+  el.classList.add('js-focusable');
+});
+
+ally.query.tabbable().forEach(el => {
+  el.classList.remove('js-focusable');
+  el.classList.add('native-focusable');
+});

--- a/packages/keyboard-e2e/test/assertions/isActiveElement.js
+++ b/packages/keyboard-e2e/test/assertions/isActiveElement.js
@@ -1,3 +1,5 @@
+/* eslint-disable valid-typeof */
+
 /**
  * Checks if the given element is focused on the page.
  *

--- a/packages/keyboard-e2e/test/assertions/isActiveElement.js
+++ b/packages/keyboard-e2e/test/assertions/isActiveElement.js
@@ -1,0 +1,23 @@
+/**
+ * Checks if the given element is focused on the page.
+ *
+ * ```javascript
+ *  this.demoTest = function (client) {
+ *    client.assert.isActiveElement(".should_be_focused");
+ *  };
+ * ```
+ *
+ * @method isActiveElement
+ * @param {string} selector The selector (CSS / Xpath) used to locate the element.
+ * @param {string} [message] Optional log message to display in the output. If missing, one is displayed by default.
+ * @api assertions
+ */
+
+exports.assertion = function isActiveElement(selector, msg) {
+  this.message =
+    msg || `Testing if element that matches <${selector}> is focused.`;
+  this.expected = true;
+  this.pass = value => value === this.expected;
+  this.value = result => result.value;
+  this.command = callback => this.api.checkActiveElement(selector, callback);
+};

--- a/packages/keyboard-e2e/test/assertions/isAllyDeepEquals.js
+++ b/packages/keyboard-e2e/test/assertions/isAllyDeepEquals.js
@@ -1,0 +1,27 @@
+/**
+ * Checks if the number of focusable and tabbable elements are correct.
+ * This is a simple equality check, to make sure the right number of
+ * elements can be reached by pressing TAB or through programmatic
+ * focus with the JS .focus() method.
+ *
+ * ```javascript
+ *  this.demoTest = function (client) {
+ *    client.assert.isAllyDeepEquals("body", true);
+ *  };
+ * ```
+ *
+ * @method isAllyDeepEqual
+ * @param {string} [selector] The selector (CSS / Xpath) used to locate the element
+ * @param {boolean} [balanceBool] True if page has no no tabIndex="-1"
+ * @api assertions
+ */
+exports.assertion = function isAllyDeepEquals(selector, balanceBool) {
+  this.message = balanceBool
+    ? `${selector} returned equal arrays of tabbable and focusable elements`
+    : `${selector} returned unequal arrays of tabbable and focusable elements`;
+
+  this.expected = balanceBool;
+  this.pass = value => value === this.expected;
+  this.value = result => result.value[0] === result.value[1];
+  this.command = callback => this.api.allyDeepEquals(selector, callback);
+};

--- a/packages/keyboard-e2e/test/assertions/isAllyDeepEquals.js
+++ b/packages/keyboard-e2e/test/assertions/isAllyDeepEquals.js
@@ -1,3 +1,5 @@
+/* eslint-disable valid-typeof */
+
 /**
  * Checks if the number of focusable and tabbable elements are correct.
  * This is a simple equality check, to make sure the right number of

--- a/packages/keyboard-e2e/test/assertions/isAllyDisabledElement.js
+++ b/packages/keyboard-e2e/test/assertions/isAllyDisabledElement.js
@@ -1,0 +1,25 @@
+/**
+ * Checks if the given element is disabled on the page.
+ *
+ * ```javascript
+ *  this.demoTest = function (client) {
+ *    client.assert.isActiveElement(".should_be_focused");
+ *  };
+ * ```
+ *
+ * @method isAllyDisabledElement
+ * @param {string} selector The selector (CSS / Xpath) used to locate the element.
+ * @param {string} [message] Optional log message to display in the output. If missing, one is displayed by default.
+ * @api assertions
+ */
+
+exports.assertion = function isAllyDisabledElement(selector, outcome) {
+  this.message = outcome
+    ? `[ALLY.JS] ${selector} was disabled`
+    : `[ALLY.JS] ${selector} was not disabled`;
+  this.expected = outcome;
+  this.pass = value => value === this.expected;
+  this.value = result => result.value;
+  this.command = callback =>
+    this.api.allyCheckDisabled(selector, outcome, callback);
+};

--- a/packages/keyboard-e2e/test/assertions/isAllyFocusableCount.js
+++ b/packages/keyboard-e2e/test/assertions/isAllyFocusableCount.js
@@ -1,0 +1,26 @@
+/**
+ * Checks if the count of focusable elements is correct. Focusable elements are those
+ * in the normal tab order (native focusable elements or those with tabIndex <= 0).
+ *
+ * ```javascript
+ *  this.demoTest = function (client) {
+ *    client.assert.isAllyFocusableCount("body", 10, "Your custom message");
+ *  };
+ * ```
+ *
+ * @method isAllyFocusableCount
+ * @param {string} [selector] The selector (CSS / Xpath) used to locate the element
+ * @param {number} [count] The number of focusable elements on the page
+ * @param {string} [message] Optional log message displayed in output. Defaults to this.message.
+ * @api assertions
+ */
+exports.assertion = function isAllyFocusableCount(selector, count, message) {
+  this.message =
+    message ||
+    `[ALLY.JS] Page contained the expected number of focusable elements: ${count}`;
+  this.expected = parseInt(count, 10);
+  this.pass = value => value.value.length === this.expected;
+  this.value = result => result;
+  this.command = callback =>
+    this.api.allyCheckFocusableCount(selector, callback);
+};

--- a/packages/keyboard-e2e/test/assertions/isAllyFocusableObject.js
+++ b/packages/keyboard-e2e/test/assertions/isAllyFocusableObject.js
@@ -1,0 +1,24 @@
+/**
+ * Checks if the query returns an object of focusable element(s). This method can
+ * be used as a smoke test to ensure the checks are working properly or to
+ * determine if a group of buttons, links, form inputs, etc. are able to
+ * receive focus correctly.
+ *
+ * ```javascript
+ *  this.demoTest = function (client) {
+ *    client.assert.isAllyFocusableObject("body");
+ *  };
+ * ```
+ *
+ * @method isAllyFocusableObject
+ * @param {string} [selector] The selector (CSS / Xpath) used to locate the element
+ * @param {string} [msg] Optional log message displayed in output. Defaults to this.message.
+ * @api assertions
+ */
+exports.assertion = function isAllyFocusableObject(selector, msg) {
+  this.message = msg || `[ALLY.JS] ${selector} returned a focusable object.`;
+  this.pass = value => typeof value === 'object';
+  this.value = result => result;
+  this.command = callback =>
+    this.api.allyConfirmFocusableObject(selector, callback);
+};

--- a/packages/keyboard-e2e/test/assertions/isAllyFocusableObject.js
+++ b/packages/keyboard-e2e/test/assertions/isAllyFocusableObject.js
@@ -1,3 +1,5 @@
+/* eslint-disable valid-typeof */
+
 /**
  * Checks if the query returns an object of focusable element(s). This method can
  * be used as a smoke test to ensure the checks are working properly or to
@@ -17,7 +19,8 @@
  */
 exports.assertion = function isAllyFocusableObject(selector, msg) {
   this.message = msg || `[ALLY.JS] ${selector} returned a focusable object.`;
-  this.pass = value => typeof value === 'object';
+  this.expected = 'object';
+  this.pass = value => typeof value === this.expected;
   this.value = result => result;
   this.command = callback =>
     this.api.allyConfirmFocusableObject(selector, callback);

--- a/packages/keyboard-e2e/test/assertions/isAllyTabbableCount.js
+++ b/packages/keyboard-e2e/test/assertions/isAllyTabbableCount.js
@@ -1,0 +1,27 @@
+/**
+ * Checks if the count of focusable elements is correct. Focusable elements are those
+ * in the normal tab order (native focusable elements or those with tabIndex <= 0), and
+ * those elements with a tabIndex="-1".
+ *
+ * ```javascript
+ *  this.demoTest = function (client) {
+ *    client.assert.isAllyTabbableCount("body", 10, "Your custom message");
+ *  };
+ * ```
+ *
+ * @method isAllyTabbableCount
+ * @param {string} [selector] The selector (CSS / Xpath) used to locate the element
+ * @param {number} [count] The number of tabbable elements on the page
+ * @param {string} [message] Optional log message displayed in output. Defaults to this.message.
+ * @api assertions
+ */
+exports.assertion = function isAllyTabbableCount(selector, count, msg) {
+  this.message =
+    msg ||
+    `[ALLY.JS] Page contained the expected number of tabbable elements: ${count}`;
+  this.expected = parseInt(count, 10);
+  this.pass = value => value === this.expected;
+  this.value = result => result.value.length;
+  this.command = callback =>
+    this.api.allyCheckTabbableCount(selector, callback);
+};

--- a/packages/keyboard-e2e/test/assertions/isAllyTabbableObject.js
+++ b/packages/keyboard-e2e/test/assertions/isAllyTabbableObject.js
@@ -1,0 +1,25 @@
+/**
+ * Checks if the query returns an object of tabbable element(s). This method can
+ * be used as a smoke test to ensure the checks are working properly or to
+ * determine if a group of buttons, links, form inputs, etc. can be tabbed
+ * to either in the normal tab order or programmatically with tabIndex="-1"
+ * and the JS .focus() method.
+ *
+ * ```javascript
+ *  this.demoTest = function (client) {
+ *    client.assert.isAllyTabbableObject("body");
+ *  };
+ * ```
+ *
+ * @method isAllyTabbableObject
+ * @param {string} [selector] The selector (CSS / Xpath) used to locate the element
+ * @param {string} [msg] Optional log message displayed in output. Defaults to this.message.
+ * @api assertions
+ */
+exports.assertion = function isAllyTabbableObject(selector, msg) {
+  this.message = msg || `[ALLY.JS] ${selector} returned a tabbable object.`;
+  this.pass = value => typeof value === 'object';
+  this.value = result => result;
+  this.command = callback =>
+    this.api.allyConfirmTabbableObject(selector, callback);
+};

--- a/packages/keyboard-e2e/test/assertions/isAllyTabbableObject.js
+++ b/packages/keyboard-e2e/test/assertions/isAllyTabbableObject.js
@@ -1,3 +1,5 @@
+/* eslint-disable valid-typeof */
+
 /**
  * Checks if the query returns an object of tabbable element(s). This method can
  * be used as a smoke test to ensure the checks are working properly or to
@@ -18,7 +20,8 @@
  */
 exports.assertion = function isAllyTabbableObject(selector, msg) {
   this.message = msg || `[ALLY.JS] ${selector} returned a tabbable object.`;
-  this.pass = value => typeof value === 'object';
+  this.expected = 'object';
+  this.pass = value => typeof value === this.expected;
   this.value = result => result;
   this.command = callback =>
     this.api.allyConfirmTabbableObject(selector, callback);

--- a/packages/keyboard-e2e/test/commands/allyCheckDisabled.js
+++ b/packages/keyboard-e2e/test/commands/allyCheckDisabled.js
@@ -1,3 +1,5 @@
+/* eslint-disable func-names, prefer-arrow-callback */
+
 const ally = require('ally.js');
 
 /**
@@ -18,7 +20,7 @@ const ally = require('ally.js');
  */
 exports.command = function allyCheckDisabled(selector, disabled, callback) {
   return this.execute(
-    sel => {
+    function(sel) {
       const target = document.querySelector(sel);
       const disabledTarget = ally.is.disabled(target);
 

--- a/packages/keyboard-e2e/test/commands/allyCheckDisabled.js
+++ b/packages/keyboard-e2e/test/commands/allyCheckDisabled.js
@@ -1,0 +1,30 @@
+const ally = require('ally.js');
+
+/**
+ * Checks if the given element is focused on the page.
+ *
+ * ```javascript
+ *  this.demoTest = function (client) {
+ *    client.checkActiveElement(".should_be_focused", callback);
+ *  };
+ * ```
+ *
+ * @method checkActiveElement
+ * @param {string} [selector] The selector (CSS / Xpath) used to locate the element.
+ * @param {boolean} [disabled] Value expected for ally.is.disabled() assertion.
+ * @param {function} [callback] Optional callback function to be called when the command finishes.
+ * @returns {boolean}
+ * @api commands
+ */
+exports.command = function allyCheckDisabled(selector, disabled, callback) {
+  return this.execute(
+    sel => {
+      const target = document.querySelector(sel);
+      const disabledTarget = ally.is.disabled(target);
+
+      return disabledTarget;
+    },
+    [selector, disabled],
+    callback,
+  );
+};

--- a/packages/keyboard-e2e/test/commands/allyCheckFocusableCount.js
+++ b/packages/keyboard-e2e/test/commands/allyCheckFocusableCount.js
@@ -1,0 +1,33 @@
+const ally = require('ally.js');
+
+/**
+ * Checks for the number of focusable elements on the page,
+ * using the ally.query.tabbable method:
+ * https://allyjs.io/api/query/focusable.html
+ *
+ * "Focusable" means the element or elements can receive
+ * keyboard focus natively by pressing `TAB` or `SHIFT + TAB`,
+ * and elements that have a tabindex="-1" attribute, and can be
+ * focused programmatically.
+ *
+ * @method allyCheckFocusableCount
+ * @param {string} [selector] The selector (CSS / Xpath) used to locate the element.
+ * @param {function} [callback] Optional callback function to be called when the command finishes.
+ * @returns {array} The array of focusable elements found in the selector.
+ * @api commands
+ */
+exports.command = function allyCheckFocusableCount(selector, callback) {
+  return this.execute(
+    sel => {
+      const focusableItems = ally.query.focusable({
+        context: sel,
+        includeContext: true,
+        strategy: 'strict',
+      });
+
+      return focusableItems;
+    },
+    [selector],
+    callback,
+  );
+};

--- a/packages/keyboard-e2e/test/commands/allyCheckFocusableCount.js
+++ b/packages/keyboard-e2e/test/commands/allyCheckFocusableCount.js
@@ -1,3 +1,5 @@
+/* eslint-disable func-names, prefer-arrow-callback */
+
 const ally = require('ally.js');
 
 /**
@@ -18,7 +20,7 @@ const ally = require('ally.js');
  */
 exports.command = function allyCheckFocusableCount(selector, callback) {
   return this.execute(
-    sel => {
+    function(sel) {
       const focusableItems = ally.query.focusable({
         context: sel,
         includeContext: true,

--- a/packages/keyboard-e2e/test/commands/allyCheckTabbableCount.js
+++ b/packages/keyboard-e2e/test/commands/allyCheckTabbableCount.js
@@ -1,0 +1,31 @@
+const ally = require('ally.js');
+
+/**
+ * Checks for the number of tabbable elements on the page,
+ * using the ally.query.tabbable method:
+ * https://allyjs.io/api/query/focusable.html
+ *
+ * "Tabbable" means the element or elements can receive
+ * keyboard focus natively by pressing `TAB` or `SHIFT + TAB`.
+ *
+ * @method allyCheckTabbableCount
+ * @param {string} [selector] The selector (CSS / Xpath) used to locate the element.
+ * @param {function} [callback] Optional callback function to be called when the command finishes.
+ * @returns {array} The array of tabbable elements found in the selector.
+ * @api commands
+ */
+exports.command = function allyCheckTabbableCount(selector, callback) {
+  return this.execute(
+    sel => {
+      const tabbableItems = ally.query.tabbable({
+        context: sel,
+        includeContext: true,
+        strategy: 'strict',
+      });
+
+      return tabbableItems;
+    },
+    [selector],
+    callback,
+  );
+};

--- a/packages/keyboard-e2e/test/commands/allyCheckTabbableCount.js
+++ b/packages/keyboard-e2e/test/commands/allyCheckTabbableCount.js
@@ -1,3 +1,5 @@
+/* eslint-disable func-names, prefer-arrow-callback */
+
 const ally = require('ally.js');
 
 /**
@@ -16,7 +18,7 @@ const ally = require('ally.js');
  */
 exports.command = function allyCheckTabbableCount(selector, callback) {
   return this.execute(
-    sel => {
+    function(sel) {
       const tabbableItems = ally.query.tabbable({
         context: sel,
         includeContext: true,

--- a/packages/keyboard-e2e/test/commands/allyConfirmFocusableObject.js
+++ b/packages/keyboard-e2e/test/commands/allyConfirmFocusableObject.js
@@ -1,0 +1,28 @@
+const ally = require('ally.js');
+
+/**
+ * Checks that Ally.js is returning an object of focusable elements
+ * https://allyjs.io
+ *
+ *
+ * @method allyConfirmFocusable
+ * @param {string} [selector] The selector (CSS / Xpath) used to locate the element
+ * @param {function} [callback] Optional callback function to be called when the command finishes.
+ * @returns {object} An object of one or more focusable elements.
+ * @api commands
+ */
+exports.command = function allyConfirmFocusableObject(selector, callback) {
+  return this.execute(
+    sel => {
+      const focusableItems = ally.query.focusable({
+        context: sel,
+        includeContext: true,
+        strategy: 'strict',
+      });
+
+      return focusableItems;
+    },
+    [selector],
+    callback,
+  );
+};

--- a/packages/keyboard-e2e/test/commands/allyConfirmFocusableObject.js
+++ b/packages/keyboard-e2e/test/commands/allyConfirmFocusableObject.js
@@ -1,3 +1,5 @@
+/* eslint-disable func-names, prefer-arrow-callback */
+
 const ally = require('ally.js');
 
 /**
@@ -13,7 +15,7 @@ const ally = require('ally.js');
  */
 exports.command = function allyConfirmFocusableObject(selector, callback) {
   return this.execute(
-    sel => {
+    function(sel) {
       const focusableItems = ally.query.focusable({
         context: sel,
         includeContext: true,

--- a/packages/keyboard-e2e/test/commands/allyConfirmTabbableObject.js
+++ b/packages/keyboard-e2e/test/commands/allyConfirmTabbableObject.js
@@ -1,3 +1,5 @@
+/* eslint-disable func-names, prefer-arrow-callback */
+
 const ally = require('ally.js');
 
 /**
@@ -13,7 +15,7 @@ const ally = require('ally.js');
  */
 exports.command = function allyCheckTabbable(selector, callback) {
   return this.execute(
-    sel => {
+    function(sel) {
       const tabbableItems = ally.query.tabbable({
         context: sel,
         includeContext: true,

--- a/packages/keyboard-e2e/test/commands/allyConfirmTabbableObject.js
+++ b/packages/keyboard-e2e/test/commands/allyConfirmTabbableObject.js
@@ -1,0 +1,27 @@
+const ally = require('ally.js');
+
+/**
+ * Checks that Ally.js is returning an object of tabbable elements
+ * https://allyjs.io
+ *
+ *
+ * @method allyCheckTabbale
+ * @param {string} [selector] The selector (CSS / Xpath) used to locate the element
+ * @param {function} [callback] Optional callback function to be called when the command finishes.
+ * @returns {object} An object of one or more tabbable elements.
+ * @api commands
+ */
+exports.command = function allyCheckTabbable(selector, callback) {
+  return this.execute(
+    sel => {
+      const tabbableItems = ally.query.tabbable({
+        context: sel,
+        includeContext: true,
+      });
+
+      return tabbableItems;
+    },
+    [selector],
+    callback,
+  );
+};

--- a/packages/keyboard-e2e/test/commands/allyDeepEquals.js
+++ b/packages/keyboard-e2e/test/commands/allyDeepEquals.js
@@ -1,3 +1,5 @@
+/* eslint-disable func-names, prefer-arrow-callback */
+
 const ally = require('ally.js');
 
 /**
@@ -19,7 +21,7 @@ const ally = require('ally.js');
  */
 exports.command = function allyDeepEquals(selector, callback) {
   return this.execute(
-    sel => {
+    function(sel) {
       const focusableItems = ally.query.focusable({
         context: sel,
         includeContext: true,

--- a/packages/keyboard-e2e/test/commands/allyDeepEquals.js
+++ b/packages/keyboard-e2e/test/commands/allyDeepEquals.js
@@ -1,0 +1,42 @@
+const ally = require('ally.js');
+
+/**
+ * Checks if the objects of focusable and tabbable elements are equal.
+ * This is useful for pages that might include tabindex="-1" on one or
+ * more elements. In that case, we'd expect the two objects not to be
+ * equal. All other cases assume objects should be equal.
+ * https://allyjs.io/api/query/focusable.html
+ *
+ * "Tabbable" means the element or elements can receive
+ * keyboard focus natively by pressing `TAB` or `SHIFT + TAB`,
+ * and elements that have a tabindex="-1" attribute, and can be
+ * focused programmatically.
+ *
+ * @method allyDeepEquals
+ * @param {string} [selector] The selector (CSS / Xpath) used to locate the element.
+ * @returns {array} [comparator] The array objects for focusable, and tabbable elements.
+ * @api commands
+ */
+exports.command = function allyDeepEquals(selector, callback) {
+  return this.execute(
+    sel => {
+      const focusableItems = ally.query.focusable({
+        context: sel,
+        includeContext: true,
+        strategy: 'strict',
+      });
+
+      const tabbableItems = ally.query.tabbable({
+        context: sel,
+        includeContext: true,
+        strategy: 'strict',
+      });
+
+      const comparator = [focusableItems.length, tabbableItems.length];
+
+      return comparator;
+    },
+    [selector],
+    callback,
+  );
+};

--- a/packages/keyboard-e2e/test/commands/checkActiveElement.js
+++ b/packages/keyboard-e2e/test/commands/checkActiveElement.js
@@ -1,3 +1,5 @@
+/* eslint-disable func-names, prefer-arrow-callback */
+
 /**
  * Checks if the given element is focused on the page.
  *
@@ -9,7 +11,9 @@
  */
 exports.command = function checkActiveElement(selector, callback) {
   return this.execute(
-    sel => document.querySelector(sel) === document.activeElement,
+    function(sel) {
+      return document.querySelector(sel) === document.activeElement;
+    },
     [selector],
     callback,
   );

--- a/packages/keyboard-e2e/test/commands/checkActiveElement.js
+++ b/packages/keyboard-e2e/test/commands/checkActiveElement.js
@@ -1,0 +1,16 @@
+/**
+ * Checks if the given element is focused on the page.
+ *
+ * @method checkActiveElement
+ * @param {string} selector The selector (CSS / Xpath) used to locate the element.
+ * @param {function} [callback] Optional callback function to be called when the command finishes.
+ * @returns {boolean}
+ * @api commands
+ */
+exports.command = function checkActiveElement(selector, callback) {
+  return this.execute(
+    sel => document.querySelector(sel) === document.activeElement,
+    [selector],
+    callback,
+  );
+};

--- a/packages/keyboard-e2e/test/commands/evaluateCheckboxes.js
+++ b/packages/keyboard-e2e/test/commands/evaluateCheckboxes.js
@@ -1,3 +1,5 @@
+/* eslint-disable func-names, prefer-arrow-callback */
+
 /**
  * Evaluate checkboxes for basic keyboard functionality:
  *
@@ -24,7 +26,7 @@ exports.command = function evaluateCheckboxes(selectorArray) {
   const element = selectorArray[0];
   const client = this;
 
-  return client.waitForElementVisible(element, 1000, () => {
+  return client.waitForElementVisible(element, 1000, function() {
     for (let i = 0; i < arrLength; i += 1) {
       this.assert
         .isActiveElement(selectorArray[i])

--- a/packages/keyboard-e2e/test/commands/evaluateCheckboxes.js
+++ b/packages/keyboard-e2e/test/commands/evaluateCheckboxes.js
@@ -1,0 +1,39 @@
+/**
+ * Evaluate checkboxes for basic keyboard functionality:
+ *
+ * Each checkbox can receive keyboard focus by pressing TAB
+ * Each checkbox can be toggled by pressing SPACE
+ *
+ * ```javascript
+ *  this.demoTest = function (client) {
+ *    client.evaluateCheckboxes([
+ *      "input[type="checkbox"]#1",
+ *      "input[type="checkbox"]#2",
+ *      "input[type="checkbox"]#3"
+ *    ]);
+ *  };
+ * ```
+ *
+ * @method evaluateCheckboxes
+ * @param {string} [selectorArray] The array of checkboxes to be evaluated
+ * @api commands
+ */
+exports.command = function evaluateCheckboxes(selectorArray) {
+  const { TAB } = this.Keys;
+  const arrLength = selectorArray.length;
+  const element = selectorArray[0];
+  const client = this;
+
+  return client.waitForElementVisible(element, 1000, () => {
+    for (let i = 0; i < arrLength; i += 1) {
+      this.assert
+        .isActiveElement(selectorArray[i])
+        .keys(this.Keys.SPACE)
+        .assert.attributeContains(element, 'checked', 'true');
+
+      if (i < arrLength - 1) {
+        client.keys(TAB);
+      }
+    }
+  });
+};

--- a/packages/keyboard-e2e/test/commands/evaluateRadioButtons.js
+++ b/packages/keyboard-e2e/test/commands/evaluateRadioButtons.js
@@ -1,3 +1,5 @@
+/* eslint-disable func-names, prefer-arrow-callback */
+
 /**
  * Evaluate radio buttons for basic forward keyboard functionality:
  *
@@ -25,7 +27,7 @@ exports.command = function evaluateRadioButtons(selectorArray, arrowPressed) {
   const element = selectorArray[0];
   const client = this;
 
-  return client.waitForElementVisible(element, 1000, () => {
+  return client.waitForElementVisible(element, 1000, function() {
     for (let i = 0; i < arrLength; i += 1) {
       this.assert.isActiveElement(selectorArray[i]).keys(arrowPressed);
     }

--- a/packages/keyboard-e2e/test/commands/evaluateRadioButtons.js
+++ b/packages/keyboard-e2e/test/commands/evaluateRadioButtons.js
@@ -1,0 +1,33 @@
+/**
+ * Evaluate radio buttons for basic forward keyboard functionality:
+ *
+ * Radio groups can receive keyboard focus by pressing TAB
+ * Each radio button can be checked by pressing the DOWN or
+ * RIGHT arrow keys.
+ *
+ * ```javascript
+ *  this.demoTest = function (client) {
+ *    client.evaluateRadioButtons([
+ *      "input[type="radio"]#1",
+ *      "input[type="radio"]#2",
+ *      "input[type="radio"]#3"
+ *    ], client.Keys.ARROW_DOWN);
+ *  };
+ * ```
+ *
+ * @method evaluateRadioButtons
+ * @param {string} [selectorArray] The array of radio buttons to be evaluated
+ * @param {object} [arrowPressed] Nightwatch Keys object. Expects ARROW_DOWN || ARROW_RIGHT.
+ * @api commands
+ */
+exports.command = function evaluateRadioButtons(selectorArray, arrowPressed) {
+  const arrLength = selectorArray.length;
+  const element = selectorArray[0];
+  const client = this;
+
+  return client.waitForElementVisible(element, 1000, () => {
+    for (let i = 0; i < arrLength; i += 1) {
+      this.assert.isActiveElement(selectorArray[i]).keys(arrowPressed);
+    }
+  });
+};

--- a/packages/keyboard-e2e/test/commands/evaluateRadioButtonsReverse.js
+++ b/packages/keyboard-e2e/test/commands/evaluateRadioButtonsReverse.js
@@ -1,0 +1,36 @@
+/**
+ * Evaluate radio buttons for basic reverse keyboard functionality:
+ *
+ * Radio groups can receive keyboard focus by pressing TAB
+ * Each radio button can be checked from bottom to top by pressing
+ * the UP or LEFT arrow keys.
+ *
+ * ```javascript
+ *  this.demoTest = function (client) {
+ *    client.evaluateRadioButtonsReverse([
+ *      "input[type="radio"]#1",
+ *      "input[type="radio"]#2",
+ *      "input[type="radio"]#3"
+ *    ], client.Keys.ARROW_UP);
+ *  };
+ * ```
+ *
+ * @method evaluateRadioButtonsReverse
+ * @param {string} [selectorArray] The array of radio buttons to be evaluated
+ * @param {object} [arrowPressed] Nightwatch Keys object. Expects ARROW_UP || ARROW_LEFT.
+ * @api commands
+ */
+exports.command = function evaluateRadioButtonsReverse(
+  selectorArray,
+  arrowPressed,
+) {
+  const arrLength = selectorArray.length;
+  const element = selectorArray[0];
+  const client = this;
+
+  return client.waitForElementVisible(element, 1000, () => {
+    for (let i = arrLength - 1; i >= 0; i -= 1) {
+      this.keys(arrowPressed).assert.isActiveElement(selectorArray[i]);
+    }
+  });
+};

--- a/packages/keyboard-e2e/test/commands/evaluateRadioButtonsReverse.js
+++ b/packages/keyboard-e2e/test/commands/evaluateRadioButtonsReverse.js
@@ -1,3 +1,5 @@
+/* eslint-disable func-names, prefer-arrow-callback */
+
 /**
  * Evaluate radio buttons for basic reverse keyboard functionality:
  *
@@ -28,7 +30,7 @@ exports.command = function evaluateRadioButtonsReverse(
   const element = selectorArray[0];
   const client = this;
 
-  return client.waitForElementVisible(element, 1000, () => {
+  return client.waitForElementVisible(element, 1000, function() {
     for (let i = arrLength - 1; i >= 0; i -= 1) {
       this.keys(arrowPressed).assert.isActiveElement(selectorArray[i]);
     }

--- a/packages/keyboard-e2e/test/commands/evaluateSelectMenu.js
+++ b/packages/keyboard-e2e/test/commands/evaluateSelectMenu.js
@@ -1,3 +1,5 @@
+/* eslint-disable func-names, prefer-arrow-callback */
+
 /**
  * Evaluate select menus for basic keyboard functionality:
  *

--- a/packages/keyboard-e2e/test/commands/evaluateSelectMenu.js
+++ b/packages/keyboard-e2e/test/commands/evaluateSelectMenu.js
@@ -1,0 +1,38 @@
+/**
+ * Evaluate select menus for basic keyboard functionality:
+ *
+ * Each select can receive keyboard focus by pressing TAB.
+ * Select menus should open with SPACE press, and user
+ * should be able to enter keys. This is an imperfect
+ * approximation, but Nightwatch doesn't support arrow
+ * keys for traversing options in the open select.
+ *
+ * ```javascript
+ *  this.demoTest = function (client) {
+ *    client.evaluateSelectMenu('selector', 'option text', 'option value');
+ *  };
+ * ```
+ *
+ * @method evaluateSelectMenu
+ * @param {string} [selectMenu] The selector (CSS / Xpath) used to locate the element.
+ * @param {string} [optionText] The text of the <option> that should be selected.
+ * @param {string} [selectedOption] Value attribute of the <option> that should be selected.
+ * @api commands
+ */
+module.exports.command = function evaluateSelectMenu(
+  selectMenu,
+  optionText,
+  selectedOption,
+) {
+  const { SPACE } = this.Keys;
+  const client = this;
+
+  return client.waitForElementVisible(selectMenu, 1000, () => {
+    this.assert
+      .isAllyDisabledElement(selectMenu, false)
+      .assert.isActiveElement(selectMenu)
+      .keys(SPACE)
+      .sendKeys(selectMenu, optionText)
+      .assert.value(selectMenu, selectedOption);
+  });
+};

--- a/packages/keyboard-e2e/test/commands/evaluateTextInput.js
+++ b/packages/keyboard-e2e/test/commands/evaluateTextInput.js
@@ -1,3 +1,5 @@
+/* eslint-disable func-names, prefer-arrow-callback */
+
 /**
  * Evaluate inputs and text areas for basic keyboard functionality:
  *

--- a/packages/keyboard-e2e/test/commands/evaluateTextInput.js
+++ b/packages/keyboard-e2e/test/commands/evaluateTextInput.js
@@ -1,0 +1,30 @@
+/**
+ * Evaluate inputs and text areas for basic keyboard functionality:
+ *
+ * Each select can receive keyboard focus by pressing TAB.
+ * Select menus should open with SPACE press, and user
+ * should be able to enter keys. This is an imperfect
+ * approximation, but Nightwatch doesn't support arrow
+ * keys for traversing options in the open select.
+ *
+ * ```javascript
+ *  this.demoTest = function (client) {
+ *    client.evaluateTextInput('selector', 'option text', 'option value');
+ *  };
+ * ```
+ *
+ * @method evaluateTextInput
+ * @param {string} [input] The selector (CSS / Xpath) used to locate the element.
+ * @param {string} [textValue] Text to be sent to input by Nightwatch sendKeys().
+ * @api commands
+ */
+module.exports.command = function evaluateTextInput(input, textValue) {
+  const client = this;
+
+  return client.waitForElementVisible(input, 1000, () => {
+    this.assert
+      .isActiveElement(input)
+      .sendKeys(input, textValue)
+      .assert.attributeContains(input, 'value', textValue);
+  });
+};

--- a/packages/keyboard-e2e/test/e2e/content-1.e2e.js
+++ b/packages/keyboard-e2e/test/e2e/content-1.e2e.js
@@ -1,0 +1,192 @@
+module.exports = {
+  // TODO: Add global import for common keys (ENTER, SPACE, TAB, ARROWS)
+  'CONTENT-1: Smoke test. Ensure ALLY.JS returns two objects': client => {
+    const body = client.globals.contentOne.body;
+    const url = client.globals.contentOne.url;
+
+    client
+      .url(url)
+      .waitForElementVisible(body)
+      .assert.isAllyFocusableObject(body)
+      .assert.isAllyTabbableObject(body);
+  },
+
+  'CONTENT-1: Assert ALLY.JS array lengths are correct for tabindex="-1"': client => {
+    const body = client.globals.contentOne.body;
+
+    client.assert.isAllyDeepEquals(body, false);
+  },
+
+  'CONTENT-1: Assert ALLY.JS expects the correct number of focusable elements': client => {
+    const body = client.globals.contentOne.body;
+
+    client.assert.isAllyFocusableCount(body, 18);
+  },
+
+  'CONTENT-1: Assert ALLY.JS expects the correct number of tabbable elements': client => {
+    const body = client.globals.contentOne.body;
+
+    client.assert.isAllyTabbableCount(body, 17);
+  },
+
+  'CONTENT-1: Assert the submit <button> is not disabled': client => {
+    const button = client.globals.contentOne.button;
+
+    client
+      .waitForElementVisible(button)
+      .assert.isAllyDisabledElement(button, false);
+  },
+
+  'CONTENT-1: Test the skip link functionality': client => {
+    const { ENTER, TAB } = client.Keys;
+    const mainContainer = client.globals.contentOne.main;
+    const skipNav = client.globals.contentOne.skipNav;
+
+    // Advance to skip nav link and start keyboard testing mocks
+    client.keys(TAB);
+
+    client.assert
+      .isActiveElement(skipNav)
+      .keys(ENTER)
+      .assert.isActiveElement(mainContainer);
+
+    // Advance to form
+    client.keys(TAB);
+  },
+
+  'CONTENT-1: Evaluate the name field for text entry': client => {
+    const { TAB } = client.Keys;
+    const name = client.globals.contentOne.textInputs.name.selector;
+    const textValue = client.globals.contentOne.textInputs.name.value;
+
+    client.evaluateTextInput(name, textValue);
+
+    // Advance to age input
+    client.keys(TAB);
+  },
+
+  'CONTENT-1: Evaluate the age field for text entry': client => {
+    const { TAB } = client.Keys;
+    const age = client.globals.contentOne.textInputs.age.selector;
+    const textValue = client.globals.contentOne.textInputs.age.value;
+
+    client.evaluateTextInput(age, textValue);
+
+    // Advance to email input
+    client.keys(TAB);
+  },
+
+  'CONTENT-1: Evaluate the email field for text entry': client => {
+    const { TAB } = client.Keys;
+    const email = client.globals.contentOne.textInputs.email.selector;
+    const textValue = client.globals.contentOne.textInputs.email.value;
+
+    client.evaluateTextInput(email, textValue);
+
+    // Advance to phone number input
+    client.keys(TAB);
+  },
+
+  'CONTENT-1: Evaluate the telephone field for text entry': client => {
+    const { TAB } = client.Keys;
+    const telephone = client.globals.contentOne.textInputs.telephone.selector;
+    const textValue = client.globals.contentOne.textInputs.telephone.value;
+
+    client.evaluateTextInput(telephone, textValue);
+
+    // Advance to optional Twitter input
+    client.keys(TAB);
+  },
+
+  'CONTENT-1: Evaluate the optional Twitter field for text entry': client => {
+    const { TAB } = client.Keys;
+    const twitter = client.globals.contentOne.textInputs.twitter.selector;
+    const textValue = client.globals.contentOne.textInputs.twitter.value;
+
+    client.evaluateTextInput(twitter, textValue);
+
+    // Advance to optional Keybase input
+    client.keys(TAB);
+  },
+
+  'CONTENT-1: Evaluate the optional Keybase field for blank entry': client => {
+    const { TAB } = client.Keys;
+    const keybase = client.globals.contentOne.textInputs.keybase.selector;
+    const textValue = client.globals.contentOne.textInputs.keybase.value;
+
+    client.evaluateTextInput(keybase, textValue);
+
+    // Advance to textarea
+    client.keys(TAB);
+  },
+
+  'CONTENT-1: Evalaute the social media textarea': client => {
+    const { TAB } = client.Keys;
+    const textarea = client.globals.contentOne.textAreas.socialMedia.selector;
+    const textValue = client.globals.contentOne.textAreas.socialMedia.value;
+
+    client.evaluateTextInput(textarea, textValue);
+
+    // Advance to checkbox group
+    client.keys(TAB);
+  },
+
+  'CONTENT-1: Evaluate checkbox SPACEBAR interaction': client => {
+    const { TAB } = client.Keys;
+    const checkboxes = client.globals.contentOne.checkboxes;
+
+    client.evaluateCheckboxes(checkboxes);
+
+    // Advance to radio button group
+    client.keys(TAB);
+  },
+
+  'CONTENT-1: Evaluate radio buttons for ARROW_DOWN and ARROW_RIGHT': client => {
+    const { ARROW_DOWN, ARROW_RIGHT } = client.Keys;
+    const radioButtons = client.globals.contentOne.radioButtons;
+
+    client.evaluateRadioButtons(radioButtons, ARROW_DOWN);
+    client.evaluateRadioButtons(radioButtons, ARROW_RIGHT);
+  },
+
+  'CONTENT-1: Evaluate radio buttons for ARROW_UP and ARROW_LEFT': client => {
+    const { ARROW_UP, ARROW_LEFT, TAB } = client.Keys;
+    const radioButtons = client.globals.contentOne.radioButtons;
+
+    client.evaluateRadioButtonsReverse(radioButtons, ARROW_UP);
+    client.evaluateRadioButtonsReverse(radioButtons, ARROW_LEFT);
+
+    // Advance to select menu
+    client.keys(TAB);
+  },
+
+  'CONTENT-1: Evaluate the select menu': client => {
+    const { TAB } = client.Keys;
+    const select = client.globals.contentOne.select;
+    const optionText = 'What is your favorite sports team?';
+    const selectedOption = 'value3';
+
+    client.evaluateSelectMenu(select, optionText, selectedOption);
+
+    // Advance to submit button
+    client.keys(TAB);
+  },
+
+  // TODO: Add a button submit helper function
+  'CONTENT-1: Assert button can submit form by pressing SPACEBAR': client => {
+    const { SPACE } = client.Keys;
+    const button = client.globals.contentOne.button;
+
+    client.assert
+      .elementPresent(button)
+      .assert.isActiveElement(button)
+      .keys(SPACE)
+      .assert.urlContains(
+        'http://localhost:8080/content/content1.html?name=Josephine+Rogers&age=29&email=josephine%40test.com&telephone=5551234567&twitter=itsjrogers&keybase=&checkbox-contacts=checkbox-email&checkbox-contacts=checkbox-telephone&checkbox-contacts=checkbox-twitter&checkbox-contacts=checkbox-keybase&radio-subscribe=radio-yes#',
+      );
+  },
+
+  after: client => {
+    client.end();
+  },
+};

--- a/packages/keyboard-e2e/test/e2e/index.e2e.js
+++ b/packages/keyboard-e2e/test/e2e/index.e2e.js
@@ -1,0 +1,18 @@
+module.exports = {
+  'INDEX: Assert 1 TAB to load page Content 1': client => {
+    const { ENTER, TAB } = client.Keys;
+
+    client
+      .url('http://localhost:8080')
+      .waitForElementVisible('[data-nwId="body-index"]')
+      .assert.visible('a.native-focusable')
+      .assert.isActiveElement('body')
+      .keys(TAB)
+      .assert.isActiveElement('a[data-nwId="link-content-1"]')
+      .keys(ENTER)
+      .waitForElementVisible('[data-nwId="content-1-body"]')
+      .assert.urlContains('http://localhost:8080/content/content1.html');
+
+    client.end();
+  },
+};

--- a/packages/keyboard-e2e/test/globals/index.js
+++ b/packages/keyboard-e2e/test/globals/index.js
@@ -1,0 +1,56 @@
+const contentOne = {
+  body: '[data-nwId="content-1-body"]',
+  button: 'button[data-nwId="content-1-form-1-button-1"]',
+  form: '[data-nwId="content-1-form-1"]',
+  main: '#main-container',
+  select: '[data-nwId="content-1-form-1-select-1"]',
+  skipNav: '#skip-nav',
+  url: 'http://localhost:8080/content/content1.html',
+  checkboxes: [
+    '[data-nwId="content-1-form-1-checkbox-1"]',
+    '[data-nwId="content-1-form-1-checkbox-2"]',
+    '[data-nwId="content-1-form-1-checkbox-3"]',
+    '[data-nwId="content-1-form-1-checkbox-4"]',
+  ],
+  radioButtons: [
+    '[data-nwId="content-1-form-1-radio-1"]',
+    '[data-nwId="content-1-form-1-radio-2"]',
+    '[data-nwId="content-1-form-1-radio-3"]',
+  ],
+  textInputs: {
+    name: {
+      selector: '[data-nwId="content-1-form-1-input-1"]',
+      value: 'Josephine Rogers',
+    },
+    age: {
+      selector: '[data-nwId="content-1-form-1-input-2"]',
+      value: '29',
+    },
+    email: {
+      selector: '[data-nwId="content-1-form-1-input-3"]',
+      value: 'josephine@test.com',
+    },
+    telephone: {
+      selector: '[data-nwId="content-1-form-1-input-4"]',
+      value: '5551234567',
+    },
+    twitter: {
+      selector: '[data-nwId="content-1-form-1-input-5"]',
+      value: 'itsjrogers',
+    },
+    keybase: {
+      selector: '[data-nwId="content-1-form-1-input-6"]',
+      value: '',
+    },
+  },
+  textAreas: {
+    socialMedia: {
+      selector: '[data-nwId="content-1-form-textarea-1"]',
+      value: 'Instagram is my preferred social media',
+    },
+  },
+};
+
+module.exports = {
+  contentOne,
+};

--- a/packages/keyboard-e2e/webpack.config.js
+++ b/packages/keyboard-e2e/webpack.config.js
@@ -1,0 +1,51 @@
+const path = require("path");
+const CopyWebpackPlugin = require("copy-webpack-plugin");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+
+module.exports = {
+  entry: ["./src/js/index.js"],
+  output: {
+    path: path.resolve(__dirname, "dist"),
+    filename: "js/[name].bundle.js"
+  },
+  module: {
+    rules: [
+      {
+        test: /\.m?.js$/,
+        exclude: /node_modules/,
+        use: {
+          loader: "babel-loader",
+          options: {
+            presets: ["@babel/preset-env"]
+          }
+        }
+      },
+      {
+        test: /\.css$/,
+        use: [
+          {
+            loader: MiniCssExtractPlugin.loader
+          },
+          {
+            loader: "css-loader",
+            options: {
+              import: true
+            }
+          }
+        ]
+      }
+    ]
+  },
+  mode: "production",
+  plugins: [
+    new CopyWebpackPlugin([
+      { from: "src/index.html" },
+      { from: "src/content", to: "content" }
+    ]),
+    new MiniCssExtractPlugin({ filename: "css/[name].bundle.css" })
+  ],
+  devServer: {
+    contentBase: path.join(__dirname, "dist"),
+    port: 8080
+  }
+};


### PR DESCRIPTION
## Description
I've been working on a suite of helper methods for Nightwatch, to mock and automate [happy path](https://en.wikipedia.org/wiki/Happy_path) keyboard navigation. The goal of this project is to show how those methods could be put together to test a simple form, and to ensure the right level of abstraction. I want to promote widespread use and felt making these one-line helpers was the way to go.

## Testing done
1. Entire suite run locally while developing. All 69 assertions passing.
2. Lots of documentation on each method in JSDoc format
3. Footnotes.md file with related troubleshooting and documentation

## Screenshots
![Screen Shot 2019-12-17 at 12 46 55 PM](https://user-images.githubusercontent.com/934879/71024820-613c1980-20cb-11ea-905a-02b6841828b6.png)


## Acceptance criteria
- [ ] Methods are abstracted correctly
- [ ] Documentation is deemed complete by reviewers

## Definition of done
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
