### PR TITLE
Page creation error handling to prevent build breaking on invalid JSX.

### DIFF
--- a/packages/documentation/plugins/gatsby-plugin-mdx(forked)/gatsby/on-create-page.js
+++ b/packages/documentation/plugins/gatsby-plugin-mdx(forked)/gatsby/on-create-page.js
@@ -23,17 +23,22 @@ module.exports = async ({ page, actions }, pluginOptions) => {
     const { frontmatter } = extractExports(code)
 
     deletePage(page)
-    createPage(
-      merge(
-        {
-          context: {
-            frontmatter: {
-              ...frontmatter,
+
+    try {
+      createPage(
+        merge(
+          {
+            context: {
+              frontmatter: {
+                ...frontmatter,
+              },
             },
           },
-        },
-        page
+          page
+        )
       )
-    )
+    } catch (e) {
+      console.log(e)
+    }
   }
 }

--- a/packages/documentation/src/pages/forms/about-the-schema-and-uischema-objects.mdx
+++ b/packages/documentation/src/pages/forms/about-the-schema-and-uischema-objects.mdx
@@ -4,7 +4,7 @@ title: About the schema and uiSchema objects
 
 # About the schema and uiSchema objects
 
-The VA.gov Forms System lets you build web-based forms using the JSON Schema standard for form data and React for the form UI. The form data and UI are represented by `schema` and `uiSchema` objects, respectively, which are included in the form configuration file.
+The VA.gov Forms System lets you build web-based forms using the JSON Schema standard for form data and React for the form UI. The form data and UI are represented by `schema` and `uiSchema` objects, respectively, which are included in the form configuration file. <dt> and <dd> elements
 
 - [Understanding the `schema` object](#understanding-the-schema-object)
   - [Describing object fields and arrays](#describing-object-fields-and-arrays)


### PR DESCRIPTION
## Description
Attempted to ignore invalid JSX for creating MDX pages, but the proposed fix did not appear to work.

## Testing done
Tested on branch build.

## Acceptance criteria
- [ ] Build should not fail on invalid JSX.

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
