### PR TITLE
enable GFM for markdown files

### DIFF
--- a/packages/documentation/gatsby-config.js
+++ b/packages/documentation/gatsby-config.js
@@ -76,7 +76,21 @@ module.exports = {
       },
     },
     `gatsby-transformer-react-docgen`,
-    `gatsby-transformer-remark`,
+    {
+      resolve: `gatsby-transformer-remark`,
+      options: {
+        // CommonMark mode (default: true)
+        commonmark: true,
+        // Footnotes mode (default: true)
+        footnotes: true,
+        // Pedantic mode (default: true)
+        pedantic: true,
+        // GitHub Flavored Markdown mode (default: true)
+        gfm: true,
+        // Plugins configs
+        plugins: [],
+      },
+    },
     `github-api-pages`,
     `mdx-pages`,
     {
@@ -88,7 +102,7 @@ module.exports = {
         resolvers: {
           // For any node of type MarkdownRemark, list how to resolve the fields` values
           SitePage: {
-            title: node => {
+            title: (node) => {
               if (
                 node.context &&
                 node.context.frontmatter &&
@@ -108,7 +122,7 @@ module.exports = {
 
               return '';
             },
-            tags: node => {
+            tags: (node) => {
               if (
                 node.context &&
                 node.context.frontmatter &&
@@ -119,7 +133,7 @@ module.exports = {
 
               return '';
             },
-            path: node => node.path,
+            path: (node) => node.path,
           },
         },
       },


### PR DESCRIPTION
## Description
Configure syntax highlighting for Github Flavored Markdown using https://www.gatsbyjs.org/packages/gatsby-transformer-remark/
