### PR TITLE
Sortable table stories

### DIFF
--- a/packages/formation-react/src/components/SortableTable/SortableTable.jsx
+++ b/packages/formation-react/src/components/SortableTable/SortableTable.jsx
@@ -4,7 +4,9 @@ import classNames from 'classnames';
 
 class SortableTable extends Component {
   static propTypes = {
-    // Used to pass custom classes.
+    /**
+     * Used to pass custom classes.
+     */
     className: PropTypes.string,
 
     /**
@@ -16,11 +18,14 @@ class SortableTable extends Component {
       order: PropTypes.oneOf(['ASC', 'DESC']),
     }).isRequired,
 
-    // Mappings of header labels to properties on the objects in `data`.
+    /*
+     * Mappings of header labels to properties on the objects in `data`.
+     */
     fields: PropTypes.arrayOf(
       PropTypes.shape({
         label: PropTypes.string.isRequired,
         value: PropTypes.string.isRequired,
+        nonSortable: PropTypes.boolean,
       }),
     ).isRequired,
 
@@ -39,7 +44,9 @@ class SortableTable extends Component {
       }),
     ).isRequired,
 
-    // A callback for when a header is clicked.
+    /**
+     * A callback for when a header is clicked.
+     */
     onHeaderClick: PropTypes.func,
   };
 

--- a/packages/formation-react/src/components/SortableTable/SortableTable.stories.jsx
+++ b/packages/formation-react/src/components/SortableTable/SortableTable.stories.jsx
@@ -1,0 +1,124 @@
+import React from 'react';
+
+import SortableTable from './SortableTable';
+
+export default {
+  title: 'Library/SortableTable',
+  component: SortableTable,
+};
+
+const Template = args => <SortableTable {...args} />;
+
+const defaultArgs = {
+  currentSort: {
+    value: 'year',
+    order: 'ASC',
+  },
+  data: [
+    {
+      title: 'Declaration of Independence',
+      description:
+        'Statement adopted by the Continental Congress declaring independence from the British Empire',
+      year: '1776',
+    },
+    {
+      title: 'Bill of Rights',
+      description:
+        'The first ten ammendements of the U.S. Constitution guaranteeing rights and freedoms',
+      year: '1791',
+    },
+    {
+      title: 'Declaration of Sentiments',
+      description:
+        'A document written during the Seneca Falls Convention outlining the rights that American women should be entitled to as citizens.',
+      year: '1848',
+    },
+    {
+      title: 'Emancipation Proclamation',
+      description:
+        'An executive order granting freedom to slaves in designated southern states.',
+      year: '1863',
+    },
+  ],
+  fields: [
+    {
+      label: 'Document title',
+      value: 'title',
+    },
+    {
+      label: 'Description',
+      value: 'description',
+    },
+    {
+      label: 'Year',
+      value: 'year',
+    },
+  ],
+};
+
+/**
+ * Use this for informational purposes.
+ */
+export const Default = Template.bind({});
+Default.args = {
+  ...defaultArgs,
+};
+
+export const Unsortable = Template.bind({});
+Unsortable.args = {
+  ...defaultArgs,
+  fields: [
+    {
+      label: 'Document title',
+      value: 'title',
+      nonSortable: true,
+    },
+    defaultArgs.fields[1],
+    defaultArgs.fields[2],
+  ],
+};
+
+/**
+ * The first item in the first column is displayed as three dashes for a null value
+ */
+export const MissingData = Template.bind({});
+MissingData.args = {
+  ...defaultArgs,
+  data: [
+    {
+      title: 'A document',
+      description: null,
+      year: null,
+    },
+    defaultArgs.data[1],
+  ],
+};
+
+export const CustomComponents = Template.bind({});
+CustomComponents.args = {
+  ...defaultArgs,
+  data: [
+    ...defaultArgs.data,
+    {
+      title: 'Social Security Act',
+      description: (
+        <>
+          <div>
+            An act to provide for the general welfare by establishing a system
+            of Federal old-age benefits. Enables provisions for:
+          </div>
+
+          <ul>
+            <li>aged persons</li>
+            <li>blind persons</li>
+            <li>dependent and crippled children</li>
+            <li>maternal and child welfare</li>
+            <li>public health</li>
+            <li>unemployment compensation</li>
+          </ul>
+        </>
+      ),
+      year: '1935',
+    },
+  ],
+};


### PR DESCRIPTION
## Description

### Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/15436

Adds some stories for `<SortableTable>`, basically copied from the `<Table>` stories.

This component shouldn't exist, and it is only used once in `vets-website` where it is configured so that it doesn't sort. Replacing that use with `<Table>` would be good, but might not be a high priority.

## Testing done

Storybook :eyes: 


## Screenshots

### Desktop

![image](https://user-images.githubusercontent.com/2008881/99122931-10bb8d80-25b4-11eb-99b7-81239e631cd1.png)


### Mobile

![image](https://user-images.githubusercontent.com/2008881/99122964-1fa24000-25b4-11eb-8f64-26a4346270e1.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
