### PR TITLE
Kelsonic 11781 telephone error

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "5.4.10",
+  "version": "5.4.11",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/Telephone/Telephone.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.jsx
@@ -51,14 +51,21 @@ const parseNumber = number =>
 
 /**
  * Insert the provided number into the pattern
- * @param {string} num - parsed number string (no non-digits included)
+ * @param {string} phoneNumber - parsed number string (no non-digits included)
  * @param {string} pattern - provided pattern (using "#") for link text
  * @return {string} - formatted phone number for link text
  */
 // Create link text from pattern
-const formatTelText = (num, pattern) => {
+const formatTelText = (phoneNumber, pattern) => {
+  const patternLength = pattern.match(/#/g).length;
+
+  // If the pattern does not match the phone number, return the raw phone number.
+  if (phoneNumber.length !== patternLength) {
+    return phoneNumber;
+  }
+
   let i = 0;
-  return pattern.replace(/#/g, () => num[i++] || '');
+  return pattern.replace(/#/g, () => phoneNumber[i++] || '');
 };
 
 /**
@@ -138,8 +145,7 @@ function Telephone({
 
   // Capture 3 digit patterns here
   const contactPattern = deriveContactPattern(pattern, parsedNumber);
-  const patternLength = contactPattern.match(/#/g).length;
-  const formattedNumber = formatTelText(phoneNumber, contactPattern, extension);
+  const formattedNumber = formatTelText(phoneNumber, contactPattern);
 
   // Show nothing if no phone number was provided.
   if (!phoneNumber) {

--- a/packages/formation-react/src/components/Telephone/Telephone.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.jsx
@@ -27,7 +27,7 @@ export const CONTACTS = Object.freeze({
 
 // Patterns used in formatting visible text
 export const PATTERNS = {
-  911: '###', // needed to match 911 CONTACT
+  '3_DIGIT': '###',
   DEFAULT: '###-###-####',
   OUTSIDE_US: '+1-###-###-####',
 };
@@ -83,6 +83,28 @@ const formatTelLabel = number =>
     .join('. ');
 
 /**
+ * Derive the contact pattern value
+ * @param {string} pattern (optional) - Link text format pattern, using "#" as
+ *  the digit placeholder
+ * @param {string} parsedNumber (optional) - Telephone number with non-digit characters
+ * stripped out
+ */
+const deriveContactPattern = (pattern, parsedNumber) => {
+  // Use their pattern if provided.
+  if (pattern) {
+    return pattern;
+  }
+
+  // If the number is 3 digits, use that pattern as the default.
+  if (parsedNumber && parsedNumber.length === PATTERNS['3_DIGIT'].length) {
+    return PATTERNS['3_DIGIT'];
+  }
+
+  // Use the default pattern.
+  return PATTERNS.DEFAULT;
+}
+
+/**
  * Telephone component
  * @param {string|number} contact (required) - telephone number, with or without
  *  formatting; all non-digit characters will be stripped out
@@ -114,15 +136,15 @@ function Telephone({
   const parsedNumber = parseNumber(contact.toString());
   const phoneNumber = CONTACTS[parsedNumber] || parsedNumber;
 
-  // Capture "911" pattern here
-  const contactPattern = pattern || PATTERNS[parsedNumber] || PATTERNS.DEFAULT;
+  // Capture 3 digit patterns here
+  const contactPattern = deriveContactPattern(pattern, parsedNumber);
   const patternLength = contactPattern.match(/#/g).length;
   const formattedNumber = formatTelText(phoneNumber, contactPattern, extension);
 
-  if (!phoneNumber || phoneNumber.length !== patternLength) {
-    throw new Error(
-      `Contact number "${phoneNumber}" does not match the pattern (${contactPattern})`,
-    );
+  // Show nothing if no phone number was provided.
+  if (!phoneNumber) {
+    console.warn('Contact number is missing so the <Telephone /> component did not render.');
+    return null;
   }
 
   const formattedAriaLabel =

--- a/packages/formation-react/src/components/Telephone/Telephone.mdx
+++ b/packages/formation-react/src/components/Telephone/Telephone.mdx
@@ -63,7 +63,7 @@ import Telephone, { CONTACTS, PATTERNS } from '@department-of-veterans-affairs/f
   pattern={false} // Ignored when text is included
   ariaLabel="8 8 8. 4 4 2. 4 5 5 1"
   onClick={() => {}}
-/>
+>
   1-888-GI-BILL-1
 </Telephone>
 
@@ -150,6 +150,6 @@ import Telephone, { CONTACTS, PATTERNS } from '@department-of-veterans-affairs/f
 
 | Key | Pattern | Description |
 |:----|:--------|:------------|
-| `911` | `###` | Matches the `911` contact number |
+| `3_DIGIT` | `###` | Matches the `911` or `711` contact number |
 | `DEFAULT` | `###-###-####` | Current phone pattern used throughout the site |
 | `OUTSIDE_US` | `+1-###-###-####` | Use on pages for veterans outside the U.S. |

--- a/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
@@ -24,21 +24,21 @@ describe('Widget <Telephone />', () => {
     expect(wrapper.text()).to.equal('800-555-1000');
     wrapper.unmount();
   });
-  it('should throw an error when number does not match pattern', () => {
+  it('should show the raw number if no number is provided', () => {
     expect(() => {
       const wrapper = shallow(<Telephone />);
       expect(wrapper.text()).to.equal('');
       wrapper.unmount();
     })
   });
-  it('should throw an error when number is less than 10-digits', () => {
+  it('should show the raw number if the number is less than 10-digits', () => {
     expect(() => {
       const wrapper = shallow(<Telephone contact={4321} />);
       expect(wrapper.text()).to.equal('4321');
       wrapper.unmount();
     })
   });
-  it('should throw an error when number is more than 10-digits', () => {
+  it('should show the raw number if the number is more than 10-digits', () => {
     expect(() => {
       const wrapper = shallow(<Telephone contact="01234567891" />);
       expect(wrapper.text()).to.equal('01234567891');

--- a/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.unit.spec.jsx
@@ -27,24 +27,23 @@ describe('Widget <Telephone />', () => {
   it('should throw an error when number does not match pattern', () => {
     expect(() => {
       const wrapper = shallow(<Telephone />);
+      expect(wrapper.text()).to.equal('');
       wrapper.unmount();
-    }).to.throw('Contact number "" does not match the pattern (###-###-####)');
+    })
   });
   it('should throw an error when number is less than 10-digits', () => {
     expect(() => {
       const wrapper = shallow(<Telephone contact={4321} />);
+      expect(wrapper.text()).to.equal('4321');
       wrapper.unmount();
-    }).to.throw(
-      `Contact number "4321" does not match the pattern (###-###-####)`,
-    );
+    })
   });
   it('should throw an error when number is more than 10-digits', () => {
     expect(() => {
       const wrapper = shallow(<Telephone contact="01234567891" />);
+      expect(wrapper.text()).to.equal('01234567891');
       wrapper.unmount();
-    }).to.throw(
-      'Contact number "01234567891" does not match the pattern (###-###-####)',
-    );
+    })
   });
 
   // known numbers


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/11781

This PR fixes the `<Telephone />` component when a pattern prop is not provided for a 3-digit phone number (e.g. 911 or 711). It also **deprecates `PATTERNS['911']` in favor of `PATTERNS['3_DIGIT']`.

#### FOLLOW-UP

This PR will require a follow-up PR in vets-website to match the version bump but also to **update all use of `PATTERNS['911']` in favor of `PATTERNS['3_DIGIT']` across `vets-website`**.

## Testing done
Tested locally extensively when `<Telephone />` has no props passed and when it only has a 3-digit phone number passed for the `contact` prop (e.g. no `pattern` prop).

## Screenshots
N/A

## Acceptance criteria
- [x] Ensure `<Telephone />` does not throw an error when `pattern` prop is not provided for a 3-digit number.
- [x] Deprecate `PATTERNS['911']` in favor of `PATTERNS['3_DIGIT']`.

## Definition of done
- [x] Changes have been tested in vets-website
- [x] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
