### PR TITLE
Stop auto-formatting with linting errors

### DIFF
--- a/packages/vagov-eslint/.prettierrc
+++ b/packages/vagov-eslint/.prettierrc
@@ -7,5 +7,6 @@
   "trailingComma": "all",
   "bracketSpacing": true,
   "jsxBracketSameLine": false,
-  "proseWrap": "preserve"
+  "proseWrap": "preserve",
+  "arrowParens": "avoid"
 }


### PR DESCRIPTION
## Description
The auto-formatting on file save was adding parens around single-argument arrow functions. We experienced this behavior in Emacs, Vim, and VS Code, so it's not an editor-specific configuration. I have no idea why it was doing this...and then why eslint was saying it was an error according to the prettier/prettier rule, but hey. This fixes it. :see_no_evil:

For some context, when I ran `npx eslint --fix <file>` on the file with unwanted parens, it removed them. As did `npx prettier --write <file>`. So this is very confusing to me.

## Testing done
Tested the behavior locally.

## Screenshots
N/A

## Acceptance criteria
- [x] Auto-formatting on file save no longer adds unwanted parens