### PR TITLE
Apply formatting from prettier to gatsby-config.js

### DIFF
--- a/packages/documentation/gatsby-config.js
+++ b/packages/documentation/gatsby-config.js
@@ -6,7 +6,7 @@ module.exports = {
     description: `Resources and documentation for Development within the VA.gov project`,
     siteUrl: `https://department-of-veterans-affairs.github.io/veteran-facing-services-tools`,
     title: `VA.gov | Client Application Documentation`,
-    sidebar: require('./src/sidebar.js')
+    sidebar: require('./src/sidebar.js'),
   },
   pathPrefix: '/veteran-facing-services-tools',
   plugins: [
@@ -14,10 +14,11 @@ module.exports = {
       resolve: 'gatsby-source-git',
       options: {
         name: 'va.gov-team',
-        remote: 'https://github.com/department-of-veterans-affairs/va.gov-team.git',
+        remote:
+          'https://github.com/department-of-veterans-affairs/va.gov-team.git',
         branch: 'master',
-        patterns: 'platform/working-with-vsp/**'
-      }
+        patterns: 'platform/working-with-vsp/**',
+      },
     },
     `gatsby-plugin-react-helmet`,
     {
@@ -50,17 +51,20 @@ module.exports = {
             resolve: `gatsby-remark-images`,
             options: {
               maxWidth: 1035,
-              sizeByPixelDensity: true
-            }
+              sizeByPixelDensity: true,
+            },
           },
           {
-            resolve: path.resolve(__dirname, './plugins/remark/gatsby-remark-mdx-mermaid'),
+            resolve: path.resolve(
+              __dirname,
+              './plugins/remark/gatsby-remark-mdx-mermaid',
+            ),
           },
           {
-            resolve: 'gatsby-remark-slug'
+            resolve: 'gatsby-remark-slug',
           },
         ],
-      }
+      },
     },
     `gatsby-plugin-sass`,
     `gatsby-plugin-sitemap`,
@@ -68,8 +72,8 @@ module.exports = {
       resolve: `gatsby-source-filesystem`,
       options: {
         path: `../formation-react/src/components`,
-        name: 'components'
-      }
+        name: 'components',
+      },
     },
     `gatsby-transformer-react-docgen`,
     `gatsby-transformer-remark`,
@@ -85,9 +89,17 @@ module.exports = {
           // For any node of type MarkdownRemark, list how to resolve the fields` values
           SitePage: {
             title: node => {
-              if (node.context && node.context.frontmatter && node.context.frontmatter.title) {
+              if (
+                node.context &&
+                node.context.frontmatter &&
+                node.context.frontmatter.title
+              ) {
                 return node.context.frontmatter.title;
-              } else if (node.context && node.context.sourceUrl && node.context.title) {
+              } else if (
+                node.context &&
+                node.context.sourceUrl &&
+                node.context.title
+              ) {
                 // Search by title derived from documents pulled from the GitHub repo.
                 return node.context.title;
               } else {
@@ -97,7 +109,11 @@ module.exports = {
               return '';
             },
             tags: node => {
-              if (node.context && node.context.frontmatter && node.context.frontmatter.tags) {
+              if (
+                node.context &&
+                node.context.frontmatter &&
+                node.context.frontmatter.tags
+              ) {
                 return node.context.frontmatter.tags;
               }
 
@@ -109,4 +125,4 @@ module.exports = {
       },
     },
   ],
-}
+};


### PR DESCRIPTION
## Description

Chris V. asked about if we could link to specific sections of a Gatsby page. There is an [existing Gatsby plugin](https://www.gatsbyjs.org/packages/gatsby-remark-autolink-headers/) to add that functionality. I'd like to test out that plug-in, but the formatting in the `gatsby-config.js` file was inconsistent with prettier's settings. This PR simply applies formatting from prettier so future changes to this file are easier to review. 

### Note
We have a [prettier config file in one of the other packages in this repo](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/master/packages/vagov-eslint/.prettierrc), but not in the root. 

### Question
Do we have a standard prettier config that we want to use in some/most/all of our applications? If so, which one is the source of truth? 

## Links

- https://www.gatsbyjs.org/packages/gatsby-remark-autolink-headers/
- https://dsva.slack.com/archives/CL181NRJQ/p1584055107083000