### PR TITLE
Add a link to the documentation site

### DIFF
--- a/packages/documentation/README.md
+++ b/packages/documentation/README.md
@@ -1,3 +1,7 @@
+The documentation site can be found at https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/.
+
+---
+
 <!-- AUTO-GENERATED-CONTENT:START (STARTER) -->
 <p align="center">
   <a href="https://www.gatsbyjs.org">


### PR DESCRIPTION
## Description
I never remember where to go to find the documentation site. Thought this might be useful.