### PR TITLE
bradl3yC - 5553 - Add styles to enforce padding on firefox

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.9.0",
+  "version": "6.9.1",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/modules/_m-alert.scss
+++ b/packages/formation/sass/modules/_m-alert.scss
@@ -8,6 +8,8 @@
   width: 100%;
 
   &::before {
+    display: block;
+    width: auto;
     background: none;
     font-family: "Font Awesome 5 Free";
     font-size: 2rem;


### PR DESCRIPTION
## Description
- [x] - some padding and margin was not being adhered to without having a width property on that element. 

## Testing done


## Screenshots
### Before:
![Screen Shot 2020-02-14 at 9 06 04 AM](https://user-images.githubusercontent.com/6165421/74556842-e35e8800-4f2c-11ea-9c94-543f427a96d5.png)

### After:
![Screen Shot 2020-02-14 at 9 05 47 AM](https://user-images.githubusercontent.com/6165421/74556872-f07b7700-4f2c-11ea-8353-0cf039f37fe1.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
