### PR TITLE
Update link to preview formation

### DIFF
--- a/packages/documentation/src/pages/getting-started/common-tasks/updating-formation.mdx
+++ b/packages/documentation/src/pages/getting-started/common-tasks/updating-formation.mdx
@@ -9,7 +9,7 @@ You can find a detailed guide on contributing to formation at [https://dev-desig
 ## Making updates to formation-react
 1. Components should be created and tested in vets-website first before being moved over to formation-react
 2. Transfer component to formation-react
-3. Test the formation-react version of the component in vets-website before publishing. [Check out these instructions on how to do so](./previewing-changes).
+3. Test the formation-react version of the component in vets-website before publishing. [Check out these instructions on how to do so](/getting-started/common-tasks/previewing-changes).
 4. Write component tests
 5. [Create your react component documentation](/documentation-guide/doc-page)
 


### PR DESCRIPTION
## Description
There was a dead link in the documentation to preview updates to formation-react. Now, that link should point to the correct place.

## Testing done
I did not know how to test the correctness of this change, but my fix follows a pattern used elsewhere in the docs.