### PR TITLE
'Percentage of Logged in Users' for unauthenticated scenario

### DIFF
--- a/packages/documentation/src/pages/platform/tools/feature-toggles.mdx
+++ b/packages/documentation/src/pages/platform/tools/feature-toggles.mdx
@@ -196,7 +196,9 @@ flipper:
 
 3. Once you have logged into the Flipper UI, you can perform the following actions:
    - Select "Enable for everyone" or "Disable for everyone" to enable or disable the feature for all users.
-   - For a gradual rollout or an a/b test you can use "Percentage of Logged in Users." "Percentage of Logged in Users" will enable the feature for the same users each time they return to the site as long as you don't change the percentage.
+   - Use "Percentage of Logged in Users" for a [staged rollout](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/product-management/release-plan-template.md#phase-ii-staged-rollout-also-known-as-unmoderated-production-testing) (gradual rollout or an a/b test).
+       - "Percentage of Logged in Users" will enable the feature for only a percentage of logged in users. It will be applied to the same users each time they return to the site (even when they log out and back in) as long as you don't change the percentage.
+       - If the feature toggle's actor_type in [config/features.yml](https://github.com/department-of-veterans-affairs/vets-api/blob/master/config/features.yml) is set to "cookie_id" rather than "user" then the feature instead applies to only a percentage of users for the duration of a cookie within a single browser, *regardless of their logged in status*. This is useful when you need to apply a staged rollout that involves an unauthenticated user experience.
    - Use "Percentage of Time" to enable a feature for all users for a percentage of time.
    - Register a "Group" of users to enable a feature for.
    - You can also roll out a feature for a select few users by adding their email address to the “Users” section. For performance reasons, the list of users is intended to be small — do not use this option for hundreds of users.


### PR DESCRIPTION
Clarification on how to apply staged rollouts (A/B testing) in Flipper to unauthenticated scenarios. This explicitly ties the Flipper UI options back to the earlier advice on when to "choose cookie_id as the actor_type". If you don't realize that setting has an impact here, then this parts reads as if it only can be applied to logged-in users. The term "Percentage of Logged in Users" can be confusing when the actor_type is set to 'cookie_id' rather than the usual 'user.'

I've also updated the terminology to match the term "staged rollouts" and linked it back to the release plan template.

For further context, this is the Slack thread:
https://dsva.slack.com/archives/CBU0KDSB1/p1601326204185500
