### PR TITLE
Refactored usage of ref on SearchMenu to fix its documentation page.

### DIFF
--- a/packages/formation-react/src/components/SearchMenu/SearchMenu.jsx
+++ b/packages/formation-react/src/components/SearchMenu/SearchMenu.jsx
@@ -6,8 +6,13 @@ import IconSearch from '../IconSearch/IconSearch';
 import DropDownPanel from '../DropDownPanel/DropDownPanel';
 
 class SearchMenu extends React.Component {
+  constructor(props) {
+    super(props);
+    this.searchFieldRef = React.createRef();
+  }
+
   componentDidUpdate() {
-    this.refs.searchField.focus();
+    this.searchFieldRef.current.focus();
   }
 
   toggleSearchForm = () => {
@@ -37,7 +42,7 @@ class SearchMenu extends React.Component {
       <div className="va-flex">
         <input
           autoComplete="off"
-          ref="searchField"
+          ref={this.searchFieldRef}
           className="usagov-search-autocomplete"
           id="query"
           name="query"


### PR DESCRIPTION
## Description
You can observe a breakage when you go to the [SearchMenu page on the documentation site](https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/visual-design/components/searchmenu/).

This stems from how the `ref` is used. The error is obscured in prod, but in a local build, you would see this error:
> Element ref was specified as a string (myRefName) but no owner was set.

I'm not entirely sure why, but this change addresses the issue as well as updates the component to follow the [newer, non-deprecated approach for using refs](https://reactjs.org/docs/refs-and-the-dom.html#adding-a-ref-to-a-dom-element).

## Testing done
Verified locally that the page now loads properly.

## Acceptance criteria
- [ ] The SearchMenu page in the documentation site should load.

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
