### PR TITLE
Errorable select story

### DIFF
--- a/packages/formation-react/src/components/ErrorableSelect/ErrorableSelect.jsx
+++ b/packages/formation-react/src/components/ErrorableSelect/ErrorableSelect.jsx
@@ -154,6 +154,7 @@ ErrorableSelect.propTypes = {
   emptyDescription: PropTypes.string,
 
   /** Object containing:
+   *
    *   - `value`: Value of the select field.
    *   - `dirty`: Whether a field has been touched by the user.
    */

--- a/packages/formation-react/src/components/ErrorableSelect/ErrorableSelect.jsx
+++ b/packages/formation-react/src/components/ErrorableSelect/ErrorableSelect.jsx
@@ -82,7 +82,7 @@ class ErrorableSelect extends React.Component {
         </label>
         {errorSpan}
         <select
-          className={this.props.selectClass || this.props.additionalClass}
+          className={this.props.additionalClass}
           aria-describedby={errorSpanId}
           id={this.selectId}
           name={this.props.name}
@@ -144,18 +144,18 @@ ErrorableSelect.propTypes = {
   required: PropTypes.bool,
 
   /**
-   * is there an empty selectable thing
+   * Is there an empty selectable option
    */
   includeBlankOption: PropTypes.bool,
 
   /**
-   * Description that shows up for the blank option, when includeBlankOption is true
+   * Description that shows up for the blank option, when `includeBlankOption` is true
    */
   emptyDescription: PropTypes.string,
 
-  /** `value` - object containing:
+  /** Object containing:
    *   - `value`: Value of the select field.
-   *   - `dirty`: boolean. Whether a field has been touched by the user.
+   *   - `dirty`: Whether a field has been touched by the user.
    */
   value: PropTypes.shape({
     value: PropTypes.string,
@@ -163,7 +163,7 @@ ErrorableSelect.propTypes = {
   }).isRequired,
 
   /**
-   * a function with this prototype: (newValue)
+   * A function with this prototype: (newValue)
    */
   onValueChange: PropTypes.func.isRequired,
 

--- a/packages/formation-react/src/components/ErrorableSelect/ErrorableSelect.stories.jsx
+++ b/packages/formation-react/src/components/ErrorableSelect/ErrorableSelect.stories.jsx
@@ -7,8 +7,6 @@ export default {
   component: ErrorableSelect,
 };
 
-// const Template = (args) => <ErrorableSelect {...args} />;
-
 const Template = (args) => {
   const [value, setValue] = useState(args.value);
   const onValueChange = (newValue) => {

--- a/packages/formation-react/src/components/ErrorableSelect/ErrorableSelect.stories.jsx
+++ b/packages/formation-react/src/components/ErrorableSelect/ErrorableSelect.stories.jsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+
+import ErrorableSelect from './ErrorableSelect';
+
+export default {
+  title: 'Library/ErrorableSelect',
+  component: ErrorableSelect,
+};
+
+// const Template = (args) => <ErrorableSelect {...args} />;
+
+const Template = (args) => {
+  const [value, setValue] = useState(args.value);
+  const onValueChange = (newField) => {
+    console.log('value changed:', newField);
+    setValue(newField);
+  };
+
+  return (
+    <ErrorableSelect {...args} value={value} onValueChange={onValueChange} />
+  );
+};
+
+const defaultArgs = {
+  label: 'Branch of Service',
+  name: 'branch',
+  value: {
+    value: 'Marines',
+    dirty: false,
+  },
+  options: ['Army', 'Navy', 'Air Force', 'Marines', 'Coast Guard'],
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  ...defaultArgs,
+};
+
+export const ErrorMessage = Template.bind({});
+ErrorMessage.args = {
+  ...defaultArgs,
+  errorMessage: 'There was a problem',
+};
+
+export const Required = Template.bind({});
+Required.args = {
+  ...defaultArgs,
+  required: true,
+};
+
+export const NoBlankOption = Template.bind({});
+NoBlankOption.args = {
+  ...defaultArgs,
+  includeBlankOption: false,
+};

--- a/packages/formation-react/src/components/ErrorableSelect/ErrorableSelect.stories.jsx
+++ b/packages/formation-react/src/components/ErrorableSelect/ErrorableSelect.stories.jsx
@@ -11,9 +11,9 @@ export default {
 
 const Template = (args) => {
   const [value, setValue] = useState(args.value);
-  const onValueChange = (newField) => {
-    console.log('value changed:', newField);
-    setValue(newField);
+  const onValueChange = (newValue) => {
+    console.log('value changed:', newValue);
+    setValue(newValue);
   };
 
   return (


### PR DESCRIPTION
## Description

### Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/15415

Some stories for `<ErrorableSelect />`

This also removes the `selectClass` prop from the component which wasn't used anywhere. `additionalClass` can be used instead.


## Testing done

Storybook :eyes: 

## Screenshots

![image](https://user-images.githubusercontent.com/2008881/98853793-84bc3100-240e-11eb-8570-0c2562450934.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
