### PR TITLE
[Bug] Prevent form continue on pressing `Enter`

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "5.7.1",
+  "version": "5.7.2",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/ErrorableTextInput/ErrorableTextInput.jsx
+++ b/packages/formation-react/src/components/ErrorableTextInput/ErrorableTextInput.jsx
@@ -72,8 +72,10 @@ class ErrorableTextInput extends React.Component {
       requiredSpan = <span className="form-required-span">(*Required)</span>;
     }
 
+    // preventDefault on the div stops the form from submitting after a user
+    // presses enter while the input is focused
     return (
-      <div className={inputErrorClass}>
+      <div className={inputErrorClass} onKeyPress={e => e.preventDefault()}>
         <label className={labelErrorClass} htmlFor={this.inputId}>
           {this.props.label}
           {requiredSpan}


### PR DESCRIPTION
## Description

When on a form page with all valid entries, focus on a text input and press <kbd>Enter</kbd>. It will cause the form to go to the next page; this is similar behavior to pressing the "Continue" button at the bottom of the form.

Step-by-step instructions on duplicating this issue can be found in https://github.com/department-of-veterans-affairs/va.gov-team/issues/14695

## Testing done

- Manual tests
- Unit tests

## Screenshots

<details><summary>Pressing enter in a text input</summary>

<!-- leave a blank line above -->
![enter-skip](https://user-images.githubusercontent.com/136959/95630826-259e8180-0a48-11eb-9d4e-fe5a6f21ffa7.gif)</details>

## Acceptance criteria
- [x] Form does not go to the next page after pressing <kbd>Enter</kbd>
- [x] All unit tests are passing

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
