### PR TITLE
Removes extra line break in getting-started doc

### DIFF
--- a/packages/documentation/src/pages/getting-started/index.mdx
+++ b/packages/documentation/src/pages/getting-started/index.mdx
@@ -15,7 +15,6 @@ These instructions cover building and running VA.gov locally, including configur
 
    [homebrew](http://brew.sh/) is recommended for installing `nvm` but other installation approaches are on [nvm Github page](https://github.com/creationix/nvm#installation-and-update).
 
-
    ```bash
    $ brew update && brew install nvm
    ```


### PR DESCRIPTION
## Description
This seems to be breaking indentation in the getting started docs.

## Screenshots
![image](https://user-images.githubusercontent.com/769353/85442171-b9554c00-b544-11ea-9a0f-aa015f70f342.png)
