### PR TITLE
Fix nav-paginate-number event when clicking a pagination number link

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "5.2.5",
+  "version": "5.2.6",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/Pagination/Pagination.jsx
+++ b/packages/formation-react/src/components/Pagination/Pagination.jsx
@@ -149,7 +149,7 @@ class Pagination extends Component {
   }
 
   render() {
-    const { ariaLabelSuffix, className, onPageSelect, page, pages } = this.props;
+    const { ariaLabelSuffix, className, page, pages } = this.props;
 
     // Do not render if there's only 1 page.
     if (pages === 1) {
@@ -166,7 +166,7 @@ class Pagination extends Component {
           key={pageNumber}
           className={pageClass}
           aria-label={`Load page ${pageNumber} ${ariaLabelSuffix}`}
-          onClick={() => onPageSelect(pageNumber, 'nav-paginate-number')}
+          onClick={() => this.onPageSelect(pageNumber, 'nav-paginate-number')}
           onKeyDown={e => this.handleKeyDown(e, pageNumber)}
           tabIndex="0">
           {pageNumber}


### PR DESCRIPTION
## Description
**Related comment:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/7199#issuecomment-622573787

This PR fixes the last event:

Description | Event + dataLayer
--- | ---
Initial Yellow Ribbon search on page | ![image](https://user-images.githubusercontent.com/62304138/80842311-41ffdd80-8bcf-11ea-90e6-8bda4066710d.png)
URL Query Param Preset with options | (none, as expected)
Paginate Next click | ![image](https://user-images.githubusercontent.com/62304138/80842389-6eb3f500-8bcf-11ea-8a80-3192b0981813.png)
Paginate Previous click | ![image](https://user-images.githubusercontent.com/62304138/80842435-8d19f080-8bcf-11ea-9a20-817abaef333c.png)
Paginate Number click | (missing.  Expected `nav-paginate-number` event)

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
