### PR TITLE
Change table css on small screens

### DIFF
--- a/packages/formation-react/src/components/Table/Table.stories.jsx
+++ b/packages/formation-react/src/components/Table/Table.stories.jsx
@@ -16,26 +16,42 @@ const defaultArgs = {
   },
   data: [
     {
-      column1: 'Testing',
-      column2: 'Moooore testing',
+      title: 'Declaration of Independence',
+      description:
+        'Statement adopted by the Continental Congress declaring independence from the British Empire',
+      year: '1776',
     },
     {
-      column1: 'Second row',
-      column2: 'Some things',
+      title: 'Bill of Rights',
+      description:
+        'The first ten ammendements of the U.S. Constitution guaranteeing rights and freedoms',
+      year: '1791',
     },
     {
-      column1: 'Third row',
-      column2: 'beeee boop',
+      title: 'Declaration of Sentiments',
+      description:
+        'A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.',
+      year: '1848',
+    },
+    {
+      title: 'Emancipation Proclamation',
+      description:
+        'An executive order granting freedom to slaves in designated southern states.',
+      year: '1863',
     },
   ],
   fields: [
     {
-      label: 'Column 1',
-      value: 'column1',
+      label: 'Document title',
+      value: 'title',
     },
     {
-      label: 'Column 2',
-      value: 'column2',
+      label: 'Description',
+      value: 'description',
+    },
+    {
+      label: 'Year',
+      value: 'year',
     },
   ],
 };
@@ -53,11 +69,12 @@ Unsortable.args = {
   ...defaultArgs,
   fields: [
     {
-      label: 'Column 1',
-      value: 'column1',
+      label: 'Document title',
+      value: 'title',
       nonSortable: true,
     },
     defaultArgs.fields[1],
+    defaultArgs.fields[2],
   ],
 };
 
@@ -69,32 +86,25 @@ MissingData.args = {
   ...defaultArgs,
   data: [
     {
-      column1: null,
-      column2: 'Things',
+      title: 'A document',
+      description: null,
+      year: null,
     },
     defaultArgs.data[1],
   ],
 };
 
+// This story might not be useful
 export const AlignLeft = Template.bind({});
 AlignLeft.args = {
   ...defaultArgs,
   fields: [
-    {
-      label: 'Cost ($)',
-      value: 'cost',
-      alignLeft: true,
-    },
+    defaultArgs.fields[0],
     defaultArgs.fields[1],
-  ],
-  data: [
     {
-      cost: 50.5,
-      column2: 'Food',
-    },
-    {
-      cost: 70.0,
-      column2: 'Utilities',
+      label: 'Year',
+      value: 'year',
+      alignLeft: true,
     },
   ],
 };

--- a/packages/formation-react/src/components/Table/Table.stories.jsx
+++ b/packages/formation-react/src/components/Table/Table.stories.jsx
@@ -108,3 +108,32 @@ AlignLeft.args = {
     },
   ],
 };
+
+export const CustomComponents = Template.bind({});
+CustomComponents.args = {
+  ...defaultArgs,
+  data: [
+    ...defaultArgs.data,
+    {
+      title: 'Social Security Act',
+      description: (
+        <>
+          <div>
+            An act to provide for the general welfare by establishing a system
+            of Federal old-age benefits. Enables provisions for:
+          </div>
+
+          <ul>
+            <li>aged persons</li>
+            <li>blind persons</li>
+            <li>dependent and crippled children</li>
+            <li>maternal and child welfare</li>
+            <li>public health</li>
+            <li>unemployment compensation</li>
+          </ul>
+        </>
+      ),
+      year: '1935',
+    },
+  ],
+};

--- a/packages/formation-react/src/components/Table/Table.stories.jsx
+++ b/packages/formation-react/src/components/Table/Table.stories.jsx
@@ -23,6 +23,10 @@ const defaultArgs = {
       column1: 'Second row',
       column2: 'Some things',
     },
+    {
+      column1: 'Third row',
+      column2: 'beeee boop',
+    },
   ],
   fields: [
     {

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.10.1",
+  "version": "6.10.2",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/modules/_m-responsive-tables.scss
+++ b/packages/formation/sass/modules/_m-responsive-tables.scss
@@ -38,6 +38,7 @@ table.responsive {
       border: none;
       font-size: 16px;
       display: flex;
+      flex-wrap: wrap;
     }
 
     td::before {

--- a/packages/formation/sass/modules/_m-responsive-tables.scss
+++ b/packages/formation/sass/modules/_m-responsive-tables.scss
@@ -23,13 +23,7 @@ table.responsive {
   table.responsive {
     border: 0;
     thead {
-      border: none;
-      clip: rect(0, 0, 0, 0);
-      height: 1px;
-      margin: -1px;
-      overflow: hidden;
-      padding: 0;
-      width: 1px;
+      display: none;
     }
 
     tr {
@@ -43,6 +37,7 @@ table.responsive {
     td {
       border: none;
       font-size: 16px;
+      display: flex;
     }
 
     td::before {


### PR DESCRIPTION
## Description

Related to #492 

This turns the `<Table>` component into a "list table" on smaller screens by:

- removing the table headers at the top
- allowing the `<td>` elements to be displayed with `flex` so that they stack
    - Also setting `flex-wrap: wrap` so that longer content can fit below the column label

It also improves the stories for `<Table>` by adding better data, and adding a new story to show how to pass in a piece of JSX instead of a string for a row's data.

## Testing done

Storybook :eyes: 


## Screenshots

### Full width:

![image](https://user-images.githubusercontent.com/2008881/98055606-bb80be80-1df2-11eb-90d2-acb06a0f600a.png)

### Tablet

![image](https://user-images.githubusercontent.com/2008881/98056979-0cde7d00-1df6-11eb-8b6e-36be6be1dff1.png)

### Small mobile:

![image](https://user-images.githubusercontent.com/2008881/98055636-d18e7f00-1df2-11eb-81b2-e35951b968e6.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
