### PR TITLE
Table tweaks

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/Table/Table.jsx
+++ b/packages/formation-react/src/components/Table/Table.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 const borderClasses =
-  'vads-u-border-top--0 vads-u-border-right--0 vads-u-border-left--0 vads-u-font-family--sans vads-u-padding--0 vads-u-padding-y--0p5 medium-screen:vads-u-padding--1';
+  'vads-u-border-top--0 vads-u-border-right--0 vads-u-border-left--0 vads-u-font-family--sans vads-u-padding--0 vads-u-padding-y--0p5 medium-screen:vads-u-padding--2';
 const rowPaddingClass = 'vads-u-padding-y--2';
 
 function Table(props) {

--- a/packages/formation-react/src/components/Table/Table.jsx
+++ b/packages/formation-react/src/components/Table/Table.jsx
@@ -54,7 +54,7 @@ function Table(props) {
                 className={classNames(borderClasses, {
                   'vads-u-text-align--left': field.alignLeft,
                 })}
-                data-label={`${field.label}:`}
+                data-label={field.label}
                 key={`${rowIndex}-${field.label}`}
                 role="cell"
               >

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.10.2",
+  "version": "6.10.3",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/modules/_m-responsive-tables.scss
+++ b/packages/formation/sass/modules/_m-responsive-tables.scss
@@ -41,6 +41,14 @@ table.responsive {
       flex-direction: column;
     }
 
+    td:first-child {
+      margin-top: 16px;
+    }
+
+    td:last-child {
+      margin-bottom: 16px;
+    }
+
     td::before {
       /*
        * aria-label has no advantage, it won't be read inside a table

--- a/packages/formation/sass/modules/_m-responsive-tables.scss
+++ b/packages/formation/sass/modules/_m-responsive-tables.scss
@@ -38,7 +38,7 @@ table.responsive {
       border: none;
       font-size: 16px;
       display: flex;
-      flex-wrap: wrap;
+      flex-direction: column;
     }
 
     td::before {


### PR DESCRIPTION
## Description

After some conversation in slack [it was decided](https://dsva.slack.com/archives/C52CL1PKQ/p1604527710459700?thread_ts=1604524377.447400&cid=C52CL1PKQ) to remove the colon from the column label on mobile views, and also to force all content to appear underneath the label.


## Testing done

Storybook :eyes: 

## Screenshots

### Desktop

![image](https://user-images.githubusercontent.com/2008881/98299000-d0349200-1f6b-11eb-84f7-aeb213d014a4.png)


### Mobile

![image](https://user-images.githubusercontent.com/2008881/98299020-de82ae00-1f6b-11eb-8857-c7b8c587ca1f.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
