### PR TITLE
[PromoBanner] Add support for long text

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "5.1.0--beta-promobanner",
+  "version": "5.1.0",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "5.0.2",
+  "version": "5.1.0--beta-promobanner",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",
@@ -33,7 +33,7 @@
     "react-transition-group": "1"
   },
   "peerDependencies": {
-    "@department-of-veterans-affairs/formation": "^6.7.3",
+    "@department-of-veterans-affairs/formation": "^6.9.0",
     "react": "^15.5.4||^16.7.0"
   }
 }

--- a/packages/formation-react/src/components/PromoBanner/PromoBanner.jsx
+++ b/packages/formation-react/src/components/PromoBanner/PromoBanner.jsx
@@ -24,14 +24,14 @@ function PromoBanner({ type, onClose, render, href, target, text }) {
   return (
     <div className="vads-c-promo-banner">
       <div className="vads-c-promo-banner__body">
-        <div className="vads-c-promo-banner__content">
-          <div className="vads-c-promo-banner__content-icon">
-            <span className="fa-stack fa-lg">
-              <i className="vads-u-color--white fa fa-circle fa-stack-2x" />
-              <i className={iconClasses} />
-            </span>
-          </div>
+        <div className="vads-c-promo-banner__icon">
+          <span className="fa-stack fa-lg">
+            <i className="vads-u-color--white fa fa-circle fa-stack-2x" />
+            <i className={iconClasses} />
+          </span>
+        </div>
 
+        <div className="vads-c-promo-banner__content">
           {render ? (
             render()
           ) : (

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.8.0",
+  "version": "6.9.0--beta-promobanner",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.9.0--beta-promobanner",
+  "version": "6.9.0",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/modules/_m-promo-banner.scss
+++ b/packages/formation/sass/modules/_m-promo-banner.scss
@@ -23,9 +23,6 @@
 .vads-c-promo-banner__content {
   padding: units(1);
   line-height: units(2.5);
-  @include media($medium-screen) {
-    // padding-left: 0;
-  }
 }
 
 .vads-c-promo-banner__icon {

--- a/packages/formation/sass/modules/_m-promo-banner.scss
+++ b/packages/formation/sass/modules/_m-promo-banner.scss
@@ -16,7 +16,7 @@
   margin: 0 auto;
 }
 
-.vads-c-promo-banner__content, .vads-c-promo-banner__close {
+.vads-c-promo-banner__content, .vads-c-promo-banner__close, .vads-c-promo-banner__icon {
   display: table-cell;
 }
 
@@ -24,15 +24,17 @@
   padding: units(1);
   line-height: units(2.5);
   @include media($medium-screen) {
-    padding-left: 0;
+    // padding-left: 0;
   }
 }
 
-.vads-c-promo-banner__content-icon {
+.vads-c-promo-banner__icon {
+  width: 54px;
   margin-right: units(1);
+  padding: units(1) 0;
   display: none;
   @include media($medium-screen) {
-    display: inline-block;
+    display: table-cell;
   }
 }
 


### PR DESCRIPTION
## Description
Because of the work being done in https://github.com/department-of-veterans-affairs/va.gov-team/issues/4700, we need the Promo Banner component to accept a long string of text. Currently, the long text will fall below the icon.

This changes the HTML, so we'll have to update the sample HTML in the docs too, https://github.com/department-of-veterans-affairs/vets-design-system-documentation/blob/master/src/_components/promo-banners.md.

## Testing done
Locally messed with component on different viewports

## Screenshots

### With long text
#### Before
![image](https://user-images.githubusercontent.com/1915775/72110539-6d9c4680-3306-11ea-9310-73750c2cf3a2.png)

#### After
![image](https://user-images.githubusercontent.com/1915775/72110550-768d1800-3306-11ea-801d-220718418a1c.png)

### With short text
(no effect)
![image](https://user-images.githubusercontent.com/1915775/72110638-b2c07880-3306-11ea-9f58-6df08fcbc9ff.png)


## Acceptance criteria
- [x] Long strings are supported by promo banner

## Definition of done
- [x] Changes have been tested in vets-website
- [x] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
