### PR TITLE
bradl3yC 4560 Reset state and wait for teardown complete

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/modal/Modal.jsx
+++ b/packages/formation-react/src/components/modal/Modal.jsx
@@ -26,6 +26,7 @@ class Modal extends React.Component {
   componentWillUnmount() {
     if (this.props.visible) {
       this.teardownModal();
+      this.setState({ lastFocus: null })
     }
   }
 
@@ -45,7 +46,6 @@ class Modal extends React.Component {
       setTimeout(() => {
         this.state.lastFocus.focus();
       }, 0)
-      this.setState({ lastFocus: null })
     }
     document.body.classList.remove('modal-open');
     document.removeEventListener('keydown', this.handleDocumentKeyDown, false);

--- a/packages/formation-react/src/components/modal/Modal.jsx
+++ b/packages/formation-react/src/components/modal/Modal.jsx
@@ -17,7 +17,6 @@ class Modal extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (!prevProps.visible && this.props.visible) {
-      this.setState({ lastFocus: document.activeElement });
       this.setupModal();
     } else if (prevProps.visible && !this.props.visible) {
       this.teardownModal();
@@ -31,6 +30,7 @@ class Modal extends React.Component {
   }
 
   setupModal() {
+    this.setState({ lastFocus: document.activeElement });
     this.applyFocusToFirstModalElement();
     document.body.classList.add('modal-open');
     document.addEventListener('keydown', this.handleDocumentKeyDown, false);

--- a/packages/formation-react/src/components/modal/Modal.jsx
+++ b/packages/formation-react/src/components/modal/Modal.jsx
@@ -95,8 +95,6 @@ class Modal extends React.Component {
       this.props.focusSelector,
     );
     if (focusableElement) {
-      // we only want to set `lastFocus` when the modal first pops up, not every
-      // time the user tabs through all elements in the modal
       focusableElement.focus();
     }
   }

--- a/packages/formation-react/src/components/modal/Modal.jsx
+++ b/packages/formation-react/src/components/modal/Modal.jsx
@@ -45,6 +45,7 @@ class Modal extends React.Component {
       setTimeout(() => {
         this.state.lastFocus.focus();
       }, 0)
+      this.setState({ lastFocus: null })
     }
     document.body.classList.remove('modal-open');
     document.removeEventListener('keydown', this.handleDocumentKeyDown, false);
@@ -52,7 +53,6 @@ class Modal extends React.Component {
     if (this.props.clickToClose) {
       document.removeEventListener('click', this.handleDocumentClicked, true);
     }
-    this.setState({ lastFocus: null })
   }
 
   handleDocumentKeyDown = event => {

--- a/packages/formation-react/src/components/modal/Modal.jsx
+++ b/packages/formation-react/src/components/modal/Modal.jsx
@@ -41,7 +41,10 @@ class Modal extends React.Component {
 
   teardownModal() {
     if (this.state.lastFocus) {
-      this.state.lastFocus.focus();
+      // Ensure last focus is set before completing modal teardown
+      setTimeout(() => {
+        this.state.lastFocus.focus();
+      }, 0)
     }
     document.body.classList.remove('modal-open');
     document.removeEventListener('keydown', this.handleDocumentKeyDown, false);
@@ -49,6 +52,7 @@ class Modal extends React.Component {
     if (this.props.clickToClose) {
       document.removeEventListener('click', this.handleDocumentClicked, true);
     }
+    this.setState({ lastFocus: null })
   }
 
   handleDocumentKeyDown = event => {

--- a/packages/formation-react/src/components/modal/Modal.jsx
+++ b/packages/formation-react/src/components/modal/Modal.jsx
@@ -17,6 +17,7 @@ class Modal extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (!prevProps.visible && this.props.visible) {
+      this.setState({ lastFocus: document.activeElement });
       this.setupModal();
     } else if (prevProps.visible && !this.props.visible) {
       this.teardownModal();
@@ -26,7 +27,6 @@ class Modal extends React.Component {
   componentWillUnmount() {
     if (this.props.visible) {
       this.teardownModal();
-      this.setState({ lastFocus: null })
     }
   }
 
@@ -97,9 +97,6 @@ class Modal extends React.Component {
     if (focusableElement) {
       // we only want to set `lastFocus` when the modal first pops up, not every
       // time the user tabs through all elements in the modal
-      if (!this.state.lastFocus) {
-        this.setState({ lastFocus: document.activeElement });
-      }
       focusableElement.focus();
     }
   }


### PR DESCRIPTION
## Description
- [x] - Add a pause before updating component to allow for modal teardown func to complete
- [x] - Reset state back to null before closing

## Testing done
- [x] - Tested locally using yalc - performs as needed

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
