### PR TITLE
Style nested abbr in visited links

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.9.5",
+  "version": "6.9.6",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -100,7 +100,8 @@ a {
   &:active {
     background: $color-link-default-hover;
   }
-  &:visited {
+  &:visited,
+  &:visited abbr {
     color: $color-visited;
   }
 }


### PR DESCRIPTION
## Description

Download links, based on the [recommended markup](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/152#issuecomment-553127340), includes an `abbr` which doesn't get properly styled when the link has been visited

![](https://user-images.githubusercontent.com/136959/94832185-365d5080-03d3-11eb-9f2d-d695b6e515eb.png)

This PR adds the `abbr` styling for visited links only. Active links only modify the background and hovered links use `inherit` color.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/14258

## Testing done

None

## Screenshots

See description

## Acceptance criteria
- [x] `abbr` text matches the visited link color

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
