### PR TITLE
Add centralized Telephone component

### DIFF
--- a/packages/formation-react/src/components/Telephone/Telephone.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.jsx
@@ -51,27 +51,18 @@ const formatTelText = (num, pattern) => {
 };
 
 /**
- * Group number parts that are divisible by 1000 or 100 (chose the greater one,
- * if possible) and spread out other numbers; we want the screenreader to sound
- * out the numbers as we typically say them, e.g. "eight hundred five five five
- * one thousand" (800-555-1000)
+ * Add a space between each number part
  * @param {string} number - number part, e.g. area code, prefix, line number
  * @return {string} - formatted number part for use in aria-label
  */
-const formatTelLabelBlock = number => {
-  const len = number.length - 1;
-  // return rounded number as a grouped value, e.g. `800` or `1000`
-  // but split non-round numbers, e.g. `827` => `8 2 7`
-  const isRoundNumber = parseInt(number.slice(-len), 10) === 0;
-  return isRoundNumber ? number : number.split('').join(' ');
-};
+const formatTelLabelBlock = number => number.split('').join(' ');
 
 /**
  * Format telephone number for label
  * @param {string} number - Expected a phone number with or without dashes that
  * matches the number of "#" within the default or set pattern
  * @return {string} - Combined phone number parts within the label separated by
- * periods, e.g. "800-555-1212" becomes "800. 5 5 5. 1 2 1 2"
+ * periods, e.g. "800-555-1212" becomes "8 0 0. 5 5 5. 1 2 1 2"
  */
 const formatTelLabel = number =>
   number

