### PR TITLE
Updated Cypress link to point to master for consistency.

### DIFF
--- a/packages/documentation/src/pages/getting-started/common-tasks/new-end-to-end-test.mdx
+++ b/packages/documentation/src/pages/getting-started/common-tasks/new-end-to-end-test.mdx
@@ -13,7 +13,7 @@ Front end engineers use end-to-end (e2e) tests in `vets-website` to validate mul
 
 - `vets-website` uses [Nightwatch](https://nightwatchjs.org) to run some of the older end-to-end tests
   - New end-to-end tests should be written in Cypress going forward.
-  - Refer to the [Cypress migration guide](https://github.com/department-of-veterans-affairs/va.gov-team/blob/6dccdd3ac61d7fbfa8b30e317230cc9212a7c9f8/teams/vsp/teams/tools/frontend/cypress-migration-guide.md) to convert old tests or write new tests.
+  - Refer to the [Cypress migration guide](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsp/teams/tools/frontend/cypress-migration-guide.md) to convert old tests or write new tests.
 - end-to-end tests are **collocated in application folder** with the application they test
 - Two node apps run with the end-to-end tests:
   - `mockapi.js` - hosts mock responses (see [Mocking API responses](#mocking-api-responses))


### PR DESCRIPTION
## Description
Cypress documentation link now goes to the master branch version rather than a specific version.

## Testing done
Tested that the link goes to the right place.

## Acceptance criteria
- [ ] Cypress documentation link should be consistent with other links to the `va.gov-team` repo.

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
