### PR TITLE
Update url for accessing staging

### DIFF
--- a/packages/documentation/src/pages/platform/site-structure/environments.mdx
+++ b/packages/documentation/src/pages/platform/site-structure/environments.mdx
@@ -25,7 +25,7 @@ There are four environments for va.gov:
 
 ## Access and test users
 
-See [Accessing Staging](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Administrative/Accessing-Staging.md) for
+See [Accessing Staging](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/Administrative/accessing-staging.md) for
 
 - HTTP basic auth **passwords** needed to access **development** and **staging** environments, and
 - **Test users** that can be used to verify features in **localhost**, **development**, and **staging** environments.


### PR DESCRIPTION
## Description
Update the [old](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Administrative/Accessing-Staging.md) `Accessing Staging` link to the new [one](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/Administrative/accessing-staging.md) on https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/platform/site-structure/environments.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
