### PR TITLE
IconBase stories

### DIFF
--- a/packages/formation-react/src/components/IconBase/IconBase.stories.jsx
+++ b/packages/formation-react/src/components/IconBase/IconBase.stories.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import IconBase from './IconBase';
+
+export default {
+  title: 'Library/IconBase',
+  component: IconBase,
+};
+
+export const Description = () => (
+  <div>
+    <p>
+      <code>IconBase</code> is just an <code>{'<svg>'}</code> wrapper for its
+      children. All props are passed to the <code>{'<svg>'}</code> element.
+    </p>
+    <p>
+      For examples of how this is used, see the other <code>Icon</code> stories.
+    </p>
+  </div>
+);


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/15420

Like I state in the story, it doesn't actually _do_ anything. I'm strongly considering deleting it entirely since it's just a straight-up pass-through for `<svg>`.

## Testing done
Storybook :eyes:

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/98978167-67e73280-24ce-11eb-9628-bd30df0ece5c.png)
:man_shrugging: 