### PR TITLE
RFC: Add markdown-link-check in Github action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,5 @@
+# https://help.github.com/en/actions/language-and-framework-guides/using-nodejs-with-github-actions#starting-with-the-nodejs-workflow-template
+
 name: Node.js CI
 
 on: [push]
@@ -12,7 +14,12 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: "12.x"
+
+      # https://github.com/tcort/markdown-link-check#installation
       - run: npm install -g markdown-link-check
+
         env:
           CI: true
+
+      # https://github.com/tcort/markdown-link-check#check-links-from-a-local-markdown-folder-recursive
       - run: find . -name \*.md -exec markdown-link-check {} \;

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+name: Node.js CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+      - run: npm install -g markdown-link-check
+        env:
+          CI: true
+      - run: find . -name \*.md -exec markdown-link-check {} \;


### PR DESCRIPTION
## Relevant links

- [markdown-link-check](https://github.com/tcort/markdown-link-check) 
- [Using Node.js with GitHub Actions](https://help.github.com/en/actions/language-and-framework-guides/using-nodejs-with-github-actions#starting-with-the-nodejs-workflow-template)

## Description

Andrew has mentioned using `markdown-link-check` in the past, and I wanted to try it on a small repo. 

I'm more familiar with GitHub Actions than I am Jenkins, and I just wanted to quickly see if I could get it running in a CI environment in a short amount of time. 

## Screenshots

![image](https://user-images.githubusercontent.com/6130520/75921637-15c21d80-5e27-11ea-99d1-ef9d9f54c92f.png)

## Testing

1. Click on [**Checks**](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/216/checks) tab of PR
1. Click on [` Run find . -name \*.md -exec markdown-link-check {} \;`](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/runs/485992799?check_suite_focus=true#step:5:1)
1. View list of links checked per `*.md` file, and how many dead links were found

## Definition of done

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
