### PR TITLE
Fix the use of platform alias 

### DIFF
--- a/packages/documentation/src/pages/getting-started/common-tasks/new-application.mdx
+++ b/packages/documentation/src/pages/getting-started/common-tasks/new-application.mdx
@@ -68,7 +68,7 @@ Here are the steps for manually setting up a new application. We're going to wal
 import 'platform/polyfills';
 import './sass/my-new-application.scss';
 
-import startApp from '../../platform/startup';
+import startApp from 'platform/startup';
 
 import routes from './routes';
 import reducer from './reducers';


### PR DESCRIPTION
## Description

After updating the `generator-vets-website` repo, I'm updating the documentation to reflect those changes

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
