### PR TITLE
Update feature toggles documentation

### DIFF
--- a/packages/documentation/src/pages/platform/tools/feature-toggles.mdx
+++ b/packages/documentation/src/pages/platform/tools/feature-toggles.mdx
@@ -56,13 +56,15 @@ Follow these steps to add and use a new feature toggle in vets-website:
 
 5. Navigate to [http://localhost:3000/flipper/features](http://localhost:3000/flipper/features) and verify that you see your new feature name. If not, restart your rails server.
 
-6. Add the feature toggle name (in camel case) to vets-website by updating [featureFlagNames.js](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/utilities/feature-toggles/featureFlagNames.js).
+6. Add the feature toggle name to vets-website by updating [featureFlagNames.js](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/utilities/feature-toggles/featureFlagNames.js).
 
-```js
-const FEATURE_FLAG_NAMES = Object.freeze({
- showYourFeatureName: 'appNameThenYourFeatureName',
-})
-```
+    ```js
+    const FEATURE_FLAG_NAMES = Object.freeze({
+     showYourFeatureName: 'app_name_then_your_feature_name',
+    })
+    ```
+
+    **Note:** The key should be camelCase for use in JavaScript, but the value should exactly match the toggle name in `features.yml`.
 
 7. Submit a PR for each feature. Crosslinking the PRs in a comment will make it easier for the reviewers to check.
 


### PR DESCRIPTION
## Description
The feature toggle names should map directly to the toggle names in `features.yml` to avoid any case inflection missteps.

## Background
@mr0sari0 discovered the hard way that numbers in the feature toggle names behave a bit unexpectedly. Specifically, if we had `feature_01_name` in `features.yml` in the API and `feature01Name` in `featureFlagNames.js` in `vets-website`, the feature toggle request would send `?features=feature01Name` which the API would translate to `feature01_name`. This, obviously, doesn't match the _actual_ feature toggle name of `feature_01_name`, so the value would always be false.

To avoid this, we can simply send the toggle names in the exact case as they're found in the API, but still use camelCase as the property name for use in JavaScript.