### PR TITLE
Errorable text input story

### DIFF
--- a/packages/formation-react/src/components/ErrorableTextInput/ErrorableTextInput.jsx
+++ b/packages/formation-react/src/components/ErrorableTextInput/ErrorableTextInput.jsx
@@ -103,50 +103,50 @@ class ErrorableTextInput extends React.Component {
 
 ErrorableTextInput.propTypes = {
   /**
-   * display error message for input that indicates a validation error
+   * Display error message for input that indicates a validation error
    */
   errorMessage: PropTypes.string,
   /**
-   * label for input field
+   * Label for input field
    */
   label: PropTypes.any.isRequired,
   /**
-   * text displayed when input has no user provided value
+   * Text displayed when input has no user-provided value
    */
   placeholder: PropTypes.string,
   /**
-   * input name attribute
+   * `<input>` name attribute
    */
   name: PropTypes.string,
   /**
-   * input autocomplete attribute
+   * `<input>` autocomplete attribute
    */
   autocomplete: PropTypes.string,
   /**
-   * render marker indicating field is required
+   * Render marker indicating field is required
    */
   required: PropTypes.bool,
   /**
-   * value of the input field and if its dirty status
+   * Value of the input field and if its dirty status
    */
   field: PropTypes.shape({
     value: PropTypes.string,
     dirty: PropTypes.bool,
   }).isRequired,
   /**
-   * extra attribute for use by CSS selector, specifically by tests
+   * CSS class that gets applied to the `<input>` element
    */
   additionalClass: PropTypes.string,
   /**
-   * maximum permitted input length
+   * Maximum permitted input length
    */
   charMax: PropTypes.number,
   /**
-   * called when input value is changed
+   * Called when input value is changed
    */
   onValueChange: PropTypes.func.isRequired,
   /**
-   * type attribute for input field
+   * `<input>` type attribute
    */
   type: PropTypes.string,
 };

--- a/packages/formation-react/src/components/ErrorableTextInput/ErrorableTextInput.stories.jsx
+++ b/packages/formation-react/src/components/ErrorableTextInput/ErrorableTextInput.stories.jsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+
+import ErrorableTextInput from './ErrorableTextInput';
+
+export default {
+  title: 'Library/ErrorableTextInput',
+  component: ErrorableTextInput,
+};
+
+const Template = args => {
+  const [field, setField] = useState(args.field);
+  const onValueChange = newField => {
+    console.log('value changed:', newField);
+    setField(newField);
+  };
+
+  return (
+    <ErrorableTextInput {...args} field={field} onValueChange={onValueChange} />
+  );
+};
+
+const defaultArgs = {
+  label: 'First name',
+  name: 'first_name',
+  field: {
+    value: '',
+    dirty: false,
+  },
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  ...defaultArgs,
+};
+
+export const ErrorMessage = Template.bind({});
+ErrorMessage.args = {
+  ...defaultArgs,
+  errorMessage: 'There was a problem',
+};
+
+export const Required = Template.bind({});
+Required.args = {
+  ...defaultArgs,
+  required: true,
+};
+
+export const WithPlaceholder = Template.bind({});
+WithPlaceholder.args = {
+  ...defaultArgs,
+  placeholder: 'This is a placeholder',
+};
+
+export const MaxChars = Template.bind({});
+MaxChars.args = {
+  ...defaultArgs,
+  charMax: 16,
+  placeholder: 'No more than 16 characters',
+};
+
+export const Autocomplete = Template.bind({});
+Autocomplete.args = {
+  ...defaultArgs,
+  autocomplete: 'email',
+  label: 'Email',
+  name: 'email',
+  placeholder: 'This should autocomplete using email addresses',
+};


### PR DESCRIPTION
## Description

### Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/15417

Adds some stories for `<ErrorableTextInput />`


## Testing done

Storybook :eyes: 

## Screenshots

![image](https://user-images.githubusercontent.com/2008881/98871224-6b74ae00-2429-11eb-865f-0851d847b29f.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