--- a/packages/formation-react/src/components/Telephone/Telephone.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.jsx
@@ -24,7 +24,7 @@ export const CONTACTS = Object.freeze({
 export const PATTERNS = {
   911: '###', // needed to match 911 CONTACT
   DEFAULT: '###-###-####',
-  WRAP_AREACODE: '(###) ###-####',
+  OUTSIDE_US: '+1-###-###-####',
 };
 
 // Strip out leading "1" and any non-digits

--- a/packages/formation-react/src/components/Telephone/Telephone.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.jsx
@@ -131,8 +131,10 @@ function Telephone({
   const href = `tel:${
     phoneNumber.length === 10 ? `+1${phoneNumber}` : phoneNumber
   }${
-    // extension format from RFC3966 https://tools.ietf.org/html/rfc3966#page-5
-    extension ? `;ext=${extension}` : ''
+    // extension format ";ext=" from RFC3966 https://tools.ietf.org/html/rfc3966#page-5
+    // but it seems that using a comma to pause for 2 seconds might be a better
+    // solution - see https://dsva.slack.com/archives/C8E985R32/p1589814301103200
+    extension ? `,${extension}` : ''
   }`;
 
   return (

--- a/packages/formation-react/src/components/Telephone/Telephone.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.jsx
@@ -21,10 +21,16 @@ export const CONTACTS = Object.freeze({
   VA_BENEFITS: '8008271000', // Veterans Benefits Assistance
 });
 
+// Patterns used in formatting visible text
 export const PATTERNS = {
   911: '###', // needed to match 911 CONTACT
   DEFAULT: '###-###-####',
   OUTSIDE_US: '+1-###-###-####',
+};
+
+// Custom aria labels (only used internally)
+const LABELS = {
+  911: '1. 9 1 1.',
 };
 
 /**
@@ -115,13 +121,14 @@ function Telephone({
 
   const formattedAriaLabel =
     ariaLabel ||
+    LABELS[parsedNumber] || // custom 911 aria-label
     `${formatTelLabel(formattedNumber)}${
       extension ? `. extension ${formatTelLabelBlock(extension)}.` : '.'
     }`;
 
-  const href = `tel:${
-    phoneNumber.length === 10 ? `+1${phoneNumber}` : phoneNumber
-  }${
+  // Add a "+1" to the tel for all included patterns
+  const isIncludedPattern = Object.values(PATTERNS).includes(contactPattern);
+  const href = `tel:${isIncludedPattern ? `+1${phoneNumber}` : phoneNumber}${
     // extension format ";ext=" from RFC3966 https://tools.ietf.org/html/rfc3966#page-5
     // but it seems that using a comma to pause for 2 seconds might be a better
     // solution - see https://dsva.slack.com/archives/C8E985R32/p1589814301103200

--- a/packages/formation-react/src/components/Telephone/Telephone.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.jsx
@@ -27,28 +27,52 @@ export const PATTERNS = {
   OUTSIDE_US: '+1-###-###-####',
 };
 
-// Strip out leading "1" and any non-digits
+/**
+ * Parse the raw phone number string. And strip out leading "1" and any
+ * non-digits
+ * @param {string} number - raw phone number input
+ * @return {string} - string containing only numbers
+ */
 const parseNumber = number =>
   number
     .replace(/^1/, '') // strip leading "1" from telephone number
     .replace(/[^\d]/g, '');
 
+/**
+ * Insert the provided number into the pattern
+ * @param {string} num - parsed number string (no non-digits included)
+ * @param {string} pattern - provided pattern (using "#") for link text
+ * @return {string} - formatted phone number for link text
+ */
 // Create link text from pattern
 const formatTelText = (num, pattern) => {
   let i = 0;
   return pattern.replace(/#/g, () => num[i++] || '');
 };
 
+/**
+ * Group number parts that are divisible by 1000 or 100 (chose the greater one,
+ * if possible) and spread out other numbers; we want the screenreader to sound
+ * out the numbers as we typically say them, e.g. "eight hundred five five five
+ * one thousand" (800-555-1000)
+ * @param {string} number - number part, e.g. area code, prefix, line number
+ * @return {string} - formatted number part for use in aria-label
+ */
 const formatTelLabelBlock = number => {
   const len = number.length - 1;
   // return rounded number as a grouped value, e.g. `800` or `1000`
   // but split non-round numbers, e.g. `827` => `8 2 7`
-  const roundNumber = parseInt(number.slice(-len), 10) === 0;
-  return roundNumber ? number : number.split('').join(' ');
+  const isRoundNumber = parseInt(number.slice(-len), 10) === 0;
+  return isRoundNumber ? number : number.split('').join(' ');
 };
 
-// Combine phone number blocks within the label separated by periods
-// "800-555-1212" => "800. 5 5 5. 1 2 1 2"
+/**
+ * Format telephone number for label
+ * @param {string} number - Expected a phone number with or without dashes that
+ * matches the number of "#" within the default or set pattern
+ * @return {string} - Combined phone number parts within the label separated by
+ * periods, e.g. "800-555-1212" becomes "800. 5 5 5. 1 2 1 2"
+ */
 const formatTelLabel = number =>
   number
     .split(/[^\d]+/)
@@ -56,6 +80,22 @@ const formatTelLabel = number =>
     .map(formatTelLabelBlock)
     .join('. ');
 
+/**
+ * Telephone component
+ * @param {string|number} contact (required) - telephone number, with or without
+ *  formatting; all non-digit characters will be stripped out
+ * @param {string} className (required) - additional space-separated class names
+ *  to add to the link
+ * @param {string} pattern (required) - Link text format pattern, using "#" as
+ *  the digit placeholder
+ * @param {string} ariaLabel (optional) - if included, this custom aria-label
+ *  will replace the generated aria-label
+ * @param {function} onClick (optional) - function called when the link is
+ *  clicked
+ * @param {string|JSX} children (optional) - if included, this custom
+ *  telephone link text will replace the generated text; the pattern passed in
+ *  will be ignored
+ */
 function Telephone({
   // phone number (length _must_ match the pattern; leading "1" is removed)
   contact = '', // telephone number
@@ -96,9 +136,10 @@ function Telephone({
 
 Telephone.propTypes = {
   /**
-   * Pass a telephone number, or use a known phone number in CONTACTS. Any
-   * number with a leading "1" will be stripped off (assuming country code).
-   * Whitespace and non-digits will be stripped out of this string.
+   * Pass a telephone number as a string, or use a known phone number in
+   * CONTACTS. Any number with a leading "1" will be stripped off (assuming
+   * country code). Whitespace and non-digits will be stripped out of this
+   * string.
    */
   contact: PropTypes.string.isRequired,
 

--- a/packages/formation-react/src/components/Telephone/Telephone.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.jsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export const CONTACTS = Object.freeze({
+  '222_VETS': '8772228387', // VA Help Line
+  '4AID_VET': '8774243838', // National Call Center for Homeless Veterans
+  911: '911',
+  CAREGIVER: '8552603274', // VA National Caregiver Support Line
+  CRISIS_LINE: '8002738255', // Veterans Crisis hotline
+  CRISIS_TTY: '8007994889', // Veterans Crisis hotline TTY
+  DS_LOGON: '8005389552', // Defense Manpower Data Center
+  DS_LOGON_TTY: '8663632883', // Defense Manpower Data Center TTY
+  GI_BILL: '8884424551', // Education Call Center (1-888-GI-BILL-1)
+  GO_DIRECT: '8003331795', // Go Direct/Direct Express (Treasury)
+  HELP_DESK: '8555747286', // VA Help desk
+  HELP_TTY: '8008778339', // VA Help Desk TTY
+  MY_HEALTHEVET: '8773270022', // My HealtheVet help desk
+  NCA: '8005351117', // National Cemetery Scheduling Office
+  TESC: '8882242950', // U.S. Treasury Electronic Payment Solution Center
+  VA_311: '8446982311', // VA Help desk (VA311)
+  VA_BENEFITS: '8008271000', // Veterans Benefits Assistance
+});
+
+export const PATTERNS = {
+  911: '###', // needed to match 911 CONTACT
+  DEFAULT: '###-###-####',
+  WRAP_AREACODE: '(###) ###-####',
+};
+
+// Strip out leading "1" and any non-digits
+const parseNumber = number =>
+  number
+    .replace(/^1/, '') // strip leading "1" from telephone number
+    .replace(/[^\d]/g, '');
+
+// Create link text from pattern
+const formatTelText = (num, pattern) => {
+  let i = 0;
+  return pattern.replace(/#/g, () => num[i++] || '');
+};
+
+const formatBlock = number => {
+  const len = number.length - 1;
+  // return rounded number as a grouped value, e.g. `800` or `1000`
+  // but split non-round numbers, e.g. `827` => `8 2 7`
+  const roundNumber = parseInt(number.slice(-len), 10) === 0;
+  return roundNumber ? number : number.split('').join(' ');
+};
+
+// Combine phone number blocks within the label separated by periods
+// "800-555-1212" => "800. 5 5 5. 1 2 1 2"
+const formatTelLabel = number =>
+  number
+    .split(/[^\d]+/)
+    .filter(n => n)
+    .map(formatBlock)
+    .join('. ');
+
+function Telephone({
+  // phone number (length _must_ match the pattern; leading "1" is removed)
+  contact = '', // telephone number
+  className = '', // additional css class to add
+  pattern = '', // output format; defaults to patterns.default value
+  ariaLabel = '', // custom aria-label
+  onClick = () => {},
+  children,
+}) {
+  // strip out non-digits for use in href: "###-### ####" => "##########"
+  const contactString = parseNumber(contact.toString());
+  const cleanNumber = CONTACTS[contactString] || contactString;
+
+  // Capture "911" pattern here
+  const contactPattern = pattern || PATTERNS[contactString] || PATTERNS.DEFAULT;
+  const patternLength = contactPattern.match(/#/g).length;
+  const formattedTel = formatTelText(cleanNumber, contactPattern);
+
+  if (!cleanNumber || cleanNumber.length !== patternLength) {
+    throw new Error(
+      `Contact number "${cleanNumber}" does not match the pattern (${contactPattern})`,
+    );
+  }
+
+  const href = cleanNumber.length === 10 ? `+1${cleanNumber}` : cleanNumber;
+
+  return (
+    <a
+      className={`no-wrap ${className}`}
+      href={`tel:${href}`}
+      aria-label={ariaLabel || formatTelLabel(formattedTel)}
+      onClick={onClick}
+    >
+      {children || formattedTel}
+    </a>
+  );
+}
+
+Telephone.propTypes = {
+  /**
+   * Pass a telephone number, or use a known phone number in CONTACTS. Any
+   * number with a leading "1" will be stripped off (assuming country code).
+   * Whitespace and non-digits will be stripped out of this string.
+   */
+  contact: PropTypes.string.isRequired,
+
+  /**
+   * Additional class name to add to the link.
+   */
+  className: PropTypes.string,
+
+  /**
+   * Pattern use used while formatting the contact number. Use provided
+   * PATTERNS, or create a custom one using "#" as a placeholder for each
+   * number. Note that the number of "#"'s in the pattern <em>must</em> equal
+   * the contact number length or an error is thrown.
+   */
+  pattern: PropTypes.string,
+
+  /**
+   * Custom aria-label string.
+   */
+  ariaLabel: PropTypes.string,
+
+  /**
+   * Custom onClick function
+   */
+  onClick: PropTypes.func,
+};
+
+export default Telephone;

--- a/packages/formation-react/src/components/Telephone/Telephone.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.jsx
@@ -158,6 +158,13 @@ Telephone.propTypes = {
   contact: PropTypes.string.isRequired,
 
   /**
+   * Options extension for the telephone number. Only include the numbers,
+   * "ext" will be added automatically along with "extension" within the
+   * aria-label
+   */
+  extension: PropTypes.string,
+
+  /**
    * Additional class name to add to the link.
    */
   className: PropTypes.string,

--- a/packages/formation-react/src/components/Telephone/Telephone.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.jsx
@@ -39,7 +39,7 @@ const formatTelText = (num, pattern) => {
   return pattern.replace(/#/g, () => num[i++] || '');
 };
 
-const formatBlock = number => {
+const formatTelLabelBlock = number => {
   const len = number.length - 1;
   // return rounded number as a grouped value, e.g. `800` or `1000`
   // but split non-round numbers, e.g. `827` => `8 2 7`
@@ -53,7 +53,7 @@ const formatTelLabel = number =>
   number
     .split(/[^\d]+/)
     .filter(n => n)
-    .map(formatBlock)
+    .map(formatTelLabelBlock)
     .join('. ');
 
 function Telephone({

--- a/packages/formation-react/src/components/Telephone/Telephone.mdx
+++ b/packages/formation-react/src/components/Telephone/Telephone.mdx
@@ -99,7 +99,6 @@ import Telephone, { CONTACTS, PATTERNS } from '@department-of-veterans-affairs/f
 
   <strong>Special case (911)</strong>
   <p>
-    <!-- prevent accidental clicks in this demo page -->
     <Telephone contact={CONTACTS.911} onClick={e => e.preventDefault()} />
   </p>
 

--- a/packages/formation-react/src/components/Telephone/Telephone.mdx
+++ b/packages/formation-react/src/components/Telephone/Telephone.mdx
@@ -47,6 +47,13 @@ import Telephone, { CONTACTS, PATTERNS } from '@department-of-veterans-affairs/f
 </a>
 */
 
+// Special case (911)
+<Telephone contact={CONTACTS.911} />
+
+/* Renders as
+<a href="tel:+1911" aria-label="1. 9 1 1." class="no-wrap">911</a>
+*/
+
 // Showing all options
 <Telephone
   contact="18884424551" // leading "1" is removed
@@ -88,6 +95,12 @@ import Telephone, { CONTACTS, PATTERNS } from '@department-of-veterans-affairs/f
       contact="8005551212"
       extension="123"
     />
+  </p>
+
+  <strong>Special case (911)</strong>
+  <p>
+    <!-- prevent accidental clicks in this demo page -->
+    <Telephone contact={CONTACTS.911} onClick={e => e.preventDefault()} />
   </p>
 
   <strong>Showing all options</strong>

--- a/packages/formation-react/src/components/Telephone/Telephone.mdx
+++ b/packages/formation-react/src/components/Telephone/Telephone.mdx
@@ -1,0 +1,111 @@
+---
+title: Telephone
+name: Telephone
+tags: telephone, component
+---
+
+import Telephone, { CONTACTS, PATTERNS } from './Telephone';
+
+### Code:
+
+```javascript
+import Telephone, { CONTACTS, PATTERNS } from '@department-of-veterans-affairs/formation-react/ProgressBar'
+
+// Minimal example
+<Telephone contact={CONTACTS.VA_BENEFITS} />
+
+/* Renders as
+<a href="tel:+18008271000" aria-label="800. 8 2 7. 1000" class="no-wrap">
+  800-827-1000
+</a>
+*/
+
+// Adding a pattern
+<Telephone
+  contact={CONTACTS.VA_311}
+  pattern={PATTERNS.WRAP_CODE}
+/>
+
+/* Renders as
+<a href="tel:+18446982311" aria-label="8 4 4. 6 9 8. 2 3 1 1" class="no-wrap">
+  (844) 698-2311
+</a>
+*/
+
+// Showing all options
+<Telephone
+  contact="18884424551" // leading "1" is removed
+  className="foo"
+  pattern={false} // Ignored when text is included
+  ariaLabel="8 8 8. 4 4 2. 4 5 5 1"
+  onClick={() => {}}
+/>
+  1-888-GI-BILL-1
+</Telephone>
+
+/* Renders as
+<a href="tel:+18884424551" aria-label="8 8 8. 4 4 2. 4 5 5 1" class="no-wrap foo">
+  1-888-GI-BILL-1
+</a>
+*/
+```
+
+### Rendered Component
+
+<div className="site-c-reactcomp__rendered">
+  <strong>Minimal example</strong>
+  <p>
+    <Telephone contact={CONTACTS.VA_BENEFITS} />
+  </p>
+
+  <strong>Adding a pattern</strong>
+  <p>
+    <Telephone
+      contact={CONTACTS.VA_311}
+      pattern={PATTERNS.WRAP_CODE}
+    />
+  </p>
+
+  <strong>Showing all options</strong>
+  <p>
+    <Telephone
+      contact="18884424551"
+      className="foo"
+      pattern={false}
+      ariaLabel="8 8 8. 4 4 2. 4 5 5 1"
+      onClick={() => {}}
+    />
+      1-888-GI-BILL-1
+    </Telephone>
+  </p>
+</div>
+
+### Predefined contacts
+
+| Key | Number | Description |
+|:----|:-------|:------------|
+| `222_VETS` | `8772228387` | VA Help Line |
+| `4AID_VET` | `8774243838` | National Call Center for Homeless Veterans |
+| `911` | `911` | Emergency! |
+| `CAREGIVER` | `8552603274` | VA National Caregiver Support Line |
+| `CRISIS_LINE` | `8002738255` | Veterans Crisis hotline |
+| `CRISIS_TTY` | `8007994889` | Veterans Crisis hotline TTY |
+| `DS_LOGON` | `8005389552` | Defense Manpower Data Center |
+| `DS_LOGON_TTY` | `8663632883` | Defense Manpower Data Center TTY |
+| `GI_BILL` | `8884424551` | Education Call Center (1-888-GI-BILL-1) |
+| `GO_DIRECT` | `8003331795` | Go Direct/Direct Express (Treasury) |
+| `HELP_DESK` | `8555747286` | VA Help desk |
+| `HELP_TTY` | `8008778339` | VA Help Desk TTY |
+| `MY_HEALTHEVET` | `8773270022` | My HealtheVet help desk |
+| `NCA` | `8005351117` | National Cemetery Scheduling Office |
+| `TESC` | `8882242950` | U.S. Treasury Electronic Payment Solution Center |
+| `VA_311` | `8446982311` | VA Help desk (VA311) |
+| `VA_BENEFITS` | `8008271000` | Veterans Benefits Assistance |
+
+### Predefined patterns
+
+| Key | Pattern | Description |
+|:----|:--------|:------------|
+| `911` | `###` | Matches the `911` contact number |
+| `DEFAULT` | `###-###-####` | Current phone pattern used throughout the site |
+| `WRAP_AREACODE` | `(###) ###-####` | Extra pattern; currently used for testing |

--- a/packages/formation-react/src/components/Telephone/Telephone.mdx
+++ b/packages/formation-react/src/components/Telephone/Telephone.mdx
@@ -86,7 +86,7 @@ import Telephone, { CONTACTS, PATTERNS } from '@department-of-veterans-affairs/f
   <p>
     <Telephone
       contact="8005551212"
-      extension="
+      extension="123"
     />
   </p>
 

--- a/packages/formation-react/src/components/Telephone/Telephone.mdx
+++ b/packages/formation-react/src/components/Telephone/Telephone.mdx
@@ -74,7 +74,7 @@ import Telephone, { CONTACTS, PATTERNS } from '@department-of-veterans-affairs/f
       pattern={false}
       ariaLabel="8 8 8. 4 4 2. 4 5 5 1"
       onClick={() => {}}
-    />
+    >
       1-888-GI-BILL-1
     </Telephone>
   </p>

--- a/packages/formation-react/src/components/Telephone/Telephone.mdx
+++ b/packages/formation-react/src/components/Telephone/Telephone.mdx
@@ -39,7 +39,7 @@ import Telephone, { CONTACTS, PATTERNS } from '@department-of-veterans-affairs/f
 
 /* Renders as
 <a
-  href="tel:+18005551212;ext=123"
+  href="tel:+18005551212,123"
   aria-label="800. 5 5 5. 1 2 1 2. extension 1 2 3."
   class="no-wrap"
 >

--- a/packages/formation-react/src/components/Telephone/Telephone.mdx
+++ b/packages/formation-react/src/components/Telephone/Telephone.mdx
@@ -8,7 +8,7 @@ import Telephone, { CONTACTS, PATTERNS } from './Telephone';
 
 ### Code:
 ```javascript
-import Telephone, { CONTACTS, PATTERNS } from '@department-of-veterans-affairs/formation-react/ProgressBar'
+import Telephone, { CONTACTS, PATTERNS } from '@department-of-veterans-affairs/formation-react/Telephone';
 
 // Minimal example
 <Telephone contact={CONTACTS.VA_BENEFITS} />

--- a/packages/formation-react/src/components/Telephone/Telephone.mdx
+++ b/packages/formation-react/src/components/Telephone/Telephone.mdx
@@ -14,7 +14,7 @@ import Telephone, { CONTACTS, PATTERNS } from '@department-of-veterans-affairs/f
 <Telephone contact={CONTACTS.VA_BENEFITS} />
 
 /* Renders as
-<a href="tel:+18008271000" aria-label="800. 8 2 7. 1000." class="no-wrap">
+<a href="tel:+18008271000" aria-label="8 0 0. 8 2 7. 1 0 0 0." class="no-wrap">
   800-827-1000
 </a>
 */
@@ -40,7 +40,7 @@ import Telephone, { CONTACTS, PATTERNS } from '@department-of-veterans-affairs/f
 /* Renders as
 <a
   href="tel:+18005551212,123"
-  aria-label="800. 5 5 5. 1 2 1 2. extension 1 2 3."
+  aria-label="8 0 0. 5 5 5. 1 2 1 2. extension 1 2 3."
   class="no-wrap"
 >
   800-555-1212, ext. 123

--- a/packages/formation-react/src/components/Telephone/Telephone.mdx
+++ b/packages/formation-react/src/components/Telephone/Telephone.mdx
@@ -99,7 +99,12 @@ import Telephone, { CONTACTS, PATTERNS } from '@department-of-veterans-affairs/f
 
   <strong>Special case (911)</strong>
   <p>
-    <Telephone contact={CONTACTS.911} onClick={e => e.preventDefault()} />
+    <Telephone
+      contact={CONTACTS.911}
+      onClick={(e) => {
+        e.preventDefault()
+      }}
+    />
   </p>
 
   <strong>Showing all options</strong>

--- a/packages/formation-react/src/components/Telephone/Telephone.mdx
+++ b/packages/formation-react/src/components/Telephone/Telephone.mdx
@@ -7,6 +7,7 @@ tags: telephone, component
 import Telephone, { CONTACTS, PATTERNS } from './Telephone';
 
 ### Code:
+
 ```javascript
 import Telephone, { CONTACTS, PATTERNS } from '@department-of-veterans-affairs/formation-react/Telephone';
 
@@ -48,7 +49,7 @@ import Telephone, { CONTACTS, PATTERNS } from '@department-of-veterans-affairs/f
 */
 
 // Special case (911)
-<Telephone contact={CONTACTS.911} />
+<Telephone contact={CONTACTS['911']} />
 
 /* Renders as
 <a href="tel:+1911" aria-label="1. 9 1 1." class="no-wrap">911</a>
@@ -100,10 +101,8 @@ import Telephone, { CONTACTS, PATTERNS } from '@department-of-veterans-affairs/f
   <strong>Special case (911)</strong>
   <p>
     <Telephone
-      contact={CONTACTS.911}
-      onClick={(e) => {
-        e.preventDefault()
-      }}
+      contact={CONTACTS['911']}
+      onClick={e => e.preventDefault()}
     />
   </p>
 

--- a/packages/formation-react/src/components/Telephone/Telephone.mdx
+++ b/packages/formation-react/src/components/Telephone/Telephone.mdx
@@ -7,7 +7,6 @@ tags: telephone, component
 import Telephone, { CONTACTS, PATTERNS } from './Telephone';
 
 ### Code:
-
 ```javascript
 import Telephone, { CONTACTS, PATTERNS } from '@department-of-veterans-affairs/formation-react/ProgressBar'
 
@@ -15,7 +14,7 @@ import Telephone, { CONTACTS, PATTERNS } from '@department-of-veterans-affairs/f
 <Telephone contact={CONTACTS.VA_BENEFITS} />
 
 /* Renders as
-<a href="tel:+18008271000" aria-label="800. 8 2 7. 1000" class="no-wrap">
+<a href="tel:+18008271000" aria-label="800. 8 2 7. 1000." class="no-wrap">
   800-827-1000
 </a>
 */
@@ -23,18 +22,35 @@ import Telephone, { CONTACTS, PATTERNS } from '@department-of-veterans-affairs/f
 // Adding a pattern
 <Telephone
   contact={CONTACTS.VA_311}
-  pattern={PATTERNS.WRAP_CODE}
+  pattern={PATTERNS.OUTSIDE_US}
 />
 
 /* Renders as
-<a href="tel:+18446982311" aria-label="8 4 4. 6 9 8. 2 3 1 1" class="no-wrap">
-  (844) 698-2311
+<a href="tel:+18446982311" aria-label="1. 8 4 4. 6 9 8. 2 3 1 1." class="no-wrap">
+  +1-844-698-2311
+</a>
+*/
+
+// Adding an extension
+<Telephone
+  contact="8005551212"
+  extension="123"
+/>
+
+/* Renders as
+<a
+  href="tel:+18005551212;ext=123"
+  aria-label="800. 5 5 5. 1 2 1 2. extension 1 2 3."
+  class="no-wrap"
+>
+  800-555-1212, ext. 123
 </a>
 */
 
 // Showing all options
 <Telephone
   contact="18884424551" // leading "1" is removed
+  extension="555" // Ignored when ariaLabel or text is included
   className="foo"
   pattern={false} // Ignored when text is included
   ariaLabel="8 8 8. 4 4 2. 4 5 5 1"
@@ -44,7 +60,7 @@ import Telephone, { CONTACTS, PATTERNS } from '@department-of-veterans-affairs/f
 </Telephone>
 
 /* Renders as
-<a href="tel:+18884424551" aria-label="8 8 8. 4 4 2. 4 5 5 1" class="no-wrap foo">
+<a href="tel:+18884424551" aria-label="8 8 8. 4 4 2. 4 5 5 1." class="no-wrap foo">
   1-888-GI-BILL-1
 </a>
 */
@@ -62,7 +78,15 @@ import Telephone, { CONTACTS, PATTERNS } from '@department-of-veterans-affairs/f
   <p>
     <Telephone
       contact={CONTACTS.VA_311}
-      pattern={PATTERNS.WRAP_CODE}
+      pattern={PATTERNS.OUTSIDE_US}
+    />
+  </p>
+
+  <strong>Adding an extension</strong>
+  <p>
+    <Telephone
+      contact="8005551212"
+      extension="
     />
   </p>
 
@@ -72,7 +96,7 @@ import Telephone, { CONTACTS, PATTERNS } from '@department-of-veterans-affairs/f
       contact="18884424551"
       className="foo"
       pattern={false}
-      ariaLabel="8 8 8. 4 4 2. 4 5 5 1"
+      ariaLabel="1. 8 8 8. 4 4 2. 4 5 5 1"
       onClick={() => {}}
     >
       1-888-GI-BILL-1
@@ -108,4 +132,4 @@ import Telephone, { CONTACTS, PATTERNS } from '@department-of-veterans-affairs/f
 |:----|:--------|:------------|
 | `911` | `###` | Matches the `911` contact number |
 | `DEFAULT` | `###-###-####` | Current phone pattern used throughout the site |
-| `WRAP_AREACODE` | `(###) ###-####` | Extra pattern; currently used for testing |
+| `OUTSIDE_US` | `+1-###-###-####` | Use on pages for veterans outside the U.S. |

--- a/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
@@ -79,7 +79,7 @@ describe('Widget <Telephone />', () => {
       <Telephone contact={CONTACTS.DS_LOGON} extension="555" />,
     );
     const props = wrapper.props();
-    expect(props.href).to.equal('tel:+18005389552;ext=555');
+    expect(props.href).to.equal('tel:+18005389552,555');
     expect(props['aria-label']).to.equal(
       '800. 5 3 8. 9 5 5 2. extension 5 5 5.',
     );
@@ -95,7 +95,7 @@ describe('Widget <Telephone />', () => {
       />,
     );
     const props = wrapper.props();
-    expect(props.href).to.equal('tel:+18005553000;ext=70');
+    expect(props.href).to.equal('tel:+18005553000,70');
     expect(props['aria-label']).to.equal('1. 800. 5 5 5. 3000. extension 70.');
     expect(wrapper.text()).to.equal('+1-800-555-3000, ext. 70');
     wrapper.unmount();

--- a/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
@@ -89,12 +89,12 @@ describe('Widget <Telephone />', () => {
   // pattern
   it('should render a custom pattern', () => {
     const wrapper = shallow(
-      <Telephone contact={CONTACTS.GI_BILL} pattern={PATTERNS.WRAP_AREACODE} />,
+      <Telephone contact={CONTACTS.GI_BILL} pattern={PATTERNS.OUTSIDE_US} />,
     );
     const props = wrapper.props();
     expect(props.href).to.equal('tel:+18884424551');
-    expect(props['aria-label']).to.equal('8 8 8. 4 4 2. 4 5 5 1');
-    expect(wrapper.text()).to.equal('(888) 442-4551');
+    expect(props['aria-label']).to.equal('1. 8 8 8. 4 4 2. 4 5 5 1');
+    expect(wrapper.text()).to.equal('+1-888-442-4551');
     wrapper.unmount();
   });
   it('should render a 7-digit custom pattern', () => {

--- a/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+
+import Telephone, { CONTACTS, PATTERNS } from './Telephone';
+
+describe('Widget <Telephone />', () => {
+  // custom numbers
+  it('should render a number', () => {
+    const wrapper = shallow(<Telephone contact="8005551212" />);
+    const props = wrapper.props();
+    expect(wrapper.type()).to.equal('a');
+    expect(props.href).to.equal('tel:+18005551212');
+    expect(props['aria-label']).to.equal('800. 5 5 5. 1 2 1 2');
+    expect(wrapper.text()).to.equal('800-555-1212');
+    wrapper.unmount();
+  });
+  it('should render a number with a leading "1"', () => {
+    const wrapper = shallow(<Telephone contact="1-800-555-1000" />);
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:+18005551000');
+    expect(props['aria-label']).to.equal('800. 5 5 5. 1000');
+    expect(wrapper.text()).to.equal('800-555-1000');
+    wrapper.unmount();
+  });
+  it('should throw an error when number does not match pattern', () => {
+    expect(() => {
+      const wrapper = shallow(<Telephone />);
+      wrapper.unmount();
+    }).to.throw('Contact number "" does not match the pattern (###-###-####)');
+  });
+  it('should throw an error when number is less than 10-digits', () => {
+    expect(() => {
+      const wrapper = shallow(<Telephone contact={4321} />);
+      wrapper.unmount();
+    }).to.throw(
+      `Contact number "4321" does not match the pattern (###-###-####)`,
+    );
+  });
+  it('should throw an error when number is more than 10-digits', () => {
+    expect(() => {
+      const wrapper = shallow(<Telephone contact="01234567891" />);
+      wrapper.unmount();
+    }).to.throw(
+      'Contact number "01234567891" does not match the pattern (###-###-####)',
+    );
+  });
+
+  // known numbers
+  it('should render a known number', () => {
+    const wrapper = shallow(<Telephone contact={CONTACTS.DS_LOGON} />);
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:+18005389552');
+    expect(props['aria-label']).to.equal('800. 5 3 8. 9 5 5 2');
+    expect(wrapper.text()).to.equal('800-538-9552');
+    wrapper.unmount();
+  });
+  it('should render VA311 (a known number)', () => {
+    const wrapper = shallow(<Telephone contact={CONTACTS.VA_311} />);
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:+18446982311');
+    expect(props['aria-label']).to.equal('8 4 4. 6 9 8. 2 3 1 1');
+    expect(wrapper.text()).to.equal('844-698-2311');
+    wrapper.unmount();
+  });
+  it('should render 911 (a known number)', () => {
+    const wrapper = shallow(<Telephone contact={CONTACTS['911']} />);
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:911');
+    expect(props['aria-label']).to.equal('9 1 1');
+    expect(wrapper.text()).to.equal('911');
+    wrapper.unmount();
+  });
+
+  // className
+  it('should render additional class name', () => {
+    const wrapper = shallow(
+      <Telephone contact={CONTACTS.GI_BILL} className="foo" />,
+    );
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:+18884424551');
+    expect(props['aria-label']).to.equal('8 8 8. 4 4 2. 4 5 5 1');
+    expect(props.className).to.equal('no-wrap foo');
+    expect(wrapper.text()).to.equal('888-442-4551');
+    wrapper.unmount();
+  });
+
+  // pattern
+  it('should render a custom pattern', () => {
+    const wrapper = shallow(
+      <Telephone contact={CONTACTS.GI_BILL} pattern={PATTERNS.WRAP_AREACODE} />,
+    );
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:+18884424551');
+    expect(props['aria-label']).to.equal('8 8 8. 4 4 2. 4 5 5 1');
+    expect(wrapper.text()).to.equal('(888) 442-4551');
+    wrapper.unmount();
+  });
+  it('should render a 7-digit custom pattern', () => {
+    const wrapper = shallow(<Telephone contact="5551212" pattern="###_####" />);
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:5551212');
+    expect(props['aria-label']).to.equal('5 5 5. 1 2 1 2');
+    expect(wrapper.text()).to.equal('555_1212');
+    wrapper.unmount();
+  });
+  it('should render a 3-digit custom pattern', () => {
+    const wrapper = shallow(<Telephone contact="711" pattern="# # #" />);
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:711');
+    // not sure if including a period and a space is a big deal; probably
+    // an edge case either way
+    expect(props['aria-label']).to.equal('7. 1. 1');
+    expect(wrapper.text()).to.equal('7 1 1');
+    wrapper.unmount();
+  });
+
+  // label
+  it('should render a custom label string', () => {
+    const ariaLabel = '800. 5 5 5. 12 12';
+    const wrapper = shallow(
+      <Telephone contact={CONTACTS.GI_BILL} ariaLabel={ariaLabel} />,
+    );
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:+18884424551');
+    expect(props['aria-label']).to.equal(ariaLabel);
+    expect(wrapper.text()).to.equal('888-442-4551');
+    wrapper.unmount();
+  });
+
+  // text
+  it('should render a custom text string', () => {
+    const wrapper = shallow(
+      <Telephone contact={CONTACTS.GI_BILL}>1-888-GI-BILL-1</Telephone>,
+    );
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:+18884424551');
+    expect(props['aria-label']).to.equal('8 8 8. 4 4 2. 4 5 5 1');
+    expect(wrapper.text()).to.equal('1-888-GI-BILL-1');
+    wrapper.unmount();
+  });
+
+  // tracking
+  it('should track on click', () => {
+    const onClick = sinon.spy();
+    const wrapper = shallow(
+      <Telephone contact={CONTACTS.GI_BILL} onClick={onClick} />,
+    );
+    wrapper.simulate('click');
+    expect(onClick.calledOnce).to.be.true;
+    wrapper.unmount();
+  });
+});

--- a/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
@@ -12,7 +12,7 @@ describe('Widget <Telephone />', () => {
     const props = wrapper.props();
     expect(wrapper.type()).to.equal('a');
     expect(props.href).to.equal('tel:+18005551212');
-    expect(props['aria-label']).to.equal('800. 5 5 5. 1 2 1 2.');
+    expect(props['aria-label']).to.equal('8 0 0. 5 5 5. 1 2 1 2.');
     expect(wrapper.text()).to.equal('800-555-1212');
     wrapper.unmount();
   });
@@ -20,7 +20,7 @@ describe('Widget <Telephone />', () => {
     const wrapper = shallow(<Telephone contact="1-800-555-1000" />);
     const props = wrapper.props();
     expect(props.href).to.equal('tel:+18005551000');
-    expect(props['aria-label']).to.equal('800. 5 5 5. 1000.');
+    expect(props['aria-label']).to.equal('8 0 0. 5 5 5. 1 0 0 0.');
     expect(wrapper.text()).to.equal('800-555-1000');
     wrapper.unmount();
   });
@@ -52,7 +52,7 @@ describe('Widget <Telephone />', () => {
     const wrapper = shallow(<Telephone contact={CONTACTS.DS_LOGON} />);
     const props = wrapper.props();
     expect(props.href).to.equal('tel:+18005389552');
-    expect(props['aria-label']).to.equal('800. 5 3 8. 9 5 5 2.');
+    expect(props['aria-label']).to.equal('8 0 0. 5 3 8. 9 5 5 2.');
     expect(wrapper.text()).to.equal('800-538-9552');
     wrapper.unmount();
   });
@@ -81,7 +81,7 @@ describe('Widget <Telephone />', () => {
     const props = wrapper.props();
     expect(props.href).to.equal('tel:+18005389552,555');
     expect(props['aria-label']).to.equal(
-      '800. 5 3 8. 9 5 5 2. extension 5 5 5.',
+      '8 0 0. 5 3 8. 9 5 5 2. extension 5 5 5.',
     );
     expect(wrapper.text()).to.equal('800-538-9552, ext. 555');
     wrapper.unmount();
@@ -96,7 +96,9 @@ describe('Widget <Telephone />', () => {
     );
     const props = wrapper.props();
     expect(props.href).to.equal('tel:+18005553000,70');
-    expect(props['aria-label']).to.equal('1. 800. 5 5 5. 3000. extension 70.');
+    expect(props['aria-label']).to.equal(
+      '1. 8 0 0. 5 5 5. 3 0 0 0. extension 7 0.'
+    );
     expect(wrapper.text()).to.equal('+1-800-555-3000, ext. 70');
     wrapper.unmount();
   });
@@ -146,7 +148,7 @@ describe('Widget <Telephone />', () => {
 
   // label
   it('should render a custom label string', () => {
-    const ariaLabel = '800. 5 5 5. 12 12.';
+    const ariaLabel = '8 0 0. 5 5 5. 12 12.';
     const wrapper = shallow(
       <Telephone contact={CONTACTS.GI_BILL} ariaLabel={ariaLabel} />,
     );

--- a/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
@@ -12,7 +12,7 @@ describe('Widget <Telephone />', () => {
     const props = wrapper.props();
     expect(wrapper.type()).to.equal('a');
     expect(props.href).to.equal('tel:+18005551212');
-    expect(props['aria-label']).to.equal('800. 5 5 5. 1 2 1 2');
+    expect(props['aria-label']).to.equal('800. 5 5 5. 1 2 1 2.');
     expect(wrapper.text()).to.equal('800-555-1212');
     wrapper.unmount();
   });
@@ -20,7 +20,7 @@ describe('Widget <Telephone />', () => {
     const wrapper = shallow(<Telephone contact="1-800-555-1000" />);
     const props = wrapper.props();
     expect(props.href).to.equal('tel:+18005551000');
-    expect(props['aria-label']).to.equal('800. 5 5 5. 1000');
+    expect(props['aria-label']).to.equal('800. 5 5 5. 1000.');
     expect(wrapper.text()).to.equal('800-555-1000');
     wrapper.unmount();
   });
@@ -52,7 +52,7 @@ describe('Widget <Telephone />', () => {
     const wrapper = shallow(<Telephone contact={CONTACTS.DS_LOGON} />);
     const props = wrapper.props();
     expect(props.href).to.equal('tel:+18005389552');
-    expect(props['aria-label']).to.equal('800. 5 3 8. 9 5 5 2');
+    expect(props['aria-label']).to.equal('800. 5 3 8. 9 5 5 2.');
     expect(wrapper.text()).to.equal('800-538-9552');
     wrapper.unmount();
   });
@@ -60,7 +60,7 @@ describe('Widget <Telephone />', () => {
     const wrapper = shallow(<Telephone contact={CONTACTS.VA_311} />);
     const props = wrapper.props();
     expect(props.href).to.equal('tel:+18446982311');
-    expect(props['aria-label']).to.equal('8 4 4. 6 9 8. 2 3 1 1');
+    expect(props['aria-label']).to.equal('8 4 4. 6 9 8. 2 3 1 1.');
     expect(wrapper.text()).to.equal('844-698-2311');
     wrapper.unmount();
   });
@@ -68,8 +68,36 @@ describe('Widget <Telephone />', () => {
     const wrapper = shallow(<Telephone contact={CONTACTS['911']} />);
     const props = wrapper.props();
     expect(props.href).to.equal('tel:911');
-    expect(props['aria-label']).to.equal('9 1 1');
+    expect(props['aria-label']).to.equal('9 1 1.');
     expect(wrapper.text()).to.equal('911');
+    wrapper.unmount();
+  });
+
+  // extension
+  it('should render a known number + extension', () => {
+    const wrapper = shallow(
+      <Telephone contact={CONTACTS.DS_LOGON} extension="555" />,
+    );
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:+18005389552;ext=555');
+    expect(props['aria-label']).to.equal(
+      '800. 5 3 8. 9 5 5 2. extension 5 5 5.',
+    );
+    expect(wrapper.text()).to.equal('800-538-9552, ext. 555');
+    wrapper.unmount();
+  });
+  it('should render a custom number + extension', () => {
+    const wrapper = shallow(
+      <Telephone
+        contact="18005553000"
+        pattern={PATTERNS.OUTSIDE_US}
+        extension="70"
+      />,
+    );
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:+18005553000;ext=70');
+    expect(props['aria-label']).to.equal('1. 800. 5 5 5. 3000. extension 70.');
+    expect(wrapper.text()).to.equal('+1-800-555-3000, ext. 70');
     wrapper.unmount();
   });
 
@@ -80,7 +108,7 @@ describe('Widget <Telephone />', () => {
     );
     const props = wrapper.props();
     expect(props.href).to.equal('tel:+18884424551');
-    expect(props['aria-label']).to.equal('8 8 8. 4 4 2. 4 5 5 1');
+    expect(props['aria-label']).to.equal('8 8 8. 4 4 2. 4 5 5 1.');
     expect(props.className).to.equal('no-wrap foo');
     expect(wrapper.text()).to.equal('888-442-4551');
     wrapper.unmount();
@@ -93,7 +121,7 @@ describe('Widget <Telephone />', () => {
     );
     const props = wrapper.props();
     expect(props.href).to.equal('tel:+18884424551');
-    expect(props['aria-label']).to.equal('1. 8 8 8. 4 4 2. 4 5 5 1');
+    expect(props['aria-label']).to.equal('1. 8 8 8. 4 4 2. 4 5 5 1.');
     expect(wrapper.text()).to.equal('+1-888-442-4551');
     wrapper.unmount();
   });
@@ -101,7 +129,7 @@ describe('Widget <Telephone />', () => {
     const wrapper = shallow(<Telephone contact="5551212" pattern="###_####" />);
     const props = wrapper.props();
     expect(props.href).to.equal('tel:5551212');
-    expect(props['aria-label']).to.equal('5 5 5. 1 2 1 2');
+    expect(props['aria-label']).to.equal('5 5 5. 1 2 1 2.');
     expect(wrapper.text()).to.equal('555_1212');
     wrapper.unmount();
   });
@@ -111,14 +139,14 @@ describe('Widget <Telephone />', () => {
     expect(props.href).to.equal('tel:711');
     // not sure if including a period and a space is a big deal; probably
     // an edge case either way
-    expect(props['aria-label']).to.equal('7. 1. 1');
+    expect(props['aria-label']).to.equal('7. 1. 1.');
     expect(wrapper.text()).to.equal('7 1 1');
     wrapper.unmount();
   });
 
   // label
   it('should render a custom label string', () => {
-    const ariaLabel = '800. 5 5 5. 12 12';
+    const ariaLabel = '800. 5 5 5. 12 12.';
     const wrapper = shallow(
       <Telephone contact={CONTACTS.GI_BILL} ariaLabel={ariaLabel} />,
     );
@@ -136,7 +164,7 @@ describe('Widget <Telephone />', () => {
     );
     const props = wrapper.props();
     expect(props.href).to.equal('tel:+18884424551');
-    expect(props['aria-label']).to.equal('8 8 8. 4 4 2. 4 5 5 1');
+    expect(props['aria-label']).to.equal('8 8 8. 4 4 2. 4 5 5 1.');
     expect(wrapper.text()).to.equal('1-888-GI-BILL-1');
     wrapper.unmount();
   });

--- a/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
@@ -16,7 +16,7 @@ describe('Widget <Telephone />', () => {
     expect(wrapper.text()).to.equal('800-555-1212');
     wrapper.unmount();
   });
-  it('should render a number with a leading "1"', () => {
+  it('should render a number without a leading "1"', () => {
     const wrapper = shallow(<Telephone contact="1-800-555-1000" />);
     const props = wrapper.props();
     expect(props.href).to.equal('tel:+18005551000');
@@ -67,8 +67,8 @@ describe('Widget <Telephone />', () => {
   it('should render 911 (a known number)', () => {
     const wrapper = shallow(<Telephone contact={CONTACTS['911']} />);
     const props = wrapper.props();
-    expect(props.href).to.equal('tel:911');
-    expect(props['aria-label']).to.equal('9 1 1.');
+    expect(props.href).to.equal('tel:+1911');
+    expect(props['aria-label']).to.equal('1. 9 1 1.');
     expect(wrapper.text()).to.equal('911');
     wrapper.unmount();
   });
@@ -97,7 +97,7 @@ describe('Widget <Telephone />', () => {
     const props = wrapper.props();
     expect(props.href).to.equal('tel:+18005553000,70');
     expect(props['aria-label']).to.equal(
-      '1. 8 0 0. 5 5 5. 3 0 0 0. extension 7 0.'
+      '1. 8 0 0. 5 5 5. 3 0 0 0. extension 7 0.',
     );
     expect(wrapper.text()).to.equal('+1-800-555-3000, ext. 70');
     wrapper.unmount();


### PR DESCRIPTION
## Description

This PR adds a `<Telephone />` component that builds an accessible telephone link.

To use it, import the component, then pass either a 10 (or 11) digit number in the `tel` property, or pass a "known" number tag in the `use` property.

```jsx
import Telephone, { CONTACTS, PATTERNS } from 'platform/forms-system/src/js/components/Telephone';

export default HotLineLink = () => (
  <Telephone contact={CONTACTS.VA_BENEFITS} />
);
```

renders:

```html
<a href="tel:+18008271000" aria-label="8 0 0. 8 2 7. 1 0 0 0." class="no-wrap">
  800-827-1000
</a>
```

<details><summary>Another example</summary>

<!-- leave a blank line above -->
```jsx
<Telephone contact={CONTACTS.GI_BILL}>
  1-888-GI-BILL-1
</Telephone>
```

renders:

```html
<a href="tel:+18884424551" aria-label="8 8 8. 4 4 2. 4 5 5 1.">
  1-888-GI-BILL-1
</a>
```
</details>

<details><summary>One more example!</summary>

<!-- leave a blank line above -->
```jsx
<Telephone
  contact="8446982311"
  pattern="(###) ###-####"
  className="foo"
/>
```

renders:

```html
<a href="tel:+18446982311" aria-label="8 4 4. 6 9 8. 2 3 1 1." class="no-wrap foo">
  (844) 698-2311
</a>
```
</details>


<details>
<summary>911 (special case)</summary>

<!-- leave a blank line above -->
```jsx
<Telephone contact={CONTACTS.911} />
```

renders:

```html
<a href="tel:+1911" aria-label="1. 9 1 1." class="no-wrap">911</a>
```
</details>


Full list of properties:

```js
/**
 * Produce a standardized accessible telephone link
 * @param {string} contact - Known phone number label; from CONTACTS, or pass a
 *  telephone number with or without leading "1" (it gets stripped off)
 * @param {string} className - Additional class name to add
 * @param {string} pattern - Formatted pattern using "#" as placeholders
 * @param {string} ariaLabel - Custom aria-label string
 * @param {function} onClick - Custom onClick function
 */
```

<details><summary>Detailed Docs</summary>

<!-- leave a blank line above -->
### `contact`

- Pass in a number:
  - Any leading `1` is stripped out; if it _must_ start with a `1` then add a space in front
  - Can be any length, but _must_ match the number of `#` characters within the `pattern`, or an error is thrown
  - Property can include any non-digit characters; they will be stripped out during processing
- Known number label passed to the component
  - case-sensitive
  - current list:

    | Key | Number | Description |
    |:------|:-----|:-----|
    | `222_VETS` | `8772228387` | VA Help Line |
    | `4AID_VET` | `8774243838` | National Call Center for Homeless Veterans |
    | `911` | `911` | Emergency! |
    | `CAREGIVER` | `8552603274` | VA National Caregiver Support Line |
    | `CRISIS_LINE` | `8002738255` | Veterans Crisis hotline |
    | `CRISIS_TTY` | `8007994889` | Veterans Crisis hotline TTY |
    | `DS_LOGON` | `8005389552` | Defense Manpower Data Center |
    | `DS_LOGON_TTY` | `8663632883` | Defense Manpower Data Center TTY |
    | `GI_BILL` | `8884424551` | Education Call Center (1-888-GI-BILL-1) |
    | `GO_DIRECT` | `8003331795` | Go Direct/Direct Express (Treasury) |
    | `HELP_DESK` | `8555747286` | VA Help desk |
    | `HELP_TTY` | `8008778339` | VA Help Desk TTY |
    | `MY_HEALTHEVET` | `8773270022` | My HealtheVet help desk |
    | `NCA` | `8005351117` | National Cemetery Scheduling Office |
    | `TESC` | `8882242950` | U.S. Treasury Electronic Payment Solution Center |
    | `VA_311` | `8446982311` | VA Help desk (VA311) |
    | `VA_BENEFITS` | `8008271000` | Veterans Benefits Assistance |

### `className`

- Added as space separated class names in a string

### `pattern`

- Use `#` to represent the number
- Use any characters in and around the `#`, e.g. `(###) ###-####` or `###_###_####`
- The number of `#` characters _must_ be the same length as the number
- current list

    | Key | Pattern | Description |
    |:----|:--------|:------------|
    | `911` | `###` | Matches the `911` contact number |
    | `DEFAULT` | `###-###-####` | Current phone pattern used throughout the site |
    | `OUTSIDE_US` | `+1-###-###-####` | Used on pages targeting veterans outside the U.S. |

### `ariaLabel`

- Defines a custom `aria-label`
- Pass in a string
- The built-in function will group rounded numbers together, e.g. `800` and `1000` will not be separated within the label, where as `888` will be converted into `8 8 8`; and each group is combined, but separated by a period and a space `. `. This results in something like this `8 8 8. 5 5 5. 1000`

### Custom text

- Add any custom text as a child of the `<Telephone>` component; See the included example

### `onClick`

- Defines any action to be done after the link is clicked
- The default action was going to be recording an analytics event, but is disabled in this PR until a event label can be determined.
- Only the `event` parameter is passed to this function.
</details>

Related issues:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/8793
- https://github.com/department-of-veterans-affairs/vets-website/pull/12546

## Testing done

Local unit tests added

## Screenshots

N/A

## Acceptance criteria
- [x] Accept a telephone number with or without dashes or spaces, e.g. `800 827 1000` or `8008271000`
- [x] Accept named "standard" phone numbers, e.g. `VA_311`
- [x] Allow altering the `aria-label`; <del>not separate out `800` or `1000`, but</del> should separate out `8 2 7` for screen-readers to improve output.
- [x] Prevent phone number wrap.
- [x] Allow changing the visual format (if required): `800-827-1000` vs `1-800-827-1000`

## Definition of done
- [ ] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
