### PR TITLE
Sanlouise/fix scroll error

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "5.4.7",
+  "version": "5.4.8",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/AlertBox/AlertBox.jsx
+++ b/packages/formation-react/src/components/AlertBox/AlertBox.jsx
@@ -23,9 +23,9 @@ class AlertBox extends React.Component {
       return;
     }
 
-    const isInView = this._ref && window.scrollY <= this._ref.offsetTop;
+    const isInView = window.scrollY <= this._ref.offsetTop;
 
-    if (!isInView) {
+    if (this._ref && !isInView) {
       this._ref.scrollIntoView({
         block: this.props.scrollPosition,
         behavior: 'smooth',
@@ -117,6 +117,11 @@ AlertBox.propTypes = {
    * If true, page scrolls to alert when it is shown.
    */
   scrollOnShow: PropTypes.bool,
+
+  /**
+   * Defaults to 'start' but customizable.
+   */
+  scrollPosition: PropTypes.string,
 
   /**
    * Optional class name to add to the alert box.

--- a/packages/formation-react/src/components/AlertBox/AlertBox.jsx
+++ b/packages/formation-react/src/components/AlertBox/AlertBox.jsx
@@ -23,11 +23,11 @@ class AlertBox extends React.Component {
       return;
     }
 
-    const isInView = window.scrollY <= this._ref.offsetTop;
+    const isInView = this._ref && window.scrollY <= this._ref.offsetTop;
 
-    if (this._ref && !isInView) {
+    if (!isInView) {
       this._ref.scrollIntoView({
-        block: 'end',
+        block: this.props.scrollPosition,
         behavior: 'smooth',
       });
     }
@@ -146,6 +146,7 @@ AlertBox.propTypes = {
 /* eslint-enable consistent-return */
 
 AlertBox.defaultProps = {
+  scrollPosition: 'start',
   isVisible: true,
   backgroundOnly: false,
   closeBtnAriaLabel: 'Close notification',


### PR DESCRIPTION
## Description
We are currently using the `scrollOnShow` prop on the AlertBox in a single place, `src/platform/user/profile/vet360/components/base/Vet360EditModalErrorMessage.jsx` in `vets-website`. We now need to use the scroll functionality in other places as well, and the Alert should not scroll to the end of the viewport, instead to the start or center.

I defaulted the position to `start` instead of `end`, and will make sure to pass the `scrollPosition: end` to the one place where we are currently using the scroll logic. We'd expect most scrolling behavior to want to default to `start`, top of the screen - but this is now overridable through the `scrollPosition` prop.

[PR for frontend implementation](https://github.com/department-of-veterans-affairs/vets-website/pull/13672)

## Testing done
Works locally.

## Acceptance criteria
- [x] Add prop to AlertBox to allow for customizable scrolling position.

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
