### PR TITLE
Update screenreader only definitions

### DIFF
--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -46,11 +46,20 @@ body .row.full {
 }
 
 // Screen Readers
-
+// updated to match definition in
+// packages/formation/sass/utilities/_visibility.scss
 .sr-only {
-  position: absolute;
-  left: -9999em;
-  float: left;
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute !important;
+  width: 1px;
+  // Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1241631
+  word-wrap: normal !important;
 }
 
 // Remove from print view, incidentally removes from screen readers as well

--- a/packages/formation/sass/utilities/_visibility.scss
+++ b/packages/formation/sass/utilities/_visibility.scss
@@ -6,16 +6,20 @@
   visibility: visible !important;
 }
 
+// updated to match this definition
+// https://make.wordpress.org/accessibility/handbook/markup/the-css-class-screen-reader-text/#the-css
 .vads-u-visibility--screen-reader {
   border: 0;
   clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
   height: 1px;
+  margin: -1px;
   overflow: hidden;
   padding: 0;
   position: absolute !important;
   width: 1px;
   // Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1241631
-  word-wrap: normal;
+  word-wrap: normal !important;
 }
 
 @each $bp_name, $bp_value in $breakpoints {
@@ -31,13 +35,15 @@
     .#{$bp_name}\:vads-u-visibility--screen-reader {
       border: 0;
       clip: rect(0, 0, 0, 0);
+      clip-path: inset(50%);
       height: 1px;
+      margin: -1px;
       overflow: hidden;
       padding: 0;
       position: absolute !important;
       width: 1px;
       // Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1241631
-      word-wrap: normal;
+      word-wrap: normal !important;
     }
   }
 }


### PR DESCRIPTION
## Description

There are two separate screen-reader only definitions:

- `sr-only` - https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/dec6697459836ee2ae88b10c7eaa91b142d8dea6/packages/formation/sass/base/_va.scss#L50-L54
- `vads-u-visibility--screen-reader` - https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/6bc6d59ae3fb119ac3ec1bb27995cd973301a70d/packages/formation/sass/utilities/_visibility.scss#L9-L19

Both need to be updated & match each other.

Per suggestion from an accessibility consultant, the definitions have been [updated to include extra definitions from this resource](https://make.wordpress.org/accessibility/handbook/markup/the-css-class-screen-reader-text/#the-css)

```css
.screen-reader-text {
  border: 0;
  clip: rect(1px, 1px, 1px, 1px);
  clip-path: inset(50%);
  height: 1px;
  margin: -1px;
  overflow: hidden;
  padding: 0;
  position: absolute;
  width: 1px;
  word-wrap: normal !important;
}
```

## Testing done

Local tests

## Screenshots

N/A - it hides everything!

## Acceptance criteria
- [ ] Updated & matching screen-reader definitions

## Definition of done
- [ ] Changes have been tested in vets-website
- [x] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
