### PR TITLE
Errorable number input stories

### DIFF
--- a/packages/formation-react/src/components/ErrorableNumberInput/ErrorableNumberInput.jsx
+++ b/packages/formation-react/src/components/ErrorableNumberInput/ErrorableNumberInput.jsx
@@ -91,29 +91,38 @@ ErrorableNumberInput.propTypes = {
    * Error string to display in the component. When defined, indicates input has a validation error.
    */
   errorMessage: PropTypes.string,
+
+  /**
+   * An object that contains a `value` field which controls the value of the `<input>`.
+   * `dirty` just gets passed through as part of the `field` when `onValueChange` is called for a blur event
+   */
   field: PropTypes.shape({
     value: PropTypes.string,
     dirty: PropTypes.bool,
   }).isRequired,
   /**
-   * `label` - String for the input field label.
+   * String for the input field label.
    */
   label: PropTypes.string.isRequired,
   /**
-   * name` - String for name attribute.
+   * String for `name` attribute for the `<input>`.
    */
   name: PropTypes.string,
   /**
-   * minimum number value and maximum of same
+   * Minimum number value
    */
   min: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+  /**
+   * Maximum number value
+   */
   max: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /**
    * String specifying the pattern for the input.
    */
   pattern: PropTypes.string,
   /**
-   * placeholder string for input field.
+   * Placeholder string for input field.
    */
   placeholder: PropTypes.string,
   /**
@@ -121,9 +130,13 @@ ErrorableNumberInput.propTypes = {
    */
   required: PropTypes.bool,
   /**
-   * handler for the value change with this prototype: (newValue)
+   * Handler for the value change with this prototype: (newField)
    */
   onValueChange: PropTypes.func.isRequired,
+
+  /**
+   * Will be applied as a class name on the `<input>`
+   */
   additionalClass: PropTypes.string,
 };
 

--- a/packages/formation-react/src/components/ErrorableNumberInput/ErrorableNumberInput.stories.jsx
+++ b/packages/formation-react/src/components/ErrorableNumberInput/ErrorableNumberInput.stories.jsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+
+import ErrorableNumberInput from './ErrorableNumberInput';
+
+export default {
+  title: 'Library/ErrorableNumberInput',
+  component: ErrorableNumberInput,
+};
+
+const Template = (args) => {
+  const [field, setField] = useState(args.field);
+  const onValueChange = (newField) => {
+    console.log('value changed:', newField);
+    setField(newField);
+  };
+
+  return (
+    <ErrorableNumberInput
+      {...args}
+      field={field}
+      onValueChange={onValueChange}
+    />
+  );
+};
+
+const defaultArgs = {
+  required: false,
+  label: 'Years of service',
+  name: 'years',
+  field: {
+    value: 0,
+    dirty: false,
+  },
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  ...defaultArgs,
+};
+
+/**
+ * Sets a `min` and `max`
+ */
+export const ValidRange = Template.bind({});
+ValidRange.args = {
+  ...defaultArgs,
+  min: 0,
+  max: 4,
+};
+
+export const InvalidInput = Template.bind({});
+InvalidInput.args = {
+  ...defaultArgs,
+  errorMessage: 'This is an error',
+};
+
+export const Required = Template.bind({});
+Required.args = {
+  ...defaultArgs,
+  required: true,
+};


### PR DESCRIPTION
## Description

### Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/15413

Add some stories for `<ErrorableNumberInput />`

## Testing done

Storybook :eyes: 


## Screenshots

![image](https://user-images.githubusercontent.com/2008881/98850898-4b81c200-240a-11eb-99ac-8f946ef98294.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
