### PR TITLE
Update BDD data link

### DIFF
--- a/packages/documentation/src/pages/forms/save-in-progress-menu.mdx
+++ b/packages/documentation/src/pages/forms/save-in-progress-menu.mdx
@@ -120,7 +120,7 @@ this file and paste it into the menu form data (as-is) to apply this data
 - [disability-benefits/686](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/disability-benefits/686/tests/schema/maximal-test.json)
 - [disability-benefits/996](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/disability-benefits/996/tests/fixtures/data/maximal-test.json)
 - [disability-benefits/all-claims](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-test.json)
-- [disability-benefits/bdd](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/disability-benefits/bdd/tests/fixtures/data/maximal-test.json)
+- [disability-benefits/bdd](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-bdd-test.json)
 - [edu-benefits/10203](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/edu-benefits/10203/tests/schema/maximal-test.json)
 - [edu-benefits/0993](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/edu-benefits/tests/0993/schema/maximal-test.json)
 - [edu-benefits/0994](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/edu-benefits/tests/0994/schema/maximal-test.json)


### PR DESCRIPTION
## Description

The Benefits Delivery at Discharge (BDD) folder has been merged into form 526 all-claims, and thus the test data has moved. This PR updates the url pointing to the `maximal-test.json` for BDD

Related ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/11190

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria

- [ ] Link to BDD data has been updated

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
