### PR TITLE
Add Telephone to formation-react readme

### DIFF
--- a/packages/formation-react/README.md
+++ b/packages/formation-react/README.md
@@ -38,5 +38,6 @@ See [design system](https://department-of-veterans-affairs.github.io/design-syst
 - SegmentedProgressBar.js
 - SortableTable.js
 - SystemDownView.js
+- Telephone.js
 - Tooltip.js
 - MegaMenu.js


### PR DESCRIPTION
## Description

Formation react readme didn't include the new Telephone.js component

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [ ] Update readme

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
