### PR TITLE
Documentation updates for "getting started" flow

### DIFF
--- a/packages/documentation/src/pages/getting-started/index.mdx
+++ b/packages/documentation/src/pages/getting-started/index.mdx
@@ -113,6 +113,8 @@ Setting up the backend and internal tools allows local test account login and st
 
 - [**Backend (`vets-api`) set up** instructions](https://github.com/department-of-veterans-affairs/vets-api)
 
+  The local `vets-website` is configured to point to the `vets-api` backend at `http://localhost:3000`. Any website functionality that depends on the backend (i.e. login, save-in-progress, form submission, feature toggles) will require a locally running instance of `vets-api`.
+
 - [**Local test account login** instructions](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Administrative/Accessing-Staging.md)
 
 - [Internal tools setup instructions](internal-tools)

--- a/packages/documentation/src/pages/getting-started/index.mdx
+++ b/packages/documentation/src/pages/getting-started/index.mdx
@@ -4,107 +4,106 @@ tags: local, watch, node, nvm, yarn, install
 ---
 
 # Set up VA.gov locally
-These instructions cover the installation of dependencies needed for running VA.gov locally.
-- **Node setup** - steps for installing `node` which is needed for building, testing, and running the local development server
-- **Get the source code** - steps for cloning the various repos needed to run VA.gov
-- **Start up the front end** - installing and running VA.gov locally
-- **Backend and local tools setup** - links to other setup instructions for running `vets-api` and retrieving static content
 
-## Prerequisites
-For Mac, [homebrew](http://brew.sh/) is recommended for installing `nvm` but other installation approaches are on [nvm Github page](https://github.com/creationix/nvm#installation-and-update).
+These instructions cover building and running VA.gov locally, including configuring any required dependencies.
 
 ## Node setup
 
 1. Install `nvm`:
 
-Mac:
+   **Mac:**
 
-```bash
-brew update && brew install nvm
-```
+   [homebrew](http://brew.sh/) is recommended for installing `nvm` but other installation approaches are on [nvm Github page](https://github.com/creationix/nvm#installation-and-update).
 
-Linux:
 
-To get the latest version of NVM visit the official page. [NVM](https://github.com/nvm-sh/nvm)
+   ```bash
+   $ brew update && brew install nvm
+   ```
 
-```bash
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
-```
+   **Linux:**
 
-_Follow the post install instructions in the success message._
+   To get the latest version of NVM visit the official page. [NVM](https://github.com/nvm-sh/nvm)
 
-2. Install `node 10.15.3` (this also installs `npm`):
+   ```bash
+   $ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
+   ```
 
-```bash
-nvm install 10.15.3
-```
+   Follow the post-install instructions in the success message.
 
-3. Configure `nvm` to use `node 10.15.3` by default:
+1. Install `node 10.15.3` (this also installs `npm`):
 
-```bash
-nvm alias default 10.15.3
-```
+   ```bash
+   $ nvm install 10.15.3
+   ```
 
-4. Install `yarn 1.12.3` globally:
+1. Configure `nvm` to use `node 10.15.3` by default:
 
-```bash
-npm i -g yarn@1.12.3
-```
+   ```bash
+   $ nvm alias default 10.15.3
+   ```
 
-5. Verify correct versions of `node` and `yarn` are installed:
+1. Install `yarn 1.12.3` globally:
 
-```bash
-node --version # 10.15.3
-yarn --version # 1.12.3
-```
+   ```bash
+   $ npm i -g yarn@1.12.3
+   ```
+
+1. Verify correct versions of `node` and `yarn` are installed:
+
+   ```bash
+   $ node --version # 10.15.3
+   $ yarn --version # 1.12.3
+   ```
 
 ## Get the source code
 
 6. Clone VA.gov git repos **as sibling directories**:
 
-```bash
-git clone git@github.com:department-of-veterans-affairs/vets-website.git
-git clone git@github.com:department-of-veterans-affairs/vagov-content.git
-git clone git@github.com:department-of-veterans-affairs/vets-json-schema.git
-git clone git@github.com:department-of-veterans-affairs/veteran-facing-services-tools.git
-git clone git@github.com:department-of-veterans-affairs/vets-api.git
-git clone git@github.com:department-of-veterans-affairs/vets-api-mockdata.git
-```
+   ```bash
+   $ git clone git@github.com:department-of-veterans-affairs/vets-website.git
+   $ git clone git@github.com:department-of-veterans-affairs/vagov-content.git
+   $ git clone git@github.com:department-of-veterans-affairs/vets-json-schema.git
+   $ git clone git@github.com:department-of-veterans-affairs/veteran-facing-services-tools.git
+   $ git clone git@github.com:department-of-veterans-affairs/vets-api.git
+   $ git clone git@github.com:department-of-veterans-affairs/vets-api-mockdata.git
+   ```
 
-*Front end repos*
-- **vets-website**: Core front end platform and application code
-- **vagov-content**: Markdown content used to generate static pages
-- **veteran-facing-services-tools**: Shared front end components (including non VA.gov users) and front end documentation site
+   **Front end repos**
+   - `vets-website`: Core front end platform and application code
+   - `vagov-content`: Markdown content used to generate static pages
+   - `veteran-facing-services-tools`: Shared front end components (including non VA.gov users) and front end documentation site
 
-*Back end repos*
-- **vets-api**: Core Rails API server application code
-- **vets-api-mockdata**: Mock data used when running locally and on dev for the backend
+   **Back end repos**
+   - `vets-api`: Core Rails API server application code
+   - `vets-api-mockdata`: Mock data used when running locally and on dev for the backend
 
-*Shared repos*
-- **vets-json-schema**: Shared JSON Schema definitions used by form applications and the APIs that they consume
+   **Shared repos**
+   - `vets-json-schema`: Shared JSON Schema definitions used by form applications and the APIs that they consume
 
 ## Start up the front end
 
-7. Install `vets-website` dependencies. See these [common commands](https://github.com/department-of-veterans-affairs/vets-website/blob/master/README.md) for more information.
-```bash
-yarn install
-```
+7. Navigate to the `vets-website` repository, then install `vets-website` dependencies. See these [common commands](https://github.com/department-of-veterans-affairs/vets-website/blob/master/README.md) for more information.
+   ```bash
+   $ cd vets-website
+   $ yarn install
+   ```
 
-8. Build `vets-website`. Make sure you [configured the SOCKS proxy](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/internal-tools.md#configure-the-socks-proxy).
-```bash
-yarn build
-```
-If you do not have access to the SOCKS proxy, you can fetch the latest cached version of the content.
-```bash
-yarn fetch-drupal-cache
-```
+8. Build `vets-website`. Make sure you [configured the SOCKS proxy](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/internal-tools.md#configure-the-socks-proxy) to fetch content from Drupal.
+   ```bash
+   $ yarn build
+   ```
+
+   If you do not have access to the SOCKS proxy, you can alternately fetch the latest cached version of the content.
+   ```bash
+   $ yarn fetch-drupal-cache
+   ```
 
 9. Start the local development server.
-```bash
-yarn watch
-```
+   ```bash
+   $ yarn watch
+   ```
 
-*Build is complete when the CLI says* `Compiled successfully`
+   The build is complete when the CLI says `Compiled successfully`.
 
 10. Open [http://localhost:3001](http://localhost:3001) in a browser
 
@@ -112,13 +111,10 @@ yarn watch
 
 Setting up the backend and internal tools allows local test account login and static content rendering.
 
-- **Backend set up** instructions: [vets-api](https://github.com/department-of-veterans-affairs/vets-api).
+- [**Backend (`vets-api`) set up** instructions](https://github.com/department-of-veterans-affairs/vets-api)
 
-*Follow the Docker instructions, which are in the README for the `vets-api` repo.*
+- [**Local test account login** instructions](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Administrative/Accessing-Staging.md)
 
-- **Local test account login** instructions: [Accessing Staging](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Administrative/Accessing-Staging.md)
+- [Internal tools setup instructions](internal-tools)
 
-
-- **Internal tools setup** instructions: [Accessing internal tools](internal-tools).
-
-*This proxy setup is required to access static content locally and to access to our reporting and monitoring tools. Running the watch task with the SOCK proxy active will automatically pull and cache the static content for `vets-website`*
+  This proxy setup is required to access static content locally and to access to our reporting and monitoring tools. Running the `yarn watch` task with the SOCKS proxy active will automatically pull and cache the static content for `vets-website`.

--- a/packages/documentation/src/pages/getting-started/workflow/review.mdx
+++ b/packages/documentation/src/pages/getting-started/workflow/review.mdx
@@ -68,8 +68,8 @@ After a pull request is created, **Jenkins** will automatically **rebuild** thes
 
 **Jenkins** can be **manually triggered** to build a **review instance**.
 
-1. Visit http://jenkins.vetsgov-internal/job/vets-review-instance-deploy/ and log in.
-1. Select "Build with Parameters"
+1. Visit the [Jenkins Review Application Deploy job UI](http://jenkins.vfs.va.gov/job/deploys/job/vets-review-instance-deploy/) and log in.
+1. Select **Build with Parameters**
 1. Specify the branch names for `api_branch` and `web_branch`. These branches will be deployed together with the review instance.
 1. When the process is completed, the URL for the review instance will be provided at the end of the output logs.
 

--- a/packages/documentation/src/pages/platform/tools/generator.mdx
+++ b/packages/documentation/src/pages/platform/tools/generator.mdx
@@ -9,18 +9,9 @@ We have a Yeoman generator for starting up new React applications in vets-websit
 
 > You can find more information about creating forms in the [forms section](/forms).
 
-## Getting Started
-
-To install the generator, run the following:
-
-```bash
-$ npm install -g yo
-$ npm install -g @department-of-veterans-affairs/generator-vets-website
-```
-
 ## Usage
 
-Once you have the generator installed, navigate to the root of the vets-website repository and run:
+Navigate to the root of the vets-website repository and run:
 
 ```bash
 $ yarn new:app

--- a/packages/documentation/src/pages/platform/tools/generator.mdx
+++ b/packages/documentation/src/pages/platform/tools/generator.mdx
@@ -11,11 +11,11 @@ We have a Yeoman generator for starting up new React applications in vets-websit
 
 ## Getting Started
 
-To install the generator, you'll need to do the following:
+To install the generator, run the following:
 
 ```bash
-npm install -g yo
-npm install -g @department-of-veterans-affairs/generator-vets-website
+$ npm install -g yo
+$ npm install -g @department-of-veterans-affairs/generator-vets-website
 ```
 
 ## Usage
@@ -23,40 +23,42 @@ npm install -g @department-of-veterans-affairs/generator-vets-website
 Once you have the generator installed, navigate to the root of the vets-website repository and run:
 
 ```bash
-yo @department-of-veterans-affairs/vets-website
+$ yarn new:app
 ```
 
 After running the above command, the generator will start up and ask you a series of questions:
 
 ### What's the name of your application?
-> This will be the default page title. Examples: '21P-530 Burials benefits form' or 'GI Bill School Feedback Tool'
+> This will be the default page title. Examples: `21P-530 Burials benefits form` or `GI Bill School Feedback Tool`
 
 This value will be used as the page title. If you're creating a form, it will also be used as the header for the introduction page and as a header on the confirmation page.
 
 ### What folder in `src/applications/` should your app live in?
-> This can be a subfolder. Examples: 'burials' or 'edu-benefits/0993'
+> This can be a subfolder. Examples: `burials` or `edu-benefits/0993`
 
 Most of our React applications have their own folder in src/applications, so normally you want to pick a new folder. However, if you're building an application that's related to other applications, there may be a folder that your app should go in. An example would be if you were creating a new education form, you would probably create your app in edu-benefits/newform.
 
 ### What should be the name of your app's entry bundle?
-> Examples: '0993-edu-benefits' or 'feedback-tool'
+> Examples: `0993-edu-benefits` or `feedback-tool`
 
 This is the name of the bundle that Webpack builds for your application. They're normally lower case with dashes separating words. This is primarily used to link your bundle to the content page that is created as a base for your application. It doesn't show up in your code anywhere. It's also separate from the entry file.
 
-### What's the root url for this app?
-> Examples: '/gi-bill-comparison-tool/' or 'education/opt-out-information-sharing/opt-out-form-0993'
+### What's the root URL for this app?
+> Examples: `/gi-bill-comparison-tool/` or `/education/opt-out-information-sharing/opt-out-form-0993`
 
-This is the url your application will live at. In your React apps you will likely have multiple pages and the urls for those pages will have this as the base. This value also gets translated into the page for the content page, which lives in `content/pages`.
+This is the URL your application will live at, starting with a leading slash. In your React apps you will likely have multiple pages and the URLs for those pages will have this as the base. This value also gets translated into the page for the content page, which lives in `content/pages`.
 
 ### Is this a form app?
 
 If this is a form, there are some more questions after this step. If not, you're done!
 
-### What's your form number? Examples: '22-0993' or '21P-530'
+### What's your form number?
+> Examples: `22-0993` or `21P-530`
 
-This is the form number for the paper form you're converting. Normally it's something like 22-1990 or 21-22. This is used in a couple places in the UI and also as a key for the save in progress functionality of our forms.
+This is the form number for the paper form you're converting. This is used in a couple places in the UI and also as a key for the save in progress functionality of our forms.
 
-### What's the Google Analytics event prefix that you want to use? Examples: 'burials-530-' or 'edu-0993-'
+### What's the Google Analytics event prefix that you want to use?
+> Examples: `burials-530-` or `edu-0993-`
 
 Our shared form code sends events to Google Analytics and we need a unique prefix to be able to categorize the events by form. It's normally a dash separated value like `hca-` or `edu-1990-` and is made up by developers.
 
@@ -72,13 +74,13 @@ This is the respondent burden value from that information. All the information f
 
 Similarly to the last question, this is more information from the OMB data, which lives in the margins of the pages of the paper form.
 
-### What's the OMB expiration date (in M/D/YYYY format) for this form? Example: '1/31/2019'
+### What's the OMB expiration date (in M/D/YYYY format) for this form? Example: `1/31/2019`
 
 Again similarly to the last question, this is more information from the OMB data, which lives in the margins of the pages of the paper form.
 
-### What's the benefit description for this form? Examples: 'education benefits' or 'disability claims increase'
+### What's the benefit description for this form? Examples: `education benefits` or `disability claims increase`
 
-This question is a bit more nebulous. We have a description of the type of benefits that you would be getting by using this form. Other examples are "health care benefits" and "veteran id card."
+This question is a bit more nebulous. We have a description of the type of benefits that you would be getting by using this form. Other examples are `health care benefits` and `veteran id card`.
 
 ### What kind of form template would you like to start with?
 
@@ -96,6 +98,8 @@ Choose from the following options:
 ## You're done!
 
 Once you've answered all those questions, you're done and the generator will create the files for you. To see them in your local development environment, you'll need to build again or restart the watch task you have running.
+
+Once you've done that, you can access the URL at `http://localhost:3001/APP_ROOT_URL`. Replace `APP_ROOT_URL` with the root URL for your application.
 
 To learn more about using the generator and working with the generated code, see our [forms documentation](/forms).
 


### PR DESCRIPTION
## Description

Makes a number of documentation updates to a couple key "getting started" pages --- content, formatting, and small pain points discovered while trying to run through creating and running an application from scratch.

Getting started page:
* Indents text and samples to be aligned with the ordered bullets
* Adds missing `cd vets-website` between checking out repos and `yarn install`
* Minor wording tweaks in a few places
* Removes unnecessary section descriptions at the top of the doc
* Formatting tweaks in accordance with upcoming developer content style guide
* Adds message about website depending on local backend by default 

Yeoman generator doc:
* Puts all example values in backticks
* Removes example values from headings
* Makes root URL guidance more consistent (examples + text indicate leading slash)
* Adds note about how to access the application once it's running
* Removes generator install directions

Review doc: fixes a broken link to Jenkins UI