### PR TITLE
Add ALERT_TYPE enum for use with AlertBox `status` prop

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/AlertBox/AlertBox.jsx
+++ b/packages/formation-react/src/components/AlertBox/AlertBox.jsx
@@ -2,6 +2,15 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
+// Enum used to set the AlertBox's `status` prop
+export const ALERT_TYPE = Object.freeze({
+  INFO: 'info', // Blue border, black circled 'i'
+  ERROR: 'error', // Red border, red circled exclamation
+  SUCCESS: 'success', // Green border, green checkmark
+  WARNING: 'warning', // Yellow border, black triangle exclamation
+  CONTINUE: 'continue', // Green border, green lock
+})
+
 class AlertBox extends React.Component {
   componentDidMount() {
     this.scrollToAlert();
@@ -79,13 +88,7 @@ AlertBox.propTypes = {
   /**
    * Determines the color and icon of the alert box.
    */
-  status: PropTypes.oneOf([
-    'info', // Blue border, black circled 'i'
-    'error', // Red border, red circled exclamation
-    'success', // Green border, green checkmark
-    'warning', // Yellow border, black triangle exclamation
-    'continue', // Green border, green lock
-  ]).isRequired,
+  status: PropTypes.oneOf(Object.values(ALERT_TYPE)).isRequired,
 
   /**
    * Show or hide the alert. Useful for alerts triggered by app interaction.

--- a/packages/formation-react/src/components/AlertBox/AlertBox.mdx
+++ b/packages/formation-react/src/components/AlertBox/AlertBox.mdx
@@ -4,53 +4,53 @@ name: AlertBox
 tags: informational, warning, error, success, continue, dismissable
 ---
 
-import AlertBox from './AlertBox'
+import AlertBox, { ALERT_TYPE } from './AlertBox'
 
 
 ### Code:
 ```javascript
-import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox'
+import AlertBox, { ALERT_TYPE } from '@department-of-veterans-affairs/formation-react/AlertBox'
 
 <div className="usa-width-one-whole">
   <AlertBox
     headline='Informational alert'
     content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id felis pulvinar ligula ultricies sollicitudin eget nec dui. Cras augue velit, pellentesque sit amet nisl ut, tristique suscipit sem. Cras sollicitudin auctor mattis."
-    status="info"
+    status={ALERT_TYPE.INFO}
     isVisible/>
   <AlertBox
     headline="Warning alert"
     content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id felis pulvinar ligula ultricies sollicitudin eget nec dui. Cras augue velit, pellentesque sit amet nisl ut, tristique suscipit sem. Cras sollicitudin auctor mattis."
-    status="warning"/>
+    status={ALERT_TYPE.WARNING} />
   <AlertBox
     headline="Error alert"
     content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id felis pulvinar ligula ultricies sollicitudin eget nec dui. Cras augue velit, pellentesque sit amet nisl ut, tristique suscipit sem. Cras sollicitudin auctor mattis."
-    status="error"/>
+    status={ALERT_TYPE.ERROR} />
   <AlertBox
     headline="Success alert"
     content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id felis pulvinar ligula ultricies sollicitudin eget nec dui. Cras augue velit, pellentesque sit amet nisl ut, tristique suscipit sem. Cras sollicitudin auctor mattis."
-    status="success"/>
+    status={ALERT_TYPE.SUCCESS} />
   <AlertBox
     headline="Continue alert"
     content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id felis pulvinar ligula ultricies sollicitudin eget nec dui. Cras augue velit, pellentesque sit amet nisl ut, tristique suscipit sem. Cras sollicitudin auctor mattis."
-    status="continue"/>
+    status={ALERT_TYPE.CONTINUE} />
   <AlertBox
     headline="Dismissable alert"
     content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id felis pulvinar ligula ultricies sollicitudin eget nec dui. Cras augue velit, pellentesque sit amet nisl ut, tristique suscipit sem. Cras sollicitudin auctor mattis."
-    status="info"
+    status={ALERT_TYPE.INFO}
     isVisible
     onCloseAlert={() => {}}/>
   <AlertBox
     headline="Hidden alert"
     content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id felis pulvinar ligula ultricies sollicitudin eget nec dui. Cras augue velit, pellentesque sit amet nisl ut, tristique suscipit sem. Cras sollicitudin auctor mattis."
-    status="info"
+    status={ALERT_TYPE.INFO}
     isVisible={false}/>
   <AlertBox
     content={<p>Content without heading.</p>}
-    status="info"/>
+    status={ALERT_TYPE.INFO}/>
   <AlertBox
     headline="Informational backgroundOnly alert"
     content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id felis pulvinar ligula ultricies sollicitudin eget nec dui. Cras augue velit, pellentesque sit amet nisl ut, tristique suscipit sem. Cras sollicitudin auctor mattis."
-    status="info"
+    status={ALERT_TYPE.INFO}
     backgroundOnly />
 </div>
 ```
@@ -61,42 +61,42 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox'
     <AlertBox
       headline="Informational alert"
       content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id felis pulvinar ligula ultricies sollicitudin eget nec dui. Cras augue velit, pellentesque sit amet nisl ut, tristique suscipit sem. Cras sollicitudin auctor mattis."
-      status="info"
+      status={ALERT_TYPE.INFO}
       isVisible/>
     <AlertBox
       headline="Warning alert"
       content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id felis pulvinar ligula ultricies sollicitudin eget nec dui. Cras augue velit, pellentesque sit amet nisl ut, tristique suscipit sem. Cras sollicitudin auctor mattis."
-      status="warning"/>
+      status={ALERT_TYPE.WARNING} />
     <AlertBox
       headline="Error alert"
       content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id felis pulvinar ligula ultricies sollicitudin eget nec dui. Cras augue velit, pellentesque sit amet nisl ut, tristique suscipit sem. Cras sollicitudin auctor mattis."
-      status="error"/>
+      status={ALERT_TYPE.ERROR} />
     <AlertBox
       headline="Success alert"
       content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id felis pulvinar ligula ultricies sollicitudin eget nec dui. Cras augue velit, pellentesque sit amet nisl ut, tristique suscipit sem. Cras sollicitudin auctor mattis."
-      status="success"/>
+      status={ALERT_TYPE.SUCCESS} />
     <AlertBox
       headline="Continue alert"
       content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id felis pulvinar ligula ultricies sollicitudin eget nec dui. Cras augue velit, pellentesque sit amet nisl ut, tristique suscipit sem. Cras sollicitudin auctor mattis."
-      status="continue"/>
+      status={ALERT_TYPE.CONTINUE} />
     <AlertBox
       headline="Dismissable alert"
       content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id felis pulvinar ligula ultricies sollicitudin eget nec dui. Cras augue velit, pellentesque sit amet nisl ut, tristique suscipit sem. Cras sollicitudin auctor mattis."
-      status="info"
+      status={ALERT_TYPE.INFO}
       isVisible
       onCloseAlert={() => {}}/>
     <AlertBox
       headline="Hidden alert"
       content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id felis pulvinar ligula ultricies sollicitudin eget nec dui. Cras augue velit, pellentesque sit amet nisl ut, tristique suscipit sem. Cras sollicitudin auctor mattis."
-      status="info"
+      status={ALERT_TYPE.INFO}
       isVisible={false}/>
     <AlertBox
       content={<p>Content without heading.</p>}
-      status="info"/>
+      status={ALERT_TYPE.INFO}/>
     <AlertBox
       headline="Background Only alert"
       content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam id felis pulvinar ligula ultricies sollicitudin eget nec dui. Cras augue velit, pellentesque sit amet nisl ut, tristique suscipit sem. Cras sollicitudin auctor mattis."
-      status="info"
+      status={ALERT_TYPE.INFO}
       backgroundOnly />
   </div>
 </div>


### PR DESCRIPTION
I like constants 🤷 

It's always felt wrong to me to do something like:
```
<AlertBox status="info">
```

With this change we can do:
```
<AlertBox status={ALERT_TYPE.INFO}>
```

Why? Better code completion from editors and/or earlier error/typo detection. It's not TypeScript, but it's better than throwing strings around.