### PR TITLE
Remove jsx extension

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "5.4.4",
+  "version": "5.4.5",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/EmergencyBanner/EmergencyBanner.jsx
+++ b/packages/formation-react/src/components/EmergencyBanner/EmergencyBanner.jsx
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 // Relative imports.
-import AlertBox from '../AlertBox/AlertBox.jsx';
+import AlertBox from '../AlertBox/AlertBox';
 
 const EMERGENCY_BANNER_LOCALSTORAGE = 'EMERGENCY_BANNER';
 

--- a/packages/formation-react/src/components/MaintenanceBanner/MaintenanceBanner.jsx
+++ b/packages/formation-react/src/components/MaintenanceBanner/MaintenanceBanner.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import moment from 'moment';
 // Relative imports.
-import AlertBox from '../AlertBox/AlertBox.jsx';
+import AlertBox from '../AlertBox/AlertBox';
 
 export const MAINTENANCE_BANNER = 'MAINTENANCE_BANNER';
 


### PR DESCRIPTION
## Description
Removes jsx extension due to this error:

![image](https://user-images.githubusercontent.com/12773166/87825395-49c93880-c834-11ea-98f6-5189588ee892.png)

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
