### PR TITLE
Added logic to allow for right aligning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formation-monorepo",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "CC0-1.0",
   "repository": {
     "type": "git",

--- a/packages/formation-react/src/components/Table/Table.jsx
+++ b/packages/formation-react/src/components/Table/Table.jsx
@@ -8,12 +8,13 @@ const rowPaddingClass = 'vads-u-padding-y--2';
 
 function Table(props) {
   const { currentSort, fields, data, ariaLabelledBy } = props;
+  let alignClass;
 
   return (
     <table aria-labelledby={ariaLabelledBy} className="responsive" role="table">
       <thead>
         <tr role="row">
-          {fields.map((field) =>
+          {fields.map(field =>
             field.nonSortable ? (
               <th key={field.value}>{field.label}</th>
             ) : (
@@ -48,19 +49,26 @@ function Table(props) {
             className={`${borderClasses} ${rowPaddingClass}`}
             role="row"
           >
-            {fields.map((field, index) => (
-              <td
-                data-index={index}
-                className={classNames(borderClasses, {
-                  'vads-u-text-align--left': field.alignLeft,
-                })}
-                data-label={`${field.label}:`}
-                key={`${rowIndex}-${field.label}`}
-                role="cell"
-              >
-                {item[field.value] === null ? '---' : item[field.value]}
-              </td>
-            ))}
+            {fields.map((field, index) => {
+              if (field.alignRight) {
+                alignClass = 'vads-u-text-align--right';
+              } else if (field.alignLight) {
+                alignClass = 'vads-u-text-align--left';
+              } else {
+                alignClass = 'vads-u-text-align--left';
+              }
+              return (
+                <td
+                  data-index={index}
+                  className={classNames(borderClasses, alignClass)}
+                  data-label={`${field.label}:`}
+                  key={`${rowIndex}-${field.label}`}
+                  role="cell"
+                >
+                  {item[field.value] === null ? '---' : item[field.value]}
+                </td>
+              );
+            })}
           </tr>
         ))}
       </tbody>
@@ -88,6 +96,7 @@ Table.propTypes = {
       value: PropTypes.string,
       nonSortable: PropTypes.boolean,
       alignLeft: PropTypes.boolean,
+      alignRight: PropTypes.boolean,
     }),
   ),
   /**

--- a/packages/formation-react/src/components/Table/Table.jsx
+++ b/packages/formation-react/src/components/Table/Table.jsx
@@ -51,15 +51,10 @@ function Table(props) {
             {fields.map((field, index) => (
               <td
                 data-index={index}
-                className={classNames(
-                  borderClasses,
-                  {
-                    'vads-u-text-align--left': field.alignLeft,
-                  },
-                  {
-                    'medium-screen:vads-u-text-align--right': field.alignRight,
-                  },
-                )}
+                className={classNames(borderClasses, {
+                  'vads-u-text-align--left': field.alignLeft,
+                  'medium-screen:vads-u-text-align--right': field.alignRight,
+                })}
                 data-label={`${field.label}:`}
                 key={`${rowIndex}-${field.label}`}
                 role="cell"

--- a/packages/formation-react/src/components/Table/Table.jsx
+++ b/packages/formation-react/src/components/Table/Table.jsx
@@ -51,7 +51,7 @@ function Table(props) {
           >
             {fields.map((field, index) => {
               if (field.alignRight) {
-                alignClass = 'vads-u-text-align--right';
+                alignClass = 'medium-screen:vads-u-text-align--right';
               } else if (field.alignLight) {
                 alignClass = 'vads-u-text-align--left';
               } else {

--- a/packages/formation-react/src/components/Table/Table.jsx
+++ b/packages/formation-react/src/components/Table/Table.jsx
@@ -8,7 +8,6 @@ const rowPaddingClass = 'vads-u-padding-y--2';
 
 function Table(props) {
   const { currentSort, fields, data, ariaLabelledBy } = props;
-  let alignClass;
 
   return (
     <table aria-labelledby={ariaLabelledBy} className="responsive" role="table">
@@ -49,26 +48,25 @@ function Table(props) {
             className={`${borderClasses} ${rowPaddingClass}`}
             role="row"
           >
-            {fields.map((field, index) => {
-              if (field.alignRight) {
-                alignClass = 'medium-screen:vads-u-text-align--right';
-              } else if (field.alignLight) {
-                alignClass = 'vads-u-text-align--left';
-              } else {
-                alignClass = 'vads-u-text-align--left';
-              }
-              return (
-                <td
-                  data-index={index}
-                  className={classNames(borderClasses, alignClass)}
-                  data-label={`${field.label}:`}
-                  key={`${rowIndex}-${field.label}`}
-                  role="cell"
-                >
-                  {item[field.value] === null ? '---' : item[field.value]}
-                </td>
-              );
-            })}
+            {fields.map((field, index) => (
+              <td
+                data-index={index}
+                className={classNames(
+                  borderClasses,
+                  {
+                    'vads-u-text-align--left': field.alignLeft,
+                  },
+                  {
+                    'medium-screen:vads-u-text-align--right': field.alignRight,
+                  },
+                )}
+                data-label={`${field.label}:`}
+                key={`${rowIndex}-${field.label}`}
+                role="cell"
+              >
+                {item[field.value] === null ? '---' : item[field.value]}
+              </td>
+            ))}
           </tr>
         ))}
       </tbody>
@@ -88,7 +86,10 @@ Table.propTypes = {
   data: PropTypes.arrayOf(PropTypes.object),
   /**
    * An array of objects representing columns. The `label` is what is displayed, and
-   * the `value` is what is used to match data to the correct column.
+   * the `value` is what is used to match data to the correct column. The type is
+   * the data type for the column. Available types are -
+   * - String
+   * - Number
    */
   fields: PropTypes.arrayOf(
     PropTypes.shape({

--- a/packages/formation-react/src/components/Table/Table.stories.jsx
+++ b/packages/formation-react/src/components/Table/Table.stories.jsx
@@ -113,11 +113,13 @@ AlignLeft.args = {
 export const alignRight = Template.bind({});
 alignRight.args = {
   ...defaultArgs,
-  data: [
+  fields: [
+    defaultArgs.fields[0],
+    defaultArgs.fields[1],
     {
-      title: 'alignRight',
-      description:
-        'If you need to right align data in a column, in the fields object you can set alignRight to true for that field. This will right align the entire column which is generally used for numerical data in a table.',
+      label: 'Year',
+      value: 'year',
+      alignRight: true,
     },
   ],
 };

--- a/packages/formation-react/src/components/Table/Table.stories.jsx
+++ b/packages/formation-react/src/components/Table/Table.stories.jsx
@@ -7,7 +7,7 @@ export default {
   component: Table,
 };
 
-const Template = (args) => <Table {...args} />;
+const Template = args => <Table {...args} />;
 
 const defaultArgs = {
   currentSort: {
@@ -105,6 +105,19 @@ AlignLeft.args = {
       label: 'Year',
       value: 'year',
       alignLeft: true,
+    },
+  ],
+};
+
+// This story might not be useful
+export const alignRight = Template.bind({});
+alignRight.args = {
+  ...defaultArgs,
+  data: [
+    {
+      title: 'alignRight',
+      description:
+        'If you need to right align data in a column, in the fields object you can set alignRight to true for that field. This will right align the entire column which is generally used for numerical data in a table.',
     },
   ],
 };


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/15484)

Often times numerical data is supposed to be right aligned in tables and in fact, our design system calls for right aligning numerical data in tables as well as material design and AP style guides call for right aligning numerical data in tables as well. This PR adds a prop to the `<Table />` component to allow a key of `rightAlign` to be passed in with he value true on a field and have that field get the standard design system right align class added to right-align it.

The class that is added is from medium screens and up since on mobile the table stacks and we don't want the data right aligned then.

## Testing done
All existing unit tests pass, further unit tests are coming in future iterations

## Screenshots

<img width="677" alt="Screen Shot 2020-11-05 at 2 12 19 PM" src="https://user-images.githubusercontent.com/1899695/98302267-f1e44800-1f70-11eb-9b72-b0be95341b33.png">


## Acceptance criteria
- [x] We are able to right-align data in columns in our `<Table />` component
- [x] A PR has been submitted for review

