### PR TITLE
Fix Doc Github link

### DIFF
--- a/packages/documentation/src/components/pageFooter/Documentation.jsx
+++ b/packages/documentation/src/components/pageFooter/Documentation.jsx
@@ -11,13 +11,18 @@ import sidebarData from '../../sidebar';
  */
 
 const getIndexMdx = (location) => {
+  const pathName = location.pathname.replace(
+    '/veteran-facing-services-tools',
+    '',
+  );
+
   const sidebarSection = sidebarData.sections.find((section) =>
-    location.pathname.includes(section.href),
+    pathName.includes(section.href),
   );
 
   // Test first Level of the sidebar object
   const level1 = sidebarData.sections.find(
-    (section) => section.href === location.pathname,
+    (section) => section.href === pathName,
   );
 
   if (level1?.indexmdx) {
@@ -28,12 +33,12 @@ const getIndexMdx = (location) => {
   if (sidebarSection?.items) {
     const level2Sections = sidebarSection.items.map((item) => {
       return Array.isArray(item.items)
-        ? item.items.find((lvl2Item) => lvl2Item.href === location.pathname)
+        ? item.items.find((lvl2Item) => lvl2Item.href === pathName)
         : null;
     });
 
     const level2 = level2Sections.map((section) => {
-      if (section?.href && section.href === location.pathname) {
+      if (section?.href && section.href === pathName) {
         return section?.indexmdx ? true : false;
       }
     });
@@ -49,8 +54,11 @@ const getIndexMdx = (location) => {
 export default function Documentation({ location }) {
   const base = `https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/master/packages`;
   const documentation = '/documentation/src/pages';
-  const link =
-    base + documentation + location.pathname + getIndexMdx(location) + '.mdx';
+  const pathName = location.pathname.replace(
+    '/veteran-facing-services-tools',
+    '',
+  );
+  const link = base + documentation + pathName + getIndexMdx(location) + '.mdx';
 
   return <Link to={link}>Edit this page on GitHub</Link>;
 }

--- a/packages/documentation/src/components/pageFooter/PageFooter.jsx
+++ b/packages/documentation/src/components/pageFooter/PageFooter.jsx
@@ -4,7 +4,11 @@ import Documentation from './Documentation';
 
 const getGithubHref = (location) => {
   if (location.pathname.includes('components')) {
-    return <Components pathname={location.pathname} />;
+    const pathName = location.pathname.replace(
+      '/veteran-facing-services-tools',
+      '',
+    );
+    return <Components pathname={pathName} />;
   } else {
     return <Documentation location={location} />;
   }


### PR DESCRIPTION
## Description
Client Application Documentation site adds an extra path (`/veteran-facing-services-tools`) to the relative path of the site:
`https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/getting-started`

This causes that the github links won't work as expected in the local environment. This PR will fix that problem.

## Testing done
Locally

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
