### PR TITLE
Update dependencies to install gatsby-plugin-google-tagmanager in Gatsby app

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "webpack": "4.29.6"
   },
   "dependencies": {
-    "gatsby-plugin-google-tagmanager": "^2.3.11",
     "graphql": "^14.5.3"
   }
 }

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -14,6 +14,7 @@
     "classnames": "^2.2.6",
     "gatsby": "^2.23.3",
     "gatsby-image": "^2.4.7",
+    "gatsby-plugin-google-tagmanager": "^2.3.11",
     "gatsby-plugin-manifest": "^2.4.11",
     "gatsby-plugin-mdx": "file:plugins/gatsby-plugin-mdx(forked)",
     "gatsby-plugin-react-helmet": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -808,13 +808,6 @@
     pirates "^4.0.0"
     source-map-support "^0.5.9"
 
-"@babel/runtime@^7.10.3":
-  version "7.11.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
-  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.44.tgz#f8832f4fdcee5d59bf515e595fc5106c529b394f"
@@ -5918,13 +5911,6 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-gatsby-plugin-google-tagmanager@^2.3.11:
-  version "2.3.11"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-google-tagmanager/-/gatsby-plugin-google-tagmanager-2.3.11.tgz#6192d5095ff8aa7634c66052aaab9d24ab4ff46e"
-  integrity sha512-i3tUFxuTp7CKU1cM4V7uuEcJdI/7lQRB5d02blm08dFv1GDg/nZpuBM03OTXjWec3Y6GEw7N8aiYSJuA0/OrlQ==
-  dependencies:
-    "@babel/runtime" "^7.10.3"
-
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -10734,11 +10720,6 @@ regenerator-runtime@^0.13.2:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
   integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
 
-regenerator-runtime@^0.13.4:
-  version "0.13.7"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
-  integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
-
 regenerator-transform@^0.13.4:
   version "0.13.4"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.13.4.tgz#18f6763cf1382c69c36df76c6ce122cc694284fb"
@@ -12514,7 +12495,7 @@ uuid@^3.0.1, uuid@^3.3.2:
     eslint-plugin-react "^7.12.4"
     eslint-plugin-react-hooks "^1.6.0"
     eslint-plugin-scanjs-rules "^0.2.1"
-    eslint-plugin-va-enzyme "file:../../../Library/Caches/Yarn/v4/npm-vagov-eslint-1.0.0-e767bb3b-4bb9-4325-bca9-089aeb09942d-1598032953380/node_modules/vagov-eslint/custom-eslint/va-enzyme"
+    eslint-plugin-va-enzyme "file:./packages/vagov-eslint/custom-eslint/va-enzyme"
     prettier "^1.16.4"
     shelljs "0.8.4"
     window-or-global "^1.0.1"


### PR DESCRIPTION
The [original PR to install `gatsby-plugin-google-tagmanager` in the Gatsby app](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/374) assumed the VFS Tools repo was a conventional JS repo. However, since the VFS Tools repo is a Lerna repo, the dependencies are handled unconventionally. 