### PR TITLE
Fix undefined ref issue

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "5.7.0",
+  "version": "5.7.1",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/AlertBox/AlertBox.jsx
+++ b/packages/formation-react/src/components/AlertBox/AlertBox.jsx
@@ -34,10 +34,10 @@ class AlertBox extends Component {
   scrollToAlert = () => {
     // Without using the setTimeout, React has not added the element
     // to the DOM when it calls scrollIntoView()
-    if (this.props.isVisible && this.props.scrollOnShow) {
+    if (this.props.isVisible && this.props.scrollOnShow && this._ref) {
       clearTimeout(this.scrollToAlertTimeout);
       this.scrollToAlertTimeout = setTimeout(() => {
-        this._ref?.scrollIntoView({
+        this._ref.scrollIntoView({
           block: this.props.scrollPosition,
           behavior: 'smooth',
         });

--- a/packages/formation-react/src/components/AlertBox/AlertBox.jsx
+++ b/packages/formation-react/src/components/AlertBox/AlertBox.jsx
@@ -32,9 +32,13 @@ class AlertBox extends Component {
   }
 
   scrollToAlert = () => {
+    if (!this._ref || !this._ref.scrollIntoView) {
+      return;
+    }
+
     // Without using the setTimeout, React has not added the element
     // to the DOM when it calls scrollIntoView()
-    if (this.props.isVisible && this.props.scrollOnShow && this._ref) {
+    if (this.props.isVisible && this.props.scrollOnShow) {
       clearTimeout(this.scrollToAlertTimeout);
       this.scrollToAlertTimeout = setTimeout(() => {
         this._ref.scrollIntoView({


### PR DESCRIPTION
## Description
This is a follow up to [this PR](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/452/commits/cd7df9f3d5ce8750c82d9a610ae06ae318edc6de).

This PR fixes the error thrown in vets-website after upgrading formation-react to 5.7.0.

![image](https://user-images.githubusercontent.com/14869324/95473100-fd782b00-0940-11eb-8b34-8d8b732d51ac.png)

## Acceptance criteria
- [x] Fix undefined ref issue

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
