### PR TITLE
update link of cypress migration guide

### DIFF
--- a/packages/documentation/src/pages/getting-started/common-tasks/new-end-to-end-test.mdx
+++ b/packages/documentation/src/pages/getting-started/common-tasks/new-end-to-end-test.mdx
@@ -13,7 +13,7 @@ Front end engineers use end-to-end (e2e) tests in `vets-website` to validate mul
 
 - `vets-website` uses [Nightwatch](https://nightwatchjs.org) to run some of the older end-to-end tests
   - New end-to-end tests should be written in Cypress going forward.
-  - Refer to the [Cypress migration guide](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/frontend/cypress-migration-guide.md) to convert old tests or write new tests.
+  - Refer to the [Cypress migration guide](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/testing/end-to-end/cypress-migration-guide.md) to convert old tests or write new tests.
 - end-to-end tests are **collocated in application folder** with the application they test
 - Two node apps run with the end-to-end tests:
   - `mockapi.js` - hosts mock responses (see [Mocking API responses](#mocking-api-responses))


### PR DESCRIPTION
## Description
I moved the Cypress migration guide location in the va.gov-team repo and have updated the link to it from this page.