### PR TITLE
Remove currentSort prop from defaultArgs

### DIFF
--- a/packages/formation-react/src/components/Table/Table.stories.jsx
+++ b/packages/formation-react/src/components/Table/Table.stories.jsx
@@ -10,10 +10,6 @@ export default {
 const Template = args => <Table {...args} />;
 
 const defaultArgs = {
-  currentSort: {
-    value: 'column1',
-    order: 'ASC',
-  },
   data: [
     {
       title: 'Declaration of Independence',


### PR DESCRIPTION
## Description

Removes an unnecessary prop from the `<Table>` component's storybook template.

This is so the demo will be clearer.

---

The optional chaining here means that we don't need to pass `currentSort` in:

https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/50d298a11261d270559fcca7c7a1544de29de4e5/packages/formation-react/src/components/Table/Table.jsx#L28-L36


## Testing done

Storybook


## Screenshots

### Table rendered without `currentSort`

![image](https://user-images.githubusercontent.com/2008881/98974918-4c7a2880-24ca-11eb-88e6-2fc40880f066.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
