### PR TITLE
Add disableGATracking prop and track w/GA pagination clicks onPageSelect

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/Pagination/Pagination.jsx
+++ b/packages/formation-react/src/components/Pagination/Pagination.jsx
@@ -8,7 +8,7 @@ class Pagination extends Component {
   static propTypes = {
     ariaLabelSuffix: PropTypes.string,
     className: PropTypes.string,
-    enableAnaltyics: PropTypes.bool,
+    enableAnalytics: PropTypes.bool,
     maxPageListLength: PropTypes.number.isRequired,
     onPageSelect: PropTypes.func.isRequired,
     page: PropTypes.number.isRequired,
@@ -19,7 +19,7 @@ class Pagination extends Component {
 
   static defaultProps = {
     ariaLabelSuffix: '',
-    enableAnaltyics: true,
+    enableAnalytics: true,
     maxPageListLength: 10,
     trackEvent: (...args) => {
       // Escape early if Google Analytics (GA) is not enabled.
@@ -37,7 +37,7 @@ class Pagination extends Component {
     this.props.onPageSelect(page);
 
     // Conditionally track the event.
-    if (this.props.enableAnaltyics) {
+    if (this.props.enableAnalytics) {
       this.props.trackEvent({
         event: eventID,
         'paginate-page-number': page,

--- a/packages/formation-react/src/components/Pagination/Pagination.jsx
+++ b/packages/formation-react/src/components/Pagination/Pagination.jsx
@@ -8,6 +8,7 @@ class Pagination extends Component {
   static propTypes = {
     ariaLabelSuffix: PropTypes.string,
     className: PropTypes.string,
+    disableGATracking: PropTypes.bool,
     maxPageListLength: PropTypes.number.isRequired,
     onPageSelect: PropTypes.func.isRequired,
     page: PropTypes.number.isRequired,
@@ -17,8 +18,22 @@ class Pagination extends Component {
 
   static defaultProps = {
     ariaLabelSuffix: '',
+    disableGATracking: false,
     maxPageListLength: 10,
   };
+
+  onPageSelect = (page, eventID) => {
+    // Propogate via the prop.
+    this.props.onPageSelect(page);
+
+    // Conditionally track the event.
+    if (window.dataLayer && !disableGATracking) {
+      window.dataLayer.push({
+        event: eventID,
+        'paginate-page-number': page,
+      });
+    }
+  }
 
   next = () => {
     let nextPage;
@@ -26,7 +41,7 @@ class Pagination extends Component {
       nextPage = (
         <a
           aria-label={`Load next page ${this.props.ariaLabelSuffix}`}
-          onClick={() => {this.props.onPageSelect(this.props.page + 1);}}
+          onClick={() => {this.onPageSelect(this.props.page + 1, 'nav-paginate-next');}}
           onKeyDown={e => this.handleKeyDown(e, this.props.page + 1)}
           tabIndex="0">
           Next
@@ -42,7 +57,7 @@ class Pagination extends Component {
       prevPage = (
         <a
           aria-label={`Load previous page ${this.props.ariaLabelSuffix}`}
-          onClick={() => {this.props.onPageSelect(this.props.page - 1);}}
+          onClick={() => {this.onPageSelect(this.props.page - 1, 'nav-paginate-previous');}}
           onKeyDown={e => this.handleKeyDown(e, this.props.page - 1)}
           tabIndex="0">
           <abbr title="Previous">Prev</abbr>
@@ -67,7 +82,7 @@ class Pagination extends Component {
           <a aria-label="...">
             ...
           </a>
-          <a aria-label={`Load last page ${this.props.ariaLabelSuffix}`} onClick={() => {this.props.onPageSelect(totalPages);}}>
+          <a aria-label={`Load last page ${this.props.ariaLabelSuffix}`} onClick={() => {this.onPageSelect(totalPages, 'nav-paginate-number');}}>
             {totalPages}
           </a>
         </span>
@@ -119,7 +134,7 @@ class Pagination extends Component {
     const keyCode = e.which || e.keyCode;
     if (keyCode === 13 || keyCode === 32) {
       e.preventDefault();
-      this.props.onPageSelect(pageNumber)
+      this.onPageSelect(pageNumber, 'nav-paginate-number');
     }
   }
 
@@ -141,7 +156,7 @@ class Pagination extends Component {
           key={pageNumber}
           className={pageClass}
           aria-label={`Load page ${pageNumber} ${ariaLabelSuffix}`}
-          onClick={() => onPageSelect(pageNumber)}
+          onClick={() => onPageSelect(pageNumber, 'nav-paginate-number')}
           onKeyDown={e => this.handleKeyDown(e, pageNumber)}
           tabIndex="0">
           {pageNumber}

--- a/packages/formation-react/src/components/Pagination/Pagination.jsx
+++ b/packages/formation-react/src/components/Pagination/Pagination.jsx
@@ -8,18 +8,28 @@ class Pagination extends Component {
   static propTypes = {
     ariaLabelSuffix: PropTypes.string,
     className: PropTypes.string,
-    disableGATracking: PropTypes.bool,
+    enableAnaltyics: PropTypes.bool,
     maxPageListLength: PropTypes.number.isRequired,
     onPageSelect: PropTypes.func.isRequired,
     page: PropTypes.number.isRequired,
     pages: PropTypes.number.isRequired,
     showLastPage: PropTypes.bool,
+    trackEvent: PropTypes.func,
   };
 
   static defaultProps = {
     ariaLabelSuffix: '',
-    disableGATracking: false,
+    enableAnaltyics: true,
     maxPageListLength: 10,
+    trackEvent: (...args) => {
+      // Escape early if Google Analytics (GA) is not enabled.
+      if (!window.dataLayer) {
+        return;
+      }
+
+      // Track event in GA.
+      window.dataLayer.push(...args);
+    }
   };
 
   onPageSelect = (page, eventID) => {
@@ -27,8 +37,8 @@ class Pagination extends Component {
     this.props.onPageSelect(page);
 
     // Conditionally track the event.
-    if (window.dataLayer && !disableGATracking) {
-      window.dataLayer.push({
+    if (this.props.enableAnaltyics) {
+      this.props.trackEvent({
         event: eventID,
         'paginate-page-number': page,
       });


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/7199

This PR adds Google Analytics event tracking to Pagination, as per [this analytics request](https://github.com/department-of-veterans-affairs/va.gov-team/issues/7199#issuecomment-620154353).

I've built it in a way where you would have to __opt-out__ of sending GA events (assuming `window.dataLayer` even exists). Let me know if you think we should change this to where you would have to __opt-in__ to analytics, but it sounded like the Analytics team would like it to be applied to every `<Pagination />` component we're using on va.gov.

## Testing done
Tests pass 🎉 

## Screenshots
N/A

## Acceptance criteria

<table>
<tr>
<th>Description</th><th>Screenshot</th><th>Datalayer</th>
</tr>
<tr>
<td>
Click on <em>Next</em> link in pagination control </td>
<td>  <img src="https://user-images.githubusercontent.com/62304138/80405725-fd073e80-8890-11ea-9d5d-f181b7f9ace9.png" />  </td>
<td><pre>{
    'event': 'nav-paginate-next',
    'paginate-page-number': n | undefined
}</pre></td>
</tr>

<tr>
<td>
Click on <em>Previous</em> link in pagination control </td>
<td>  <img src="https://user-images.githubusercontent.com/62304138/80405767-0abcc400-8891-11ea-8184-5798eeafc71c.png" />  </td>
<td><pre>{
    'event': 'nav-paginate-previous',
    'paginate-page-number': n | undefined
}</pre></td>
</tr>

<tr>
<td>
Click on <em>Numerical</em> link in pagination control </td>
<td>  <img src="https://user-images.githubusercontent.com/62304138/80405800-160fef80-8891-11ea-9052-34254b7d4e72.png" />  </td>
<td><pre>{
    'event': 'nav-paginate-number',
    'paginate-page-number': n | undefined
}</pre></td>
</tr>
</table>


## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
