### PR TITLE
Update formation-react docs

### DIFF
--- a/packages/documentation/gatsby-config.js
+++ b/packages/documentation/gatsby-config.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 module.exports = {
   siteMetadata: {
-    description: `Resources and documention for the Development within the VA.gov project`,
+    description: `Resources and documentation for Development within the VA.gov project`,
     siteUrl: `https://department-of-veterans-affairs.github.io/veteran-facing-services-tools`,
     title: `VA.gov | Client Application Documentation`,
     sidebar: require('./src/sidebar.js')

--- a/packages/documentation/src/pages/getting-started/common-tasks/previewing-changes.md
+++ b/packages/documentation/src/pages/getting-started/common-tasks/previewing-changes.md
@@ -1,36 +1,46 @@
-# Making changes to design-system/formation and previewing them
-As you work in the `design-system` repo, you'll want to preview how your changes look in an app that uses `formation` or `formation-react`. To do this, we use [Yalc](https://github.com/whitecolor/yalc) to publish the modules locally, rather than to NPM, and tell the consuming app to install that local version. In these examples, for the sake of simplicity, we'll assume you are using `vets-website` as the consuming app and are trying to preview changes in `formation-react`. But instructions should be similar for any app using `formation-react` or `formation`.
+---
+title: Making and Previewing Changes to formation-react
+tags: formation-react, update, preview
+---
 
-## Getting set up
+## Making changes to formation-react and previewing them
+As you work on `formation-react`, you'll want to preview how your changes look in an app that uses `formation-react`. To do this, we use [Yalc](https://github.com/whitecolor/yalc) to publish the modules locally, rather than to NPM, and tell the consuming app to install that local version. In these examples, for the sake of simplicity, we'll assume you are using `vets-website` as the consuming app and are trying to preview changes in `formation-react`. But instructions should be similar for any app using `formation-react`.
+
+### Getting set up
 First, install Yalc globally if you haven't already: `yarn global add yalc`.
 
-While in the `design-system` app:
-1. Run `npm run build` to build the module into the `packages/formation-react` dir.
-2. `cd` to `packages/formation-react`
-2. Run `yalc publish` to publish the module to your local `~/.yalc` dir.
+While in the `veteran-facing-services-tools` repo:
+
+1. `cd` to `packages/formation-react`
+2. Run `yarn build` to build the module into the `packages/formation-react` dir.
+3. Run `yalc publish` to publish the module to your local `~/.yalc` dir.
 
 Then in the consuming app (`vets-website`):
+
 1. Run `yalc link @department-of-veterans-affairs/formation-react` to tell the `vets-website` project to use the local version of `formation-react` instead of the one installed via NPM (i.e. the `formation-react` dir in `node_modules` will now be a symlink to a dir in `~/.yalc`).
 2. Fire up the website locally with `yarn watch`.
 
-The locally running project, at `localhost:3001`, will now be using the locally published version of `formation`.
+The locally running project, at `localhost:3001`, will now be using the locally published version of `formation-react`.
 
-## The change-publish-preview loop
-With each change you make to the `design-system`, you'll need to rebuild the module, republish the `formation-react` module to `~/.yalc`, and also tell the consuming app to use the new version.
+### The change-publish-preview loop
+With each change you make to `formation-react`, you'll need to rebuild the module, republish the `formation-react` module to `~/.yalc`, and also tell the consuming app to use the new version.
 
-While in the `design-system` app:
+While in the `packages/formation-react` directory:
+
 1. Make some changes to the code.
-2. Build the module and publish it locally to `~/.yalc` by running `npm run build`, `cd`ing to `packages/formation-react`, and running `yalc publish`.
+2. Build the module and publish it locally to `~/.yalc` by running `npm run build` and then running `yalc publish`.
 
 Then in the consuming app:
+
 1. Run `yalc update` to bring in the latest version of `formation-react`.
 2. If you are using `vets-website` as your consuming app and it is already running, it should notice the changes and rebuild. If not, restart the app locally.
 3. After rebuilding completes, your changes will now be visible locally at `localhost:3001`.
 
-## Tearing down the local testing setup
+### Tearing down the local testing setup
 When you are done testing your module locally, you'll want to get your consuming app back to normal; that is, tell it to stop using the version of `formation-react` published to `~/.yalc` and go back to using the version from NPM.
 
 In the consuming app:
+
 1. run `yalc remove @department-of-veterans-affairs/formation-react` to remove the link from the consuming app's `node_modules` dir to the local version of `formation-react`.
 2. **NOTE:** There seems to be [an issue](https://github.com/whitecolor/yalc/issues/37) with Yalc not cleaning up after itself properly, so you'll have to also run `unlink node_modules/@department-of-veterans-affairs/formation-react`
 3. Run `yarn install --check-files` to reinstall `formation-react` from NPM. (If you're curious about why you need the `--check-files` flag, [check out this issue](https://github.com/yarnpkg/yarn/issues/2240).)

--- a/packages/documentation/src/pages/getting-started/common-tasks/updating-formation.mdx
+++ b/packages/documentation/src/pages/getting-started/common-tasks/updating-formation.mdx
@@ -1,5 +1,5 @@
 ---
-title: Updating Formation and Formataion React
+title: Updating Formation and Formation React
 tags: formation, formation-react, update, release, publish, npm
 ---
 
@@ -9,7 +9,7 @@ You can find a detailed guide on contributing to formation at [https://dev-desig
 ## Making updates to formation-react
 1. Components should be created and tested in vets-website first before being moved over to formation-react
 2. Transfer component to formation-react
-3. Test the formation-react version of the component in vets-website before publishing [Check out these instructions on how to do so](/previewing-changes)
+3. Test the formation-react version of the component in vets-website before publishing. [Check out these instructions on how to do so](./previewing-changes).
 4. Write component tests
 5. [Create your react component documentation](/documentation-guide/doc-page)
 


### PR DESCRIPTION
## Description
I noticed that the link from the Updating Formation page to the Previewing Changes page was broken. Also the Previewing Changes document was out of date and not as clear as it could have been.

## Testing done
Local (note: running the doc site locally is painful because every time you have to rebuild the site it redownloads the entire va.gov-team repo (many gigs) as part of its build process)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs