### PR TITLE
Add placeholder CircleCI config file (.circleci/config.yml)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+# Use a package of configuration called an orb.
+orbs:
+  # Declare a dependency on the welcome-orb
+  welcome: circleci/welcome-orb@0.4.1
+# Orchestrate or schedule a set of jobs
+workflows:
+  # Name the workflow "welcome"
+  welcome:
+    # Run the welcome/run job in its own container
+    jobs:
+      - welcome/run


### PR DESCRIPTION
## Description

There was a [recent CircleCI failure](https://app.circleci.com/pipelines/github/department-of-veterans-affairs/veteran-facing-services-tools/13/workflows/698b1bf5-0674-4824-972f-6cb6c7ce83be/jobs/16) for a PR that only changed documentation. Documentation PRs should not fail. Adding a placeholder CircleCI config file should prevent CircleCI from failing. 

## Relevant links

- CircleCI config docs: https://circleci.com/docs/2.0/configuration-reference/
- Similar PR in `devops` repo: https://github.com/department-of-veterans-affairs/devops/pull/7140/

## Testing done

Installed CircleCI CLI, and then ran `circleci config validate` 

## Acceptance criteria
- [x] CircleCI check passes