### PR TITLE
Fix alert box scroll when scrollOnShow is true

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "5.6.1",
+  "version": "5.7.0",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/AlertBox/AlertBox.jsx
+++ b/packages/formation-react/src/components/AlertBox/AlertBox.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component } from 'react';
 import classNames from 'classnames';
 
 // Enum used to set the AlertBox's `status` prop
@@ -9,11 +9,15 @@ export const ALERT_TYPE = Object.freeze({
   SUCCESS: 'success', // Green border, green checkmark
   WARNING: 'warning', // Yellow border, black triangle exclamation
   CONTINUE: 'continue', // Green border, green lock
-})
+});
 
-class AlertBox extends React.Component {
+class AlertBox extends Component {
   componentDidMount() {
     this.scrollToAlert();
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this.scrollToAlertTimeout);
   }
 
   shouldComponentUpdate(nextProps) {
@@ -32,13 +36,14 @@ class AlertBox extends React.Component {
       return;
     }
 
-    const isInView = window.scrollY <= this._ref.offsetTop;
-
-    if (this._ref && !isInView) {
-      this._ref.scrollIntoView({
-        block: this.props.scrollPosition,
-        behavior: 'smooth',
-      });
+    if (this._ref) {
+      clearTimeout(this.scrollToAlertTimeout);
+      this.scrollToAlertTimeout = setTimeout(() => {
+        this._ref.scrollIntoView({
+          block: this.props.scrollPosition,
+          behavior: 'smooth',
+        });
+      }, 0);
     }
   };
 

--- a/packages/formation-react/src/components/AlertBox/AlertBox.jsx
+++ b/packages/formation-react/src/components/AlertBox/AlertBox.jsx
@@ -32,14 +32,12 @@ class AlertBox extends Component {
   }
 
   scrollToAlert = () => {
-    if (!this.props.isVisible || !this.props.scrollOnShow) {
-      return;
-    }
-
-    if (this._ref) {
+    // Without using the setTimeout, React has not added the element
+    // to the DOM when it calls scrollIntoView()
+    if (this.props.isVisible && this.props.scrollOnShow) {
       clearTimeout(this.scrollToAlertTimeout);
       this.scrollToAlertTimeout = setTimeout(() => {
-        this._ref.scrollIntoView({
+        this._ref?.scrollIntoView({
           block: this.props.scrollPosition,
           behavior: 'smooth',
         });


### PR DESCRIPTION
## Description
We also need to scroll to an AlertBox when `scrollOnShow` is passed and the AlertBox is already (partially) in the viewport). Initially, the scroll logic would not run when the AlertBox was only a few pixels in the viewport which was confusing for the user.

I needed to use a `setTimeout` to ensure the `ref` in the scroll logic was defined, since putting any logic in `componentDidMount` does not guarantee that it's actually already painted to the DOM.

## Testing done
Works locally.

## Acceptance criteria
- [x] Also scroll when the AlertBox is already in the viewport

## Definition of done
- [x] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
