### PR TITLE
PromoBanner stories

### DIFF
--- a/packages/formation-react/src/components/PromoBanner/PromoBanner.jsx
+++ b/packages/formation-react/src/components/PromoBanner/PromoBanner.jsx
@@ -62,11 +62,34 @@ function PromoBanner({ type, onClose, render, href, target, text }) {
 }
 
 PromoBanner.propTypes = {
+  /**
+   * Controls which icon gets used
+   */
   type: PropTypes.oneOf(Object.values(PROMO_BANNER_TYPES)).isRequired,
+
+  /**
+   * Callback function meant to change parent state so that `<PromoBanner>` gets dismissed
+   */
   onClose: PropTypes.func.isRequired,
+
+  /**
+   * Function for rendering custom markup instead of the `<a>` with `text` in it
+   */
   render: PropTypes.func,
+
+  /**
+   * `href` attribute for the `<a>` tag. Only gets used if `render` is _not_ used
+   */
   href: PropTypes.string,
+
+  /**
+   * `target` attribute for the `<a>` tag. Only gets used if `render` is _not_ used
+   */
   target: PropTypes.string,
+
+  /**
+   * Content for the `<a>` tag. Only gets used if `render` is _not_ used
+   */
   text: PropTypes.string,
 };
 

--- a/packages/formation-react/src/components/PromoBanner/PromoBanner.stories.jsx
+++ b/packages/formation-react/src/components/PromoBanner/PromoBanner.stories.jsx
@@ -11,7 +11,10 @@ const Template = args => {
   const [showBanner, setShowBanner] = useState(true);
   const onClose = () => setShowBanner(false);
   return showBanner ? (
-    <PromoBanner {...args} onClose={onClose} />
+    <>
+      <PromoBanner {...args} onClose={onClose} />
+      <p>See the open banner on the bottom of the page.</p>
+    </>  
   ) : (
     <button onClick={() => setShowBanner(true)}>Show Banner</button>
   );

--- a/packages/formation-react/src/components/PromoBanner/PromoBanner.stories.jsx
+++ b/packages/formation-react/src/components/PromoBanner/PromoBanner.stories.jsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+
+import PromoBanner, { PROMO_BANNER_TYPES } from './PromoBanner';
+
+export default {
+  title: 'Library/PromoBanner',
+  component: PromoBanner,
+};
+
+const Template = args => {
+  const [showBanner, setShowBanner] = useState(true);
+  const onClose = () => setShowBanner(false);
+  return showBanner ? (
+    <PromoBanner {...args} onClose={onClose} />
+  ) : (
+    <button onClick={() => setShowBanner(true)}>Show Banner</button>
+  );
+};
+
+const defaultArgs = {
+  type: PROMO_BANNER_TYPES.announcement,
+  text: 'This is an announcement.',
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  ...defaultArgs,
+};
+
+export const News = Template.bind({});
+News.args = {
+  ...defaultArgs,
+  type: PROMO_BANNER_TYPES.news,
+  text: 'Here is a bit of news.',
+};
+
+export const EmailSignup = Template.bind({});
+EmailSignup.args = {
+  ...defaultArgs,
+  type: PROMO_BANNER_TYPES.emailSignup,
+  text: 'Please sign up using your email',
+};
+
+export const WithLink = Template.bind({});
+WithLink.args = {
+  ...defaultArgs,
+  text: "For more information, check out the VA's Design System website!",
+  href: 'https://design.va.gov',
+  target: '_blank',
+};
+
+export const CustomRender = Template.bind({});
+CustomRender.args = {
+  ...defaultArgs,
+  render: () => (
+    <>
+      <h4>This is a custom rendered version</h4>
+      <span>Some of the things you can do on VA.gov include</span>
+      <ul>
+        <li>Apply for disability benefits</li>
+        <li>Find a VA location</li>
+        <li>Compare your GI Bill benefits by school</li>
+      </ul>
+    </>
+  ),
+};


### PR DESCRIPTION
## Description


### Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/15433

Add some stories for `<PromoBanner>`.

Fun fact - the `<PromoBanner>` is styled so that it is fixed to the bottom of the page, so this creates some interesting results on the Storybook docs page.

**Note**: At the moment, this component isn't _actually_ used in `vets-website`.


## Testing done

Storybook :eyes: 


## Screenshots

### Dead component

![image](https://user-images.githubusercontent.com/2008881/99010864-b103aa80-24ff-11eb-9b3b-38d3932f4484.png)

### Opening/Dismissing the banner

![Peek 2020-11-12 16-00](https://user-images.githubusercontent.com/2008881/99011333-b7465680-2500-11eb-8a72-aa5754d690d0.gif)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
