### PR TITLE
Add comment re:usage of `body.modal-open` class

### DIFF
--- a/packages/formation-react/src/components/modal/Modal.jsx
+++ b/packages/formation-react/src/components/modal/Modal.jsx
@@ -32,6 +32,9 @@ class Modal extends React.Component {
   setupModal() {
     this.setState({ lastFocus: document.activeElement });
     this.applyFocusToFirstModalElement();
+    // NOTE: With this PR (https://github.com/department-of-veterans-affairs/vets-website/pull/11712)
+    // we rely on the existence of `body.modal-open` to determine if a modal is
+    // currently open and adjust programmatic scrolling if there is.
     document.body.classList.add('modal-open');
     document.addEventListener('keydown', this.handleDocumentKeyDown, false);
     document.addEventListener('focus', this.handleDocumentFocus, true);
@@ -45,7 +48,7 @@ class Modal extends React.Component {
       // Ensure last focus is set before completing modal teardown
       setTimeout(() => {
         this.state.lastFocus.focus();
-      }, 0)
+      }, 0);
     }
     document.body.classList.remove('modal-open');
     document.removeEventListener('keydown', this.handleDocumentKeyDown, false);


### PR DESCRIPTION
## Description
Just adding a comment for future maintainers to let them know how the `modal-open` class is used in a potentially unexpected way.

More info https://github.com/department-of-veterans-affairs/vets-website/pull/11712/files#r380869229

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs