### PR TITLE
Install system dependencies for Puppeteer to fix documentation build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ RUN groupadd --gid 504 jenkins \
   && useradd --uid 504 --gid jenkins --shell /bin/bash --create-home jenkins \
   && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
-  && apt-get update && apt-get install -y google-chrome-stable
+  && apt-get update && apt-get install -y google-chrome-stable libxss1
 
 USER jenkins


### PR DESCRIPTION
## Description
The documentation site depends on `gatsby-remark-mermaid`, which has a peer dependency on `puppeteer`.
For reasons I don't know right now, it started failing with this error:

```
[2020-09-01T16:08:55.763Z]   Error: Failed to launch the browser process!

[2020-09-01T16:08:55.763Z]   /home/jenkins/workspace/ervices-tools_edit-link-refactor/packages/documentation/node_modules/puppeteer/.local-chromium/linux-722234/chrome-linux/chrome: error while loading shared libraries: libXss.so.1: cannot open shared object file: No such file or directory

[2020-09-01T16:08:55.763Z]   TROUBLESHOOTING: https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md
```

According to various answers I've found ([such as this](
https://askubuntu.com/questions/547151/error-while-loading-shared-libraries-libxss-so-1)), the problem appears to be a missing package in the container. This fix installs the necessary packages.

## Testing done
Verified that the build passes for this branch.

## Acceptance criteria
- [ ] The documentation build should pass.

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
