### PR TITLE
Add the intro and beta banner to storybook

### DIFF
--- a/packages/formation-react/.storybook/preview-body.html
+++ b/packages/formation-react/.storybook/preview-body.html
@@ -1,0 +1,9 @@
+<div id="beta-banner" class="vads-u-background-color--gold vads-u-padding-y--1 vads-u-padding-x--4">
+  <p class="vads-u-font-size--lg vads-u-margin--0">
+    <strong>This is a beta site.</strong>
+      See <a href="/?path=/story/about-introduction--page" class="vads-u-color--link-default vads-u-font-weight--bold vads-u-text-decoration--none">
+      the introduction
+    </a>
+    for details.
+  </p>
+</div>

--- a/packages/formation-react/src/Introduction.stories.mdx
+++ b/packages/formation-react/src/Introduction.stories.mdx
@@ -1,0 +1,21 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="About/Introduction" />
+
+# Welcome to VSP's Storybook Pilot!
+
+First, let's set some expectations: This is currently not considered the source
+of truth. For that, go to [our documentation
+site](https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/visual-design).
+We plan to update this regularly in preparation for a full migration to
+[design.va.gov](https://design.va.gov/components).
+
+In the meantime, please take a look around! Kick the tires, see how you like it.
+
+To guard our limited bandwidth, we're holding off on answering questions for
+now, but we'll have a proper introduction to our new documentation later. Our
+plan is to do some user research on this, so if you're interested in giving us
+feedback, please let us know in #vsp-design-system and we'll put you on the
+list.
+
+Enjoy!


### PR DESCRIPTION
## Description
Adds the intro page to storybook with a beta banner on all stories.

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/98302183-d0835c00-1f70-11eb-90ff-d31c626bee55.png)
![image](https://user-images.githubusercontent.com/12970166/98302196-d4af7980-1f70-11eb-978c-bc2f74269d37.png)
Banner shows up on `Docs` pages too.
![image](https://user-images.githubusercontent.com/12970166/98302287-fad51980-1f70-11eb-8948-e92af1bfa196.png)