### PR TITLE
Move react-scroll to formation-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "react-docgen": "^2.19.0",
     "react-dom": "^16.7.0",
     "react-router": "3",
-    "react-scroll": "^1.7.7",
     "react-test-renderer": "^16.7.0",
     "recast": "^0.14.4",
     "resolve-url-loader": "^2.2.0",

--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -33,6 +33,7 @@
     "moment": "^2.23.0",
     "prop-types": "^15.6.2",
     "react-focus-lock": "^2.4.0",
+    "react-scroll": "^1.7.16",
     "react-transition-group": "1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8410,11 +8410,6 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
-lodash.throttle@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
-  integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
-
 lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
@@ -10425,7 +10420,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.6, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -10670,14 +10665,6 @@ react-router@3:
     loose-envify "^1.2.0"
     prop-types "^15.5.6"
     warning "^3.0.0"
-
-react-scroll@^1.7.7:
-  version "1.7.16"
-  resolved "https://registry.yarnpkg.com/react-scroll/-/react-scroll-1.7.16.tgz#814f0b97ed171aad1f27e45dad16a8444817fec8"
-  integrity sha512-f4M5AdL+3cw3MJ7c/T0hPMY2iHCeQLDXV13lRanAFQ6JIt9xyAdHCpTH9mLUQt9SQh4pRarD+Qc7KhU6qMx3Yg==
-  dependencies:
-    lodash.throttle "^4.1.1"
-    prop-types "^15.5.8"
 
 react-test-renderer@^16.0.0-0, react-test-renderer@^16.7.0:
   version "16.8.6"


### PR DESCRIPTION
## Description

The `react-scroll` dependency is declared in the root `package.json`, but only ever used in `formation-react`. This lack of a dependency causes problems for us when we try to deploy storybook from https://github.com/department-of-veterans-affairs/component-library

This change will declare the dependency in the child package (formation-react), so that when we update the mirrored repo, the storybook deploy shouldn't run into any problems.


## Testing done


## Screenshots

![image](https://user-images.githubusercontent.com/2008881/98175650-d8c59380-1eab-11eb-8f8c-ed5a33e7f7c5.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
