### PR TITLE
Add ui:objectViewField docs

### DIFF
--- a/packages/documentation/src/pages/forms/about-the-schema-and-uischema-objects.mdx
+++ b/packages/documentation/src/pages/forms/about-the-schema-and-uischema-objects.mdx
@@ -152,6 +152,25 @@ The VAFS code includes additional `uiSchema` functionality not found in the RJSF
     </div>
   ),
 
+  // Renders a custom object field on the review page. This function creates the wrapper
+  // around the `ui:reviewField` content. This component is passed in parameters
+  // including all the `props` (e.g. `formContext`, `schema`, `uiSchema`, etc), `title`,
+  // `renderedProperties` (the rendered `reviewField`) and `editButton` which is used
+  // to render the review entry;
+  // **Note** this entry will need to be defined in the uiSchema page, outside of the
+  // defined item (one level up).
+  'ui:objectViewField': ({ props, renderedProperties, title, editButton }) => (
+    <>
+      <div className="form-review-panel-page-header-row">
+        <h3 className="form-review-panel-page-header vads-u-font-size--h5">
+          {title}
+        </h3>
+        {editButton}
+      </div>
+      <dl className="review">{renderedProperties}</dl>
+    </>
+  ),
+
   // Provides a function to make a field conditionally required. The data in the whole form,
   // with no page breaks, is the only parameter. Don't make a field required in the JSON
   // schema and in addition to using `ui:required` on that field. The index argument is

--- a/packages/documentation/src/pages/forms/about-the-schema-and-uischema-objects.mdx
+++ b/packages/documentation/src/pages/forms/about-the-schema-and-uischema-objects.mdx
@@ -159,13 +159,29 @@ The VAFS code includes additional `uiSchema` functionality not found in the RJSF
   // to render the review entry;
   // **Note** this entry will need to be defined in the uiSchema page, outside of the
   // defined item (one level up).
-  'ui:objectViewField': ({ props, renderedProperties, title, editButton }) => (
+  'ui:objectViewField': ({
+    schema,
+    uiSchema,
+    formData,
+    formContext,
+    renderedProperties,
+    title,
+    editButton,
+  }) => (
     <>
       <div className="form-review-panel-page-header-row">
         <h3 className="form-review-panel-page-header vads-u-font-size--h5">
           {title}
         </h3>
-        {editButton}
+        // use {editButton} (JSX), or create a custom edit button
+        <button
+          type="button"
+          className="edit-btn primary-outline"
+          aria-label={`Edit ${title}`}
+          onClick={() => formContext.onEdit()}
+        >
+          Edit
+        </button>
       </div>
       <dl className="review">{renderedProperties}</dl>
     </>

--- a/packages/documentation/src/pages/forms/about-the-schema-and-uischema-objects.mdx
+++ b/packages/documentation/src/pages/forms/about-the-schema-and-uischema-objects.mdx
@@ -166,14 +166,21 @@ The VAFS code includes additional `uiSchema` functionality not found in the RJSF
     formContext,
     renderedProperties,
     title,
-    editButton,
+    defaultEditButton,
   }) => (
     <>
       <div className="form-review-panel-page-header-row">
         <h3 className="form-review-panel-page-header vads-u-font-size--h5">
           {title}
         </h3>
-        // use {editButton} (JSX), or create a custom edit button
+        /* use the `defaultEditButton` function, or create a custom edit button
+          if the value is not included, it will fall back to its default
+          {defaultEditButton({
+            label: `Edit ${title}`, // aria-label value (default value)
+            onEdit: formContext.onEdit, // onClick function (default function)
+            text: 'Edit', // button textContent (default value)
+          )}
+        */
         <button
           type="button"
           className="edit-btn primary-outline"

--- a/packages/documentation/src/pages/forms/available-features-and-usage-guidelines.mdx
+++ b/packages/documentation/src/pages/forms/available-features-and-usage-guidelines.mdx
@@ -419,6 +419,7 @@ This property is nested directly under `uiSchema`:
 
 - `'ui:reviewWidget'`: takes a widget component to render on the review page for that field. Default review widgets are automatically rendered, so only use this if you need to customize the review widget that is used.
 - `'ui:reviewField'`: allows a custom review component to be built for each field on the review page. It is given the result of the `'ui:reviewWidget'` within the `children` parameter, so this value must be rendered within the custom function.
+- `'ui:objectViewField'`: allows adding a custom wrapper around the rendered `ui:reviewField` content. It should render a header, edit button and passed in `renderedProperties`.
 
 These properties are nested under `uiSchema: { 'ui:options': {} }`:
 

--- a/packages/documentation/src/pages/forms/available-features-and-usage-guidelines.mdx
+++ b/packages/documentation/src/pages/forms/available-features-and-usage-guidelines.mdx
@@ -415,7 +415,7 @@ When you build a form with more than one chapter (shown by the segments in a pro
 
 The review page renders the form data in review mode automatically. However, you can pass some specific options to the form config to customize some review features.
 
-This property is nested directly under `uiSchema`:
+These properties are nested directly under `uiSchema`:
 
 - `'ui:reviewWidget'`: takes a widget component to render on the review page for that field. Default review widgets are automatically rendered, so only use this if you need to customize the review widget that is used.
 - `'ui:reviewField'`: allows a custom review component to be built for each field on the review page. It is given the result of the `'ui:reviewWidget'` within the `children` parameter, so this value must be rendered within the custom function.


### PR DESCRIPTION
## Description

Add documentation for the `ui:objectViewField` setting

Related: https://github.com/department-of-veterans-affairs/vets-website/pull/14091

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [ ] Documentation added for new setting

## Definition of done
- [x] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
