### PR TITLE
Add overflow visible to pagination for focus styling

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.9.1",
+  "version": "6.9.2",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/modules/_va-pagination.scss
+++ b/packages/formation/sass/modules/_va-pagination.scss
@@ -75,6 +75,10 @@
   }
 }
 
+.va-pagination-inner {
+  overflow: visible;
+}
+
 .va-pagination-inner a {
   border-radius: 1000px;
   display: inline-block;

--- a/packages/formation/sass/modules/_va-pagination.scss
+++ b/packages/formation/sass/modules/_va-pagination.scss
@@ -69,14 +69,18 @@
     }
   }
 
+  &-prev,
+  &-next,
+  &-inner {
+    // a11y fix, ensures we show full focus outline: https://github.com/department-of-veterans-affairs/va.gov-team/issues/8790
+    padding-bottom: 4px;
+    padding-top: 4px;
+  }
+
   a {
     line-height: 2;
     text-decoration: none;
   }
-}
-
-.va-pagination-inner {
-  overflow: visible;
 }
 
 .va-pagination-inner a {


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/8790

Current:

![image](https://user-images.githubusercontent.com/12773166/81442405-c94dd380-9130-11ea-8258-d8f955779c09.png)

Desired:

![image](https://user-images.githubusercontent.com/12773166/81442436-d4a0ff00-9130-11ea-9006-7aed7c671884.png)


## Testing done
N/A

## Screenshots
[Find Forms](https://www.va.gov/find-forms):

![image](https://user-images.githubusercontent.com/12773166/81442562-10d45f80-9131-11ea-9848-14a5dc73125b.png)

[Yellow Ribbon](https://staging.va.gov/education/yellow-ribbon-participating-schools/?name=university):

![image](https://user-images.githubusercontent.com/12773166/81442627-31041e80-9131-11ea-9737-64e299242f52.png)

### Mobile

![image](https://user-images.githubusercontent.com/12773166/81444693-cb199600-9134-11ea-942c-dd44d8fd9690.png)

### Desktop

![image](https://user-images.githubusercontent.com/12773166/81444715-d40a6780-9134-11ea-9099-f9fa8b665ae5.png)

## Acceptance criteria
- [x] Add overflow visible on inner pagination div

## Definition of done
- [x] Changes have been tested in vets-website
- [x] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
