### PR TITLE
Updated broken link to va.gov-team repo

### DIFF
--- a/packages/documentation/src/pages/getting-started/internal-tools.mdx
+++ b/packages/documentation/src/pages/getting-started/internal-tools.mdx
@@ -8,7 +8,7 @@ tags: SOCKS proxy, Jenkins, Sentry, Grafana, SwitchyOmega
 
 **This content/page is no longer maintained and likely outdated.** 
  
-*[Please see the most current documentation in the va.gov-team repo >](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/working-with-vsp/onboarding/request-access-to-tools.md)*
+*[Please see the most current documentation in the va.gov-team repo >](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/working-with-vsp/orientation/request-access-to-tools.md)*
 
 
 


### PR DESCRIPTION
## Description
I replaced this broken link:  https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/working-with-vsp/onboarding/request-access-to-tools.md

with this link: https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/working-with-vsp/orientation/request-access-to-tools.md
