### PR TITLE
Add initialFocusSelector prop to Modal 

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/modal/Modal.jsx
+++ b/packages/formation-react/src/components/modal/Modal.jsx
@@ -31,7 +31,7 @@ class Modal extends React.Component {
 
   setupModal() {
     this.setState({ lastFocus: document.activeElement });
-    this.applyFocusToFirstModalElement();
+    this.setInitialModalFocus();
     // NOTE: With this PR (https://github.com/department-of-veterans-affairs/vets-website/pull/11712)
     // we rely on the existence of `body.modal-open` to determine if a modal is
     // currently open and adjust programmatic scrolling if there is.
@@ -92,6 +92,19 @@ class Modal extends React.Component {
       this.props.onClose();
     }
   };
+
+  setInitialModalFocus() {
+    if (this.props.initialFocusSelector) {
+      const focusableElement = this.element.querySelector(
+        this.props.initialFocusSelector,
+      );
+      if (focusableElement) {
+        focusableElement.focus();
+      }
+    } else {
+      this.applyFocusToFirstModalElement();
+    }
+  }
 
   applyFocusToFirstModalElement() {
     const focusableElement = this.element.querySelector(
@@ -250,10 +263,16 @@ Modal.propTypes = {
    */
   hideCloseButton: PropTypes.bool,
   /**
-   * Selector to use to find elements to focus on when the
-   * modal is opened
+   * Selector to use to find elements that should be focusable
+   * within the modal
    */
   focusSelector: PropTypes.string,
+  /**
+   * Selector to explicitly specify which element should receive
+   * focus when the modal is open, if the initially focused element
+   * is not the first focusable element in the document
+   */
+  initialFocusSelector: PropTypes.string,
 };
 
 Modal.defaultProps = {

--- a/packages/formation-react/src/components/modal/Modal.unit.spec.jsx
+++ b/packages/formation-react/src/components/modal/Modal.unit.spec.jsx
@@ -47,8 +47,64 @@ describe('<Modal/>', () => {
     global.document.removeEventListener.restore();
   });
 
-  it('should pass aXe check', () =>
-    axeCheck(
-      <Modal id="modal" title="Modal title" visible onClose={() => {}} />,
-    ));
+  it('should pass aXe check', () => {
+    return axeCheck(
+      <Modal id="modal" title="aXe Check" visible onClose={() => {}} />,
+    );
+  });
+
+  describe('programmatic focus', () => {
+    // see this issue comment for some enzyme/jsdom concerns to be aware of
+    // when testing focus:
+    // https://github.com/enzymejs/enzyme/issues/2337#issuecomment-609071803
+    let tree;
+    let root;
+
+    before(() => {
+      root = document.createElement('div');
+      global.document.body.appendChild(root);
+    })
+
+    after(() => {
+      tree && tree.unmount();
+      global.document.body.removeChild(root);
+    });
+
+    it('should start on the first focusable element by default', () => {
+      const tree = mount(
+        <Modal id="modal"
+          title="Programmatic focus"
+          visible
+          hideCloseButton
+          onClose={() => {}}
+        >
+          <button id="first-button">First button</button>
+          <button id="second-button">Second button</button>
+        </Modal>,
+        { attachTo: root }
+      );
+
+      expect(global.document.activeElement.id).to.equal('first-button');
+      tree.unmount();
+    });
+
+    it('should start on the first element matching initialFocusSelector if specified', () => {
+      const tree = mount(
+        <Modal id="modal"
+          title="My modal"
+          visible
+          hideCloseButton
+          onClose={() => {}}
+          initialFocusSelector="#second-button"
+        >
+          <button id="first-button">First button</button>
+          <button id="second-button">Second button</button>
+        </Modal>,
+        { attachTo: root }
+      );
+
+      expect(global.document.activeElement.id).to.equal('second-button');
+      tree.unmount();
+    });
+  });
 });


### PR DESCRIPTION
## Description

This PR is a small change to allow consumers of the `Modal` component to customize where programmatic focus starts when the modal is first opened. The primary use case of this feature - or at least, the use case I wanted to solve - is to initiate keyboard focus on the modal content rather than the close button without removing the close button. This is a minor improvement for keyboard users. 

Feedback on how useful this change is would be welcome - it's certainly a corner case but seems like an improvement, in my opinion.

## Testing done

* Manually tested with the [crisis line modal](https://github.com/department-of-veterans-affairs/developer-portal/blob/master/src/components/crisisLine/VeteransCrisisLine.tsx) in the Lighthouse developer portal
* Added unit tests for programmatic focus

## Screenshots

Focus on modal open without this change:

<img width="423" alt="ModalWithoutCustomInitialFocus170" src="https://user-images.githubusercontent.com/3241493/83176420-69bd6500-a0eb-11ea-8f09-84d9eea414b0.png">

Focus on modal open with the change:

<img width="406" alt="ModalWithCustomInitialFocus170" src="https://user-images.githubusercontent.com/3241493/83176446-75109080-a0eb-11ea-922e-b3472c23ca2a.png">

## Acceptance criteria
- [X] If the `initialFocusSelector` prop is provided and matches an element other than the first element that matches the `focusSelector` prop (which is the close button, with the default props), focus when the modal opens is on the first element matching `initialFocusSelector`.

## Definition of done
- [X] Changes have been tested in ~~vets-website~~ developer-portal
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
  - do the props on the documentation page get generated from `propTypes`, or do they need to be updated somewhere else?
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
  - original issue (if you have access to Lighthouse on the VA MAX.gov JIRA): https://vajira.max.gov/browse/API-170
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
