### PR TITLE
added optional resBurden to OMBInfo

### DIFF
--- a/packages/formation-react/src/components/OMBInfo/OMBInfo.jsx
+++ b/packages/formation-react/src/components/OMBInfo/OMBInfo.jsx
@@ -69,9 +69,11 @@ class OMBInfo extends React.Component {
 
     return (
       <div className="omb-info">
-        <div>
-          Respondent burden: <strong>{resBurden} minutes</strong>
-        </div>
+        {resBurden && (
+          <div>
+            Respondent burden: <strong>{resBurden} minutes</strong>
+          </div>
+        )}
         <div>
           OMB Control #: <strong>{ombNumber}</strong>
         </div>

--- a/packages/formation-react/src/components/OMBInfo/OMBInfo.jsx
+++ b/packages/formation-react/src/components/OMBInfo/OMBInfo.jsx
@@ -101,19 +101,19 @@ class OMBInfo extends React.Component {
 
 OMBInfo.propTypes = {
   /**
-   * respondent burden, length of time usually in minutes
+   * respondent burden, length of time usually in minutes. If this omitted, this will not show in the rendered component. Be sure to get approval from the design council before leaving it out. 
    */
   resBurden: PropTypes.number,
 
   /**
    * OMB control number / form number
    */
-  ombNumber: PropTypes.string,
+  ombNumber: PropTypes.string.isRequired,
 
   /**
    * form expiration date
    */
-  expDate: PropTypes.string,
+  expDate: PropTypes.string.isRequired,
 };
 
 export default OMBInfo;

--- a/packages/formation-react/src/components/OMBInfo/OMBInfo.mdx
+++ b/packages/formation-react/src/components/OMBInfo/OMBInfo.mdx
@@ -17,6 +17,15 @@ import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo'
 />
 ```
 
+### Available Props
+
+| Name | Type | Description | Required|
+|-|-|-|:-:|
+|resBurden| String or Number | The number of minutes the form is expected to take. If left falsy, this will not show.| No|
+|ombNumber | String | The form's OMB (Office of Management and Budget) control number | Yes |
+| expDate | Date as a string | This should be a formated date, in the format of `MMMM DD YYYY`| Yes |
+|children | JSX | Any children nodes will should up in the Privacy Statement Act model | No|
+
 ### Rendered Component
 
 <div className="site-c-reactcomp__rendered">

--- a/packages/formation-react/src/components/OMBInfo/OMBInfo.unit.spec.jsx
+++ b/packages/formation-react/src/components/OMBInfo/OMBInfo.unit.spec.jsx
@@ -26,4 +26,22 @@ describe('<OMBInfo/>', () => {
         expDate="Expiration date"
       />,
     ));
+  it('should render resBurden', () => {
+    const tree = shallow(
+      <OMBInfo
+        resBurden={15}
+        ombNumber="OMB Number"
+        expDate="Expiration date"
+      />,
+    );
+    expect(tree.text()).to.contain('Respondent burden');
+    tree.unmount();
+  });
+  it('should not render resBurden', () => {
+    const tree = shallow(
+      <OMBInfo ombNumber="OMB Number" expDate="Expiration date" />,
+    );
+    expect(tree.text()).to.not.contain('Respondent burden');
+    tree.unmount();
+  });
 });


### PR DESCRIPTION
## Description
To increase flexibility, this updates the OMBInfo component to only show the `resBurden` if it a truthy value. My team's UI currently does not have a `resBurden` and in order to not duplicate code,  functionality, and ownership. This feature will allow greater flexibility 

## Testing done
- added unit tests

## Definition of done
- [ ] Added logic to hide `resBurden` if it does not exist
- [ ] Added  unit tests

## Question for the reviewer: 
- Where do I need to update the docs?