### PR TITLE
[CollapsiblePanel] Fix for runtime error for non-va.gov consumers

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "5.4.2",
+  "version": "5.4.3",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/CollapsiblePanel/CollapsiblePanel.jsx
+++ b/packages/formation-react/src/components/CollapsiblePanel/CollapsiblePanel.jsx
@@ -19,6 +19,7 @@ class CollapsiblePanel extends React.Component {
   }
 
   scrollToTop() {
+    window.VetsGov = window.VetsGov ?? {};
     scroller.scrollTo(
       `collapsible-panel-${this.id}-scroll-element`,
       window.VetsGov.scroll || {


### PR DESCRIPTION
## Description
Fix `window.VetsGov` being undefined for non-VA.gov users of the design system.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/640

## Testing done


## Screenshots
N/A

## Acceptance criteria
- [ ] No more runtime error for this component

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
