### PR TITLE
Update docs for EmergencyBanner and MaintenanceBanner

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "5.4.6",
+  "version": "5.4.7",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/EmergencyBanner/EmergencyBanner.jsx
+++ b/packages/formation-react/src/components/EmergencyBanner/EmergencyBanner.jsx
@@ -10,15 +10,22 @@ const EMERGENCY_BANNER_LOCALSTORAGE = 'EMERGENCY_BANNER';
 // @WARNING: This is currently only used once in vets-website.
 export class EmergencyBanner extends Component {
   static propTypes = {
+    // A raw HTML string.
     content: PropTypes.string.isRequired,
+    // Usually this is just window.localStorage
     localStorage: PropTypes.shape({
       getItem: PropTypes.func.isRequired,
       setItem: PropTypes.func.isRequired,
     }),
+    // A function to track clicks (e.g. Google Analytics' `dataLayer.push`).
     recordEvent: PropTypes.func,
+    // Enable the close functionality. The banner will be closed until localStorage is cleared.
     showClose: PropTypes.bool,
+    // The title of the banner.
     title: PropTypes.string.isRequired,
+    // If type is equal to 'error', it will show a red emergency banner outline.
     type: PropTypes.string.isRequired,
+    // A boolean that when false makes it so the banner does not render.
     visible: PropTypes.bool.isRequired,
   };
 

--- a/packages/formation-react/src/components/EmergencyBanner/EmergencyBanner.mdx
+++ b/packages/formation-react/src/components/EmergencyBanner/EmergencyBanner.mdx
@@ -11,13 +11,13 @@ import EmergencyBanner from './EmergencyBanner'
 import EmergencyBanner from '@department-of-veterans-affairs/formation-react/EmergencyBanner'
 
 <EmergencyBanner
-  content={(
+  content={(`
     <div>
       <p>For questions about COVID-19 and how it affects VA health care and benefit services, visit our <a href="/coronavirus-veteran-frequently-asked-questions/">coronavirus FAQs</a> or read <a href="https://www.publichealth.va.gov/n-coronavirus/">VA’s public health response</a>.</p>
       <p>Please contact us first before going to any <a href="/find-locations">VA location</a>. Contacting us first helps us keep you safe.</p>
       <p>For the latest coronavirus information, visit the <a href="https://www.cdc.gov/coronavirus/2019-ncov/index.html">CDC website</a>.</p>
     </div>
-  )}
+  `)}
   title="Coronavirus"
   visible
 />
@@ -26,13 +26,13 @@ import EmergencyBanner from '@department-of-veterans-affairs/formation-react/Eme
 ### Rendered Component
 <div className="site-c-reactcomp__rendered">
   <EmergencyBanner
-    content={(
+    content={(`
       <div>
         <p>For questions about COVID-19 and how it affects VA health care and benefit services, visit our <a href="/coronavirus-veteran-frequently-asked-questions/">coronavirus FAQs</a> or read <a href="https://www.publichealth.va.gov/n-coronavirus/">VA’s public health response</a>.</p>
         <p>Please contact us first before going to any <a href="/find-locations">VA location</a>. Contacting us first helps us keep you safe.</p>
         <p>For the latest coronavirus information, visit the <a href="https://www.cdc.gov/coronavirus/2019-ncov/index.html">CDC website</a>.</p>
       </div>
-    )}
+    `)}
     title="Coronavirus"
     visible
   />

--- a/packages/formation-react/src/components/MaintenanceBanner/MaintenanceBanner.jsx
+++ b/packages/formation-react/src/components/MaintenanceBanner/MaintenanceBanner.jsx
@@ -11,17 +11,26 @@ export const MAINTENANCE_BANNER = 'MAINTENANCE_BANNER';
 // @WARNING: This is currently only used once in vets-website.
 export class MaintenanceBanner extends Component {
   static propTypes = {
+    // The content of the banner for downtime.
     content: PropTypes.string.isRequired,
+    // A 'moment' object used when downtime expires.
     expiresAt: PropTypes.object.isRequired,
+    // A unique ID that will be used for conditionally rendering the banner based on if the user has dismissed it already.
     id: PropTypes.string.isRequired,
+    // Usually this is just window.localStorage
     localStorage: PropTypes.shape({
       getItem: PropTypes.func.isRequired,
       setItem: PropTypes.func.isRequired,
     }),
+    // A 'moment' object used when downtime starts.
     startsAt: PropTypes.object.isRequired,
+    // The title of the banner for downtime.
     title: PropTypes.string.isRequired,
+    // The content of the banner for pre-downtime.
     warnContent: PropTypes.string,
+    // A 'moment' object used when pre-downtime starts.
     warnStartsAt: PropTypes.object,
+    // The title of the banner for pre-downtime.
     warnTitle: PropTypes.string,
   };
 


### PR DESCRIPTION
## Description
This PR updates the docs for EmergencyBanner and MaintenanceBanner by adding descriptions to props and fixing a rendering bug for EmergencyBanner on the [docs site](https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/visual-design/components/emergencybanner/).

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Add props descriptions for EmergencyBanner and MaintenanceBanner.
- [x] Fix EmergencyBanner documentation site rendering. 

## Definition of done
- [x] Changes have been tested in vets-website
- [x] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
