### PR TITLE
bump version so we can republish

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",


### PR DESCRIPTION
Published 5.6.0 incorrectly. Need to bump the version to publish the correct components to NPM.