### PR TITLE
Add SOCK script docs

### DIFF
--- a/packages/documentation/src/pages/getting-started/internal-tools.mdx
+++ b/packages/documentation/src/pages/getting-started/internal-tools.mdx
@@ -6,8 +6,8 @@ tags: SOCKS proxy, Jenkins, Sentry, Grafana, SwitchyOmega
 # Internal Tools
 
 
-**This content/page is no longer maintained and likely outdated.** 
- 
+**This content/page is no longer maintained and likely outdated.**
+
 *[Please see the most current documentation in the va.gov-team repo >](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/working-with-vsp/orientation/request-access-to-tools.md)*
 
 
@@ -101,17 +101,25 @@ There are slightly different commands to connect to the proxy depending on wheth
 
 - If you're on the VA network, run:
 
-```bash
-ssh socks-va -D 2001 -N &
-```
+  ```bash
+  ssh socks-va -D 2001 -N &
+  ```
 
- - If you're on the internet (outside the VA network), run:
+- If you're on the internet (outside the VA network), run:
 
-```bash
-ssh socks -D 2001 -N &
-```
+  ```bash
+  ssh socks -D 2001 -N &
+  ```
 
-_The first time you connect to the jumpbox, ssh will prompt to ask if you are sure you want to connect to a new host. You will be unable to respond "yes" if ssh is in the background, so either bring it to the foreground with `fg` or omit the `&` character from the above command._
+- Alternatively, if you have the `devops` repo cloned on your device, add the following alias:
+
+  ```bash
+  alias socks=~/path_to_repo/devops/utilities/socks.sh
+  ```
+
+  then use `socks on` or `socks off` to toggle.
+
+**Note**: _The first time you connect to the jumpbox, ssh will prompt to ask if you are sure you want to connect to a new host. You will be unable to respond "yes" if ssh is in the background, so either bring it to the foreground with `fg` or omit the `&` character from the above command._
 
 _After running the command below, continue to_ **Testing and Using thje SOCKS proxy**
 


### PR DESCRIPTION
## Description

Update Internal tools SOCKS documentation. Added alias to devops sock shell script.

## Testing done

N/A

## Screenshots

![Screen Shot 2020-05-08 at 11 14 49 AM](https://user-images.githubusercontent.com/136959/81425414-2cce0600-911d-11ea-8873-d12a85e06a6c.png)

## Acceptance criteria
- [ ] New additions are correct

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
