### PR TITLE
Fixed small typo on the Visual Design documentation page

### DIFF
--- a/packages/documentation/src/pages/visual-design/index.mdx
+++ b/packages/documentation/src/pages/visual-design/index.mdx
@@ -4,7 +4,7 @@ title: Visual design docs
 
 # VA.gov visual design
 
-In order to have a consistent look and feel that is easy to use and accessible for all Veterans, VA.gov is built on top of VA's design system (VADS). VADS is based on the [US Web Design System](https://designsystem.digital.gov) and contains components, patterns, and utilitiesthat can be used to create sites and applications that fit the VA's standards.
+In order to have a consistent look and feel that is easy to use and accessible for all Veterans, VA.gov is built on top of VA's design system (VADS). VADS is based on the [US Web Design System](https://designsystem.digital.gov) and contains components, patterns, and utilities that can be used to create sites and applications that fit the VA's standards.
 
 The VA design system documentation can be viewed at [design.va.gov](https://design.va.gov). For developers building on the platform, there are two modules that you can use to implement the look and feel on your project.
 


### PR DESCRIPTION
## Description
Just fixed a small typo on the visual design page.

## Screenshots
<img width="773" alt="Screen Shot 2020-11-03 at 3 56 25 PM" src="https://user-images.githubusercontent.com/459581/98039737-2af3af80-1ded-11eb-835d-aa08682f2bc6.png">

## Definition of done
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
