### PR TITLE
Errorable text area story

### DIFF
--- a/packages/formation-react/src/components/ErrorableTextArea/ErrorableTextArea.jsx
+++ b/packages/formation-react/src/components/ErrorableTextArea/ErrorableTextArea.jsx
@@ -98,6 +98,9 @@ class ErrorableTextArea extends React.Component {
 }
 
 ErrorableTextArea.propTypes = {
+  /**
+   * Whether or not the `<textarea>` is disabled
+   */
   disabled: PropTypes.bool,
 
   /**
@@ -111,7 +114,7 @@ ErrorableTextArea.propTypes = {
   label: PropTypes.string.isRequired,
 
   /**
-   * placeholder string for input field.
+   * Placeholder string for input field.
    */
   placeholder: PropTypes.string,
 
@@ -139,12 +142,12 @@ ErrorableTextArea.propTypes = {
   additionalClass: PropTypes.string,
 
   /**
-   * max number of characters the field will accept
+   * Max number of characters the field will accept
    */
   charMax: PropTypes.number,
 
   /**
-   * a function with this prototype: (newValue)
+   * A function with this prototype: (newValue)
    */
   onValueChange: PropTypes.func.isRequired,
 };

--- a/packages/formation-react/src/components/ErrorableTextArea/ErrorableTextArea.stories.jsx
+++ b/packages/formation-react/src/components/ErrorableTextArea/ErrorableTextArea.stories.jsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+
+import ErrorableTextArea from './ErrorableTextArea';
+
+export default {
+  title: 'Library/ErrorableTextArea',
+  component: ErrorableTextArea,
+};
+
+const Template = (args) => {
+  const [field, setField] = useState(args.field);
+  const onValueChange = (newField) => {
+    console.log('value changed:', newField);
+    setField(newField);
+  };
+
+  return (
+    <ErrorableTextArea {...args} field={field} onValueChange={onValueChange} />
+  );
+};
+
+const defaultArgs = {
+  label: 'Describe your situation',
+  name: 'description',
+  field: {
+    value: '',
+    dirty: false,
+  },
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  ...defaultArgs,
+};
+
+export const ErrorMessage = Template.bind({});
+ErrorMessage.args = {
+  ...defaultArgs,
+  errorMessage: 'There was a problem',
+};
+
+export const Required = Template.bind({});
+Required.args = {
+  ...defaultArgs,
+  required: true,
+};
+
+export const WithPlaceholder = Template.bind({});
+WithPlaceholder.args = {
+  ...defaultArgs,
+  placeholder: 'This is a placeholder',
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+  ...defaultArgs,
+  disabled: true,
+};
+
+export const MaxChars = Template.bind({});
+MaxChars.args = {
+  ...defaultArgs,
+  charMax: 16,
+  placeholder: 'No more than 16 characters',
+};


### PR DESCRIPTION
## Description

### Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/15416

Add some stories for `<ErrorableTextArea />`


## Testing done

Storybook :eyes: 


## Screenshots

![image](https://user-images.githubusercontent.com/2008881/98869135-2733de80-2426-11eb-90b0-9a2b8d89ebac.png)

![image](https://user-images.githubusercontent.com/2008881/98869170-37e45480-2426-11eb-9fe8-a3c6fcae6fd2.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
