### PR TITLE
Made AdditionalInfo trigger a block element to fix screenreader focus issue.

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/AdditionalInfo/AdditionalInfo.jsx
+++ b/packages/formation-react/src/components/AdditionalInfo/AdditionalInfo.jsx
@@ -18,17 +18,28 @@ export default class AdditionalInfo extends React.Component {
 
   render() {
     const { triggerText, children } = this.props;
+
+    // Display button as a block element in order to
+    // preserve the Safari VoiceOver navigation order
+    // when expanding the content.
+    const buttonClass = classNames(
+      'additional-info-button',
+      'va-button-link',
+      'vads-u-display--block',
+    );
+
     const iconClass = classNames({
       fas: true,
       'fa-angle-down': true,
       open: this.state.open,
     });
+
     const { tagName: TagName = 'span' } = this.props;
 
     const trigger = (
       <button
         type="button"
-        className="additional-info-button va-button-link vads-u-display--block"
+        className={buttonClass}
         aria-expanded={this.state.open ? 'true' : 'false'}
         aria-controls={this.expandedContentId}
         onClick={this.toggle}

--- a/packages/formation-react/src/components/AdditionalInfo/AdditionalInfo.jsx
+++ b/packages/formation-react/src/components/AdditionalInfo/AdditionalInfo.jsx
@@ -28,7 +28,7 @@ export default class AdditionalInfo extends React.Component {
     const trigger = (
       <button
         type="button"
-        className="additional-info-button va-button-link"
+        className="additional-info-button va-button-link vads-u-display--block"
         aria-expanded={this.state.open ? 'true' : 'false'}
         aria-controls={this.expandedContentId}
         onClick={this.toggle}


### PR DESCRIPTION
## Description

Fixes department-of-veterans-affairs/va.gov-team#8856.

## Testing done

- Local testing with Safari VoiceOver navigation.
- Added class in dev tools and tested on Staging.

## Acceptance criteria
- [ ] Safari VoiceOver should follow the proper order when navigating an `AdditionalInfo` component.

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
