### PR TITLE
Add lodash babel plugin

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -17,6 +17,7 @@ module.exports = function(api) {
         removeImport: true,
       },
     ],
+    'lodash',
   ];
 
   if (api.env('test')) {

--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",


### PR DESCRIPTION
## Description
When we reconfigured how Babel worked in this repo, we missed bringing over the lodash Babel plugin.

## Testing done
Local testing

## Screenshots
Before and after on VAOS:
![Screen Shot 2020-02-18 at 10 23 57 AM](https://user-images.githubusercontent.com/634932/74749872-ced60480-5238-11ea-8e29-737e908c2f29.png)

![Screen Shot 2020-02-18 at 10 23 43 AM](https://user-images.githubusercontent.com/634932/74749870-ce3d6e00-5238-11ea-93e6-5556fb5b4569.png)

## Acceptance criteria
- [ ] Lodash is pulled in piece by piece in apps that use formation-react

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
