### PR TITLE
ErrorableMonthYear story

### DIFF
--- a/packages/formation-react/src/components/ErrorableMonthYear/ErrorableMonthYear.jsx
+++ b/packages/formation-react/src/components/ErrorableMonthYear/ErrorableMonthYear.jsx
@@ -83,7 +83,7 @@ class ErrorableMonthYear extends React.Component {
         <div
           className={isValid ? undefined : 'usa-input-error form-error-date'}
         >
-          <div className="usa-date-of-birth row">
+          <div className="usa-date-of-birth">
             <div className="form-datefield-month">
               <ErrorableSelect
                 errorMessage={isValid ? undefined : ''}

--- a/packages/formation-react/src/components/ErrorableMonthYear/ErrorableMonthYear.stories.jsx
+++ b/packages/formation-react/src/components/ErrorableMonthYear/ErrorableMonthYear.stories.jsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import ErrorableMonthYear from './ErrorableMonthYear';
+
+export default {
+  title: 'Library/ErrorableMonthYear',
+  component: ErrorableMonthYear,
+};
+
+const Template = (args) => {
+  const [date, setDate] = useState(args.date);
+  const onChange = (newDate) => {
+    console.log('set the date to', newDate);
+    setDate(newDate);
+  };
+  return (
+    <div style={{ paddingLeft: '1em' }}>
+      <ErrorableMonthYear {...args} date={date} onValueChange={onChange} />
+    </div>
+  );
+};
+
+const defaultArgs = {
+  name: 'birthMonth',
+  label: 'Birth Month',
+  date: {
+    month: { dirty: false },
+    year: { dirty: false },
+  },
+};
+
+export const Default = Template.bind({});
+Default.args = { ...defaultArgs };
+
+export const Error = Template.bind({});
+Error.args = Object.assign({}, defaultArgs, {
+  date: {
+    month: { dirty: true },
+    year: { dirty: true },
+  },
+  invalidMessage: "That date doesn't work...",
+});
+
+export const Required = Template.bind({});
+Required.args = { ...defaultArgs, required: true };

--- a/packages/formation-react/src/components/ErrorableMonthYear/ErrorableMonthYear.stories.jsx
+++ b/packages/formation-react/src/components/ErrorableMonthYear/ErrorableMonthYear.stories.jsx
@@ -9,7 +9,6 @@ export default {
 const Template = (args) => {
   const [date, setDate] = useState(args.date);
   const onChange = (newDate) => {
-    console.log('set the date to', newDate);
     setDate(newDate);
   };
   return (

--- a/packages/formation-react/src/components/ErrorableMonthYear/ErrorableMonthYear.stories.jsx
+++ b/packages/formation-react/src/components/ErrorableMonthYear/ErrorableMonthYear.stories.jsx
@@ -34,7 +34,7 @@ Default.args = { ...defaultArgs };
 export const Error = Template.bind({});
 Error.args = Object.assign({}, defaultArgs, {
   date: {
-    month: { dirty: true },
+    month: { value: '13', dirty: true },
     year: { dirty: true },
   },
   invalidMessage: "That date doesn't work...",


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/15412
While creating the story, I removed the `row` class from the component because there was a misalignment between the label and the inputs.

## Testing done
Visual testing in Storybook.

## Screenshots
*Default*
![image](https://user-images.githubusercontent.com/12970166/98746741-eb880e80-236a-11eb-95e0-62f9f0d6684c.png)
*Error message*
Note: The error doesn't show up well, but fixing it is out of the scope of this PR.
![image](https://user-images.githubusercontent.com/12970166/98746764-f2168600-236a-11eb-8929-8e44725f047f.png)
*Required*
![image](https://user-images.githubusercontent.com/12970166/98746770-f80c6700-236a-11eb-9cd9-f2e715642cdc.png)


## Acceptance criteria
- [x] The stories are written