### PR TITLE
Add Treasury DMS phone number to contact list

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "5.7.3",
+  "version": "5.7.4",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/Telephone/Telephone.jsx
+++ b/packages/formation-react/src/components/Telephone/Telephone.jsx
@@ -21,6 +21,7 @@ export const CONTACTS = Object.freeze({
   MY_HEALTHEVET: '8773270022', // My HealtheVet help desk
   NCA: '8005351117', // National Cemetery Scheduling Office
   TESC: '8882242950', // U.S. Treasury Electronic Payment Solution Center
+  TREASURY_DMS: '8888263127', // U.S. Department of the Treasury (Debt Management Services)
   FEDERAL_RELAY_SERVICE: '8008778339', // Federal Relay Service
   SUICIDE_PREVENTION_LIFELINE: '8007994889', // Suicide Prevention Line
   DMDC_DEERS: '8663632883', // Defense Manpower Data Center (DMDC) | Defense Enrollment Eligibility Reporting System (DEERS) Support Office

--- a/packages/formation-react/src/components/Telephone/Telephone.mdx
+++ b/packages/formation-react/src/components/Telephone/Telephone.mdx
@@ -145,6 +145,7 @@ import Telephone, { CONTACTS, PATTERNS } from '@department-of-veterans-affairs/f
 | `NCA`                         | `8005351117` | National Cemetery Scheduling Office                                                                          |
 | `SUICIDE_PREVENTION_LIFELINE` | `8007994889` | Suicide Prevention Line                                                                                      |
 | `TESC`                        | `8882242950` | U.S. Treasury Electronic Payment Solution Center                                                             |
+| `TREASURY_DMS`                | `8888263127` | U.S. Department of the Treasury (Debt Management Services)                                                   |  |  |
 | `VA_311`                      | `8446982311` | VA Help desk (VA311)                                                                                         |
 | `VA_BENEFITS`                 | `8008271000` | Veterans Benefits Assistance                                                                                 |
 


### PR DESCRIPTION
## Description
Adds U.S. Department of the Treasury (Debt Management Services) phone number to contact list

## Acceptance criteria
- [x]  Added `TREASURY_DMS` to  contact list

## Definition of done
- [x] Changes have been tested in vets-website
- [x] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs