### PR TITLE
Add scrollToAlert to componentDidMount in AlertBox

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/AlertBox/AlertBox.jsx
+++ b/packages/formation-react/src/components/AlertBox/AlertBox.jsx
@@ -3,9 +3,8 @@ import React from 'react';
 import classNames from 'classnames';
 
 class AlertBox extends React.Component {
-  constructor(props) {
-    super(props);
-    this.scrollToAlert = this.scrollToAlert.bind(this);
+  componentDidMount() {
+    this.scrollToAlert();
   }
 
   shouldComponentUpdate(nextProps) {
@@ -16,13 +15,15 @@ class AlertBox extends React.Component {
   }
 
   componentDidUpdate() {
-    if (this.props.isVisible && this.props.scrollOnShow) {
-      this.scrollToAlert();
-    }
+    this.scrollToAlert();
   }
 
-  scrollToAlert() {
+  scrollToAlert = () => {
     const isInView = window.scrollY <= this._ref.offsetTop;
+
+    if (!this.props.isVisible || !this.props.scrollOnShow) {
+      return;
+    }
 
     if (this._ref && !isInView) {
       this._ref.scrollIntoView({
@@ -30,7 +31,7 @@ class AlertBox extends React.Component {
         behavior: 'smooth',
       });
     }
-  }
+  };
 
   render() {
     if (!this.props.isVisible) return <div aria-live="polite" />;


### PR DESCRIPTION
## Description
When passed both `showOnScroll` and `isVisible`, we need the Alert box to come into view. When statically passing either of those props to the component, we need to run the scroll in `componentDidMount` rather than in `componentDidUpdate`.

## Testing done
The solution works locally.

## Acceptance criteria
- [x] Scroll to the AlertBox when it appears in the DOM

## Definition of done
- [x] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
