### PR TITLE
Bump formation version for Table css changes

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.9.6",
+  "version": "6.10.0",
   "description": "The VA design system",
   "keywords": [
     "va",


### PR DESCRIPTION
## Description

This is related to #492. It added the responsive `<Table>` component to `formation-react` along with some css to `formation`, but the `formation` package wasn't updated for publishing. This updates the version number of `formation`.


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
