### PR TITLE
Add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ package-lock.json
 packages/formation-react/*.js
 public/dist
 yarn-error.log
+.env


### PR DESCRIPTION
## Description

The [`README` for the `documentation` package](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blame/master/packages/documentation/README.md#L32) mentions using a GitHub Personal Access token.

This PR adds `.env` file to the `.gitignore` so we don't have to worry about people accidentally committing local ENV variables. 

## Testing done

CI

## Definition of done
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
