### PR TITLE
Updated end-to-end page with info on Cypress.

### DIFF
--- a/packages/documentation/src/pages/getting-started/common-tasks/new-end-to-end-test.mdx
+++ b/packages/documentation/src/pages/getting-started/common-tasks/new-end-to-end-test.mdx
@@ -11,7 +11,9 @@ Front end engineers use end-to-end (e2e) tests in `vets-website` to validate mul
 
 ## End-to-end testing overview
 
-- `vets-website` uses [Nightwatch](https://nightwatchjs.org) to run the tests and provide the browser client
+- `vets-website` uses [Nightwatch](https://nightwatchjs.org) to run some of the older end-to-end tests
+  - New end-to-end tests should be written in Cypress going forward.
+  - Refer to the [Cypress migration guide](https://github.com/department-of-veterans-affairs/va.gov-team/blob/6dccdd3ac61d7fbfa8b30e317230cc9212a7c9f8/teams/vsp/teams/tools/frontend/cypress-migration-guide.md) to convert old tests or follow certain conventions with new tests.
 - end-to-end tests are **collocated in application folder** with the application they test
 - Two node apps run with the end-to-end tests:
   - `mockapi.js` - hosts mock responses (see [Mocking API responses](#mocking-api-responses))

--- a/packages/documentation/src/pages/getting-started/common-tasks/new-end-to-end-test.mdx
+++ b/packages/documentation/src/pages/getting-started/common-tasks/new-end-to-end-test.mdx
@@ -13,7 +13,7 @@ Front end engineers use end-to-end (e2e) tests in `vets-website` to validate mul
 
 - `vets-website` uses [Nightwatch](https://nightwatchjs.org) to run some of the older end-to-end tests
   - New end-to-end tests should be written in Cypress going forward.
-  - Refer to the [Cypress migration guide](https://github.com/department-of-veterans-affairs/va.gov-team/blob/6dccdd3ac61d7fbfa8b30e317230cc9212a7c9f8/teams/vsp/teams/tools/frontend/cypress-migration-guide.md) to convert old tests or follow certain conventions with new tests.
+  - Refer to the [Cypress migration guide](https://github.com/department-of-veterans-affairs/va.gov-team/blob/6dccdd3ac61d7fbfa8b30e317230cc9212a7c9f8/teams/vsp/teams/tools/frontend/cypress-migration-guide.md) to convert old tests or write new tests.
 - end-to-end tests are **collocated in application folder** with the application they test
 - Two node apps run with the end-to-end tests:
   - `mockapi.js` - hosts mock responses (see [Mocking API responses](#mocking-api-responses))


### PR DESCRIPTION
## Description
The current page for writing new E2E tests is written with Nightwatch in mind.

This updates it to recommend using Cypress with a link to the migration guide.

## Testing done
Locally verified content changes.

## Acceptance criteria
- [ ] Documentation on end-to-end tests should clarify that the instructions are for Nightwatch tests
- [ ] Documentation on end-to-end tests should designate Cypress as the new standard.

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs