### PR TITLE
Add notClickable prop to Telephone component

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "5.4.9",
+  "version": "5.4.10",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/Telephone/Telephone.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.jsx
@@ -150,7 +150,7 @@ function Telephone({
         >
           {children || `${formattedNumber}${extension ? `, ext. ${extension}` : ''}`}
         </span>
-        <span className="sr-only">
+        <span className="vads-u-visibility--screen-reader">
           {formattedAriaLabel}
         </span>
       </>

--- a/packages/formation-react/src/components/Telephone/Telephone.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.jsx
@@ -108,7 +108,7 @@ function Telephone({
   ariaLabel = '', // custom aria-label
   onClick = () => {},
   children,
-  noHref = false,
+  notClickable = false,
 }) {
   // strip out non-digits for use in href: "###-### ####" => "##########"
   const parsedNumber = parseNumber(contact.toString());
@@ -141,15 +141,19 @@ function Telephone({
     extension ? `,${extension}` : ''
   }`;
 
-  if (noHref) {
+  if (notClickable) {
     return (
-      <span
-        className={`no-wrap ${className}`}
-        aria-label={formattedAriaLabel}
-      >
-        {children ||
-          `${formattedNumber}${extension ? `, ext. ${extension}` : ''}`}
-      </span>
+      <>
+        <span
+          className={`no-wrap ${className}`}
+          aria-hidden="true"
+        >
+          {children || `${formattedNumber}${extension ? `, ext. ${extension}` : ''}`}
+        </span>
+        <span className="sr-only">
+          {formattedAriaLabel}
+        </span>
+      </>
     )
   }
 
@@ -204,7 +208,7 @@ Telephone.propTypes = {
    * Using this prop, the phone number becomes a non-clickable presentational
    * span.
    */
-  noHref: PropTypes.bool,
+  notClickable: PropTypes.bool,
 
   /**
    * Custom onClick function

--- a/packages/formation-react/src/components/Telephone/Telephone.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.jsx
@@ -108,6 +108,7 @@ function Telephone({
   ariaLabel = '', // custom aria-label
   onClick = () => {},
   children,
+  noHref = false,
 }) {
   // strip out non-digits for use in href: "###-### ####" => "##########"
   const parsedNumber = parseNumber(contact.toString());
@@ -139,6 +140,18 @@ function Telephone({
     // solution - see https://dsva.slack.com/archives/C8E985R32/p1589814301103200
     extension ? `,${extension}` : ''
   }`;
+
+  if (noHref) {
+    return (
+      <span
+        className={`no-wrap ${className}`}
+        aria-label={formattedAriaLabel}
+      >
+        {children ||
+          `${formattedNumber}${extension ? `, ext. ${extension}` : ''}`}
+      </span>
+    )
+  }
 
   return (
     <a
@@ -175,7 +188,7 @@ Telephone.propTypes = {
   className: PropTypes.string,
 
   /**
-   * Pattern use used while formatting the contact number. Use provided
+   * Pattern are used while formatting the contact number. Use provided
    * PATTERNS, or create a custom one using "#" as a placeholder for each
    * number. Note that the number of "#"'s in the pattern <em>must</em> equal
    * the contact number length or an error is thrown.
@@ -186,6 +199,12 @@ Telephone.propTypes = {
    * Custom aria-label string.
    */
   ariaLabel: PropTypes.string,
+
+  /**
+   * Using this prop, the phone number becomes a non-clickable presentational
+   * span.
+   */
+  noHref: PropTypes.bool,
 
   /**
    * Custom onClick function

--- a/packages/formation-react/src/components/Telephone/Telephone.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.jsx
@@ -188,7 +188,7 @@ Telephone.propTypes = {
   className: PropTypes.string,
 
   /**
-   * Pattern are used while formatting the contact number. Use provided
+   * Pattern is used while formatting the contact number. Use provided
    * PATTERNS, or create a custom one using "#" as a placeholder for each
    * number. Note that the number of "#"'s in the pattern <em>must</em> equal
    * the contact number length or an error is thrown.

--- a/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
@@ -176,11 +176,8 @@ describe('Widget <Telephone />', () => {
     const wrapper = shallow(
       <Telephone contact={CONTACTS.GI_BILL} className="foo" notClickable />,
     );
-    const props = wrapper.props();
     expect(wrapper.exists('span')).to.equal(true);
     expect(wrapper.exists('a')).to.equal(false);
-    expect(props.href).to.not.exist;
-    expect(props.className).to.equal('no-wrap foo');
     expect(wrapper.text()).to.equal('888-442-4551');
     wrapper.unmount();
   });

--- a/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
@@ -178,7 +178,8 @@ describe('Widget <Telephone />', () => {
     );
     expect(wrapper.exists('span')).to.equal(true);
     expect(wrapper.exists('a')).to.equal(false);
-    expect(wrapper.text()).to.equal('888-442-4551');
+    expect(wrapper.text()).to.include('888-442-4551');
+    expect(wrapper.text()).to.include('8 8 8. 4 4 2. 4 5 5 1');
     wrapper.unmount();
   });
 

--- a/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
@@ -177,6 +177,8 @@ describe('Widget <Telephone />', () => {
       <Telephone contact={CONTACTS.GI_BILL} className="foo" noHref />,
     );
     const props = wrapper.props();
+    expect(wrapper.exists('span')).to.equal(true);
+    expect(wrapper.exists('a')).to.equal(false);
     expect(props.href).to.not.exist;
     expect(props['aria-label']).to.equal('8 8 8. 4 4 2. 4 5 5 1.');
     expect(props.className).to.equal('no-wrap foo');

--- a/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
@@ -171,6 +171,19 @@ describe('Widget <Telephone />', () => {
     wrapper.unmount();
   });
 
+  // noHref
+  it('should render a span instead of an a tag', () => {
+    const wrapper = shallow(
+      <Telephone contact={CONTACTS.GI_BILL} className="foo" noHref />,
+    );
+    const props = wrapper.props();
+    expect(props.href).to.not.exist;
+    expect(props['aria-label']).to.equal('8 8 8. 4 4 2. 4 5 5 1.');
+    expect(props.className).to.equal('no-wrap foo');
+    expect(wrapper.text()).to.equal('888-442-4551');
+    wrapper.unmount();
+  });
+
   // tracking
   it('should track on click', () => {
     const onClick = sinon.spy();

--- a/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
@@ -171,10 +171,10 @@ describe('Widget <Telephone />', () => {
     wrapper.unmount();
   });
 
-  // noHref
+  // notClickable
   it('should render a span instead of an a tag', () => {
     const wrapper = shallow(
-      <Telephone contact={CONTACTS.GI_BILL} className="foo" noHref />,
+      <Telephone contact={CONTACTS.GI_BILL} className="foo" notClickable />,
     );
     const props = wrapper.props();
     expect(wrapper.exists('span')).to.equal(true);

--- a/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
@@ -180,7 +180,6 @@ describe('Widget <Telephone />', () => {
     expect(wrapper.exists('span')).to.equal(true);
     expect(wrapper.exists('a')).to.equal(false);
     expect(props.href).to.not.exist;
-    expect(props['aria-label']).to.equal('8 8 8. 4 4 2. 4 5 5 1.');
     expect(props.className).to.equal('no-wrap foo');
     expect(wrapper.text()).to.equal('888-442-4551');
     wrapper.unmount();


### PR DESCRIPTION
## Description

In Profile 2.0, we need to render a user's phone number with the same formatting as our current `Telephone` component. However, the phone number is the user's OWN phone number, therefore it needs to not be clickable.

Instead of using css to disable the onClick of the `a` tag (which possibly could lead to a11y issues), this PR adds an optional `notClickable` prop that instead of an `a` tag renders a `span`.

I believe it's a good idea to use the `Telephone` component for this use case, albeit modified, to ensure consistency across formatting and `aria-labels`.


## Testing done
Tested locally, works as expected. Updated unit tests.

## Acceptance criteria
- [x] Pass a `notClickable` prop to the `Telephone` component to allow for purely presentational phone numbers

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
