### PR TITLE
Add/modify props for <Breadcrumbs /> and <Pagination />

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "5.1.1",
+  "version": "5.2.0",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/Breadcrumbs/Breadcrumbs.jsx
+++ b/packages/formation-react/src/components/Breadcrumbs/Breadcrumbs.jsx
@@ -28,16 +28,11 @@ class Breadcrumbs extends Component {
   };
 
   render() {
-    const { ariaLabel, customClasses, className, id, listId, mobileFirstProp } = this.props;
+    const { ariaLabel, className, id, listId, mobileFirstProp } = this.props;
 
     // Derive IDs.
     const breadcrumbId = id || uniqueId('va-breadcrumbs-');
     const breadcrumbListId = listId || uniqueId('va-breadcrumbs-list-');
-
-    // Warn if they are using legacy props.
-    if (customClasses) {
-      console.warn('The prop `customClasses` for the <Breadcrumbs /> component has been deprecated. Please use the prop `className` instead.')
-    }
 
     return (
       <nav

--- a/packages/formation-react/src/components/Breadcrumbs/Breadcrumbs.jsx
+++ b/packages/formation-react/src/components/Breadcrumbs/Breadcrumbs.jsx
@@ -1,6 +1,7 @@
+// Node modules.
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import React from 'react';
-import classNames from 'classnames';
+import classnames from 'classnames';
 import { uniqueId } from 'lodash';
 
 /**
@@ -10,19 +11,7 @@ import { uniqueId } from 'lodash';
  * The component also accepts hard-coded A or LINK elements
  * as props.children.
  */
-class Breadcrumbs extends React.Component {
-  /**
-   * Provide a means to add overriding classes
-   */
-  classNames() {
-    const customClass = this.props.customClasses;
-    const mobileFirst = this.props.mobileFirstProp
-      ? 'va-nav-breadcrumbs--mobile'
-      : null;
-
-    return classNames('va-nav-breadcrumbs', mobileFirst, customClass);
-  }
-
+class Breadcrumbs extends Component {
   /**
    * Build the breadcrumb links. Convert children to an array,
    * pop and add aria-current to last item, build a set of
@@ -39,16 +28,26 @@ class Breadcrumbs extends React.Component {
   };
 
   render() {
-    const { ariaLabel, mobileFirstProp } = this.props;
-    const breadcrumbId = this.props.id || uniqueId('va-breadcrumbs-');
-    const breadcrumbListId =
-      this.props.listId || uniqueId('va-breadcrumbs-list-');
+    const { ariaLabel, customClasses, className, id, listId, mobileFirstProp } = this.props;
+
+    // Derive IDs.
+    const breadcrumbId = id || uniqueId('va-breadcrumbs-');
+    const breadcrumbListId = listId || uniqueId('va-breadcrumbs-list-');
+
+    // Warn if they are using legacy props.
+    if (customClasses) {
+      console.warn('The prop `customClasses` for the <Breadcrumbs /> component has been deprecated. Please use the prop `className` instead.')
+    }
 
     return (
       <nav
         aria-label={ariaLabel}
         aria-live="polite"
-        className={this.classNames()}
+        className={classnames({
+          'va-nav-breadcrumbs': true,
+          'va-nav-breadcrumbs--mobile': !!mobileFirstProp,
+          [className]: !!className,
+        })}
         data-mobile-first={mobileFirstProp}
         id={breadcrumbId}
       >
@@ -77,7 +76,7 @@ Breadcrumbs.propTypes = {
   /**
    * Optionally adds one or more CSS classes to the NAV element
    */
-  customClasses: PropTypes.string,
+  className: PropTypes.string,
   /**
    * Adds a custom id attribute to the NAV element
    */

--- a/packages/formation-react/src/components/Breadcrumbs/Breadcrumbs.mdx
+++ b/packages/formation-react/src/components/Breadcrumbs/Breadcrumbs.mdx
@@ -30,9 +30,9 @@ The breadcrumb component switches to a single previous step link when the screen
 
 Passing prop `ariaLabel="<STRING>"` to the `<Breadcrumbs />` component will override the default `aria-label="Breadcrumb"` declaration. If you plan to add a unique aria-label, please consider testing with one or more assistive devices to ensure proper context.
 
-### customClasses (STRING)
+### className (STRING)
 
-Passing prop `customClasses="<STRING STRING>"` to the `<Breadcrumbs />` component will append your space-separated classes to the `<nav class="va-nav-breadcrumbs">` class list.
+Passing prop `className="<STRING STRING>"` to the `<Breadcrumbs />` component will append your space-separated classes to the `<nav class="va-nav-breadcrumbs">` class list.
 
 ### id (STRING)
 

--- a/packages/formation-react/src/components/Breadcrumbs/Breadcrumbs.unit.spec.jsx
+++ b/packages/formation-react/src/components/Breadcrumbs/Breadcrumbs.unit.spec.jsx
@@ -42,7 +42,7 @@ describe('<Breadcrumbs>', () => {
     const tree = shallow(
       <Breadcrumbs
         ariaLabel="Breadcrumb foo"
-        customClasses="foo test"
+        className="foo test"
         id="foo"
         listId="foo-list"
       >

--- a/packages/formation-react/src/components/Pagination/Pagination.jsx
+++ b/packages/formation-react/src/components/Pagination/Pagination.jsx
@@ -1,19 +1,26 @@
-/* eslint-disable */
+// Node modules.
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component } from 'react';
 import classNames from 'classnames';
 import range from 'lodash/range';
 
-class Pagination extends React.Component {
-  constructor(props) {
-    super(props);
-    this.next = this.next.bind(this);
-    this.prev = this.prev.bind(this);
-    this.last = this.last.bind(this);
-    this.pageNumbers = this.pageNumbers.bind(this);
-  }
+class Pagination extends Component {
+  static propTypes = {
+    ariaLabelSuffix: PropTypes.string,
+    className: PropTypes.string,
+    maxPageListLength: PropTypes.number.isRequired,
+    onPageSelect: PropTypes.func.isRequired,
+    page: PropTypes.number.isRequired,
+    pages: PropTypes.number.isRequired,
+    showLastPage: PropTypes.bool,
+  };
 
-  next() {
+  static defaultProps = {
+    ariaLabelSuffix: '',
+    maxPageListLength: 10,
+  };
+
+  next = () => {
     let nextPage;
     if (this.props.pages > this.props.page) {
       nextPage = (
@@ -29,7 +36,7 @@ class Pagination extends React.Component {
     return nextPage;
   }
 
-  prev() {
+  prev = () => {
     let prevPage;
     if (this.props.page > 1) {
       prevPage = (
@@ -45,7 +52,7 @@ class Pagination extends React.Component {
     return prevPage;
   }
 
-  last() {
+  last = () => {
     const {
       maxPageListLength,
       page: currentPage,
@@ -69,7 +76,7 @@ class Pagination extends React.Component {
     return lastPage;
   }
 
-  pageNumbers() {
+  pageNumbers = () => {
     const {
       maxPageListLength,
       page: currentPage,
@@ -117,21 +124,24 @@ class Pagination extends React.Component {
   }
 
   render() {
-    if (this.props.pages === 1) {
+    const { ariaLabelSuffix, className, onPageSelect, page, pages } = this.props;
+
+    // Do not render if there's only 1 page.
+    if (pages === 1) {
       return <div/>;
     }
 
     const pageList = this.pageNumbers().map((pageNumber) => {
       const pageClass = classNames({
-        'va-pagination-active': this.props.page === pageNumber
+        'va-pagination-active': page === pageNumber
       });
 
       return (
         <a
           key={pageNumber}
           className={pageClass}
-          aria-label={`Load page ${pageNumber} ${this.props.ariaLabelSuffix}`}
-          onClick={() => this.props.onPageSelect(pageNumber)}
+          aria-label={`Load page ${pageNumber} ${ariaLabelSuffix}`}
+          onClick={() => onPageSelect(pageNumber)}
           onKeyDown={e => this.handleKeyDown(e, pageNumber)}
           tabIndex="0">
           {pageNumber}
@@ -140,7 +150,10 @@ class Pagination extends React.Component {
     });
 
     return (
-      <div className="va-pagination">
+      <div className={classNames({
+        'va-pagination': true,
+        [className]: className,
+      })}>
         <span className="va-pagination-prev">{this.prev()}</span>
         <div className="va-pagination-inner">
           {pageList} {this.last()}
@@ -150,19 +163,5 @@ class Pagination extends React.Component {
     );
   }
 }
-
-Pagination.propTypes = {
-  onPageSelect: PropTypes.func.isRequired,
-  page: PropTypes.number.isRequired,
-  pages: PropTypes.number.isRequired,
-  maxPageListLength: PropTypes.number.isRequired,
-  showLastPage: PropTypes.bool,
-  ariaLabelSuffix: PropTypes.string,
-};
-
-Pagination.defaultProps = {
-  maxPageListLength: 10,
-  ariaLabelSuffix: '',
-};
 
 export default Pagination;

--- a/packages/formation-react/src/components/Pagination/Pagination.mdx
+++ b/packages/formation-react/src/components/Pagination/Pagination.mdx
@@ -19,6 +19,7 @@ state = {
 import Pagination from '@department-of-veterans-affairs/formation-react/Pagination'
 
 <Pagination
+  className="custom-class"
   onPageSelect={(page) => this.setState({ page })}
   page={this.state.page}
   pages={3}
@@ -40,6 +41,7 @@ export class RenderedComponent extends React.Component {
     return (
       <div className="site-c-reactcomp__rendered">
         <Pagination
+          className="custom-class"
           onPageSelect={(page) => this.setState({ page })}
           page={this.state.page}
           pages={3}


### PR DESCRIPTION
## Description
This PR deprecates the prop `customClasses` for the `<Breadcrumbs />` component. It also adds support for a new prop called `className` to replace `customClasses`. It also updates its documentation with the new prop.

[This is the only place in `vets-website` where this prop is currently used](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/vaos/components/Breadcrumbs.jsx#L7). I will send a follow-up PR with the version bump to update this loc 🙂 

#### PR Additions!

This PR now also adds support for a `className` prop for the `<Pagination />` component. It also updates its documentation with the new prop.

## Testing done


## Screenshots
![image (6)](https://user-images.githubusercontent.com/12773166/73013779-2e75f700-3dd6-11ea-95ee-c4b844eaf332.png)

## Acceptance criteria
- [x] Update `customClasses` prop to `className` for `<Breadcrumbs />`.
- [x] Add `className` prop for `<Pagination />`.

## Definition of done
- [x] Changes have been tested in vets-website
- [x] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
