### PR TITLE
Update package globs, and fix failing unit test

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,9 +1,9 @@
 {
   "packages": [
-    "packages/documentation/*",
-    "packages/formation/*",
-    "packages/formation-react/*",
-    "packages/vagov-eslint/*"
+    "packages/documentation",
+    "packages/formation",
+    "packages/formation-react",
+    "packages/vagov-eslint"
   ],
   "version": "independent",
   "npmClient": "yarn",

--- a/packages/formation-react/src/components/SortableTable/SortableTable.unit.spec.jsx
+++ b/packages/formation-react/src/components/SortableTable/SortableTable.unit.spec.jsx
@@ -25,7 +25,7 @@ describe('<SortableTable>', () => {
     );
     expect(
       tree
-        .find('a')
+        .find('button')
         .first()
         .text(),
     ).to.contain('Label 1');


### PR DESCRIPTION
## Ticket

https://app.zenhub.com/workspaces/vsp-5cedc9cce6e3335dc5a49fc4/issues/department-of-veterans-affairs/va.gov-team/4217

## Description

Before solving what I believe to be the root problem, I had to solve two other problems. 

1. There was a bad glob used in the `packages` array in the `lerna.json` config file.
2. There was a unit test that was failing because a component was changed to render a `<button>` instead of an `<a>`. 

### Lerna and `packages`

[`Lerna`](https://github.com/lerna/lerna) repos typically have a root `package.json` and a `packages` folder. 

- [What does a Lerna repo look like?](https://github.com/lerna/lerna#what-does-a-lerna-repo-look-like)

The [`lerna` config file](https://github.com/lerna/lerna#lernajson) should have a `packages` key with a value that is an array of globs to use as package locations.

In 43ffd6bf579559543369c16b3e250c0f838136e2, a new package was added, and the `packages` array was changed from `["packages/*"]` to `["packages/documentation/*", "packages/formation/*", "packages/formation-react/*", "packages/vagov-eslint/*"]`. 

The `name` key inside the child `package.json`'s matched the folder name for 3/4 of the packages. 

```
// packages/formation-react/package.json
{ ..., name: "@department-of-veterans-affairs/formation-react" }

// packages/formation/package.json
{ ..., name: "@department-of-veterans-affairs/formation-react" }

// packages/vagov-eslint/package.json
{ ..., name: "vagov-eslint" }
```

However, the `name` key and folder name for one package didn't match. 
```
// packages/documentation/package.json
{ ..., name: "vagov-documentation" }
```

The `"packages/documentation/*"` failed to match the `"vagov-documentation"` package, and produced the following error in the build:

> `lerna ERR! EFILTER No packages remain after filtering [ 'vagov-documentation' ]`

After changing the glob from `"packages/documentation/*"` to `"packages/documentation"`, `lerna` started finding the `'vagov-documentation'` package again. 

```
- "packages/documentation/*"
+ "packages/documentation"
```

### Failing unit test

In 855b6227d118d7ef3c3a0f3edbf6b3bbc24af827, the component was changed to render a `<button>` instead of an `<a>`. However, the corresponding unit test was never updated. 

I updated that failing unit test, and then the `test` step of the `test, and build` phase of the Jenkins pipeline started passing. 

```
- .find('a')
+ .find('button')
```

### Root cause

The [Gatsby site currently uses the `gatsby-source-git`](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/master/packages/documentation/gatsby-config.js#L13) [plugin](https://www.gatsbyjs.org/packages/gatsby-source-git/) to pull `*.md` files from the [`platform/working-with-vsp` sub-tree](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/working-with-vsp) of the [`va.gov-team` repo](https://github.com/department-of-veterans-affairs/va.gov-team/). 

When the build Gatsby build was trying to sync the `*.md` files from the `va.gov-team` repo, it was failing, with the following error:

```
error "gatsby-mdx" threw an error while running the onCreateNode lifecycle 
unknown: Expected corresponding JSX closing tag for <MDXTag>
```

I wasn't able to find where the error was coming from in the source code inside the `documentation` package. So then I checked the built code in the `public` folder, and I found something that looked related. 

Then I realized that the error wasn't coming from source code inside the `veteran-facing-services-tools` repo, so I started checking other repos. 

Once I checked the `va.gov-team` repo, I found a [file with invalid HTML](https://github.com/department-of-veterans-affairs/va.gov-team/blob/e56c9b374a9cdd24bc7d50f993bafbf36ce4eda9/platform/working-with-vsp/policies-work-norms/how-to-write-your-slos.md). 

I fixed the HTML, and re-ran the CI pipeline for the `veteran-facing-services-tools` repo, and the error went away. 

#### ⚠️ Invalid HTML in the `va.gov-team` repo can break the `veteran-facing-services-tools` build ⚠️ 
 
## Testing done

CI

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
