### PR TITLE
Swap a tag to button tag

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/SortableTable/SortableTable.jsx
+++ b/packages/formation-react/src/components/SortableTable/SortableTable.jsx
@@ -80,7 +80,7 @@ class SortableTable extends Component {
     return (
       <th key={field.value}>
         <button
-          className="va-button-link"
+          className="va-button-link vads-u-font-weight--bold vads-u-color--base vads-u-text-decoration--none"
           onClick={this.onHeaderClick(field.value, nextSortOrder)}
           role="button"
           tabIndex="0"

--- a/packages/formation-react/src/components/SortableTable/SortableTable.jsx
+++ b/packages/formation-react/src/components/SortableTable/SortableTable.jsx
@@ -79,14 +79,15 @@ class SortableTable extends Component {
 
     return (
       <th key={field.value}>
-        <a
+        <button
+          className="va-button-link"
           onClick={this.onHeaderClick(field.value, nextSortOrder)}
           role="button"
           tabIndex="0"
         >
           {field.label}
           {sortIcon}
-        </a>
+        </button>
       </th>
     );
   };

--- a/packages/formation-react/src/components/SortableTable/SortableTable.jsx
+++ b/packages/formation-react/src/components/SortableTable/SortableTable.jsx
@@ -82,7 +82,6 @@ class SortableTable extends Component {
         <button
           className="va-button-link vads-u-font-weight--bold vads-u-color--base vads-u-text-decoration--none"
           onClick={this.onHeaderClick(field.value, nextSortOrder)}
-          role="button"
           tabIndex="0"
         >
           {field.label}


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/4558

**Current Behavior:** There's an a tag for header cells.

**Desired Behavior:** The header cells should be buttons.

This PR implements the above behavior.

## Testing done
N/A

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/72923076-885dba80-3d0b-11ea-8f4a-cc4b5a158f8b.png)

## Acceptance criteria
- [x] Swap `<a />` tag to `<button />` tag for column header cells in `<SortableTable />`.

## Definition of done
- [x] Changes have been tested in vets-website
- [x] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
