### PR TITLE
Removes "feature flags/flippers" nomenclature

### DIFF
--- a/packages/documentation/src/pages/platform/tools/feature-toggles.mdx
+++ b/packages/documentation/src/pages/platform/tools/feature-toggles.mdx
@@ -5,7 +5,7 @@ tags: vagovprod, vagovstaging, vagovdev
 
 # Feature toggles
 
-Feature toggles (also known as feature flags or feature flippers) can be used in both vets-api and vets-website to manage unreleased features in a continuous integration environment. Feature toggles enable VFS teams to test out new functionality (applications, features, VA.gov content pages, Metalsmith) in the VSP development, staging, or production environments for a set of users. Teams can enable or disable a feature for all users, a percentage of all users, a percentage of all logged-in users, a list of users, or users defined in a method.
+Feature toggles can be used in both vets-api and vets-website to manage unreleased features in a continuous integration environment. Feature toggles enable VFS teams to test out new functionality (applications, features, VA.gov content pages, Metalsmith) in the VSP development, staging, or production environments for a set of users. Teams can enable or disable a feature for all users, a percentage of all users, a percentage of all logged-in users, a list of users, or users defined in a method.
 
 Feature toggles:
 - Allow for production toggle switching without redeploying vets-website


### PR DESCRIPTION
This was removed awhile ago in `va.gov-team`, but I think it happened simultaneously with this doc being rewritten by the Content team and got accidentally(?) restored here.

Side note: do we want to rename `featureFlags` and similar across the codebase to stick consistently to the "Toggles" nomenclature?
