### PR TITLE
Check branch before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lint:js:changed": "npx vagov-eslint lint:js:changed",
     "lint:js:changed:fix": "npx vagov-eslint lint:js:changed:fix",
     "postinstall": "yarn bootstrap && node ./scripts/check-node-version.js",
+    "prepublish": "node ./scripts/prepublish.js",
     "publish": "lerna publish",
     "version": "lerna version --no-git-tag-version",
     "test-debug": "lerna run test-debug --scope=@department-of-veterans-affairs/formation-react",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "resolve-url-loader": "^2.2.0",
     "sass-loader": "^6.0.7",
     "semver": "^7.3.2",
+    "simple-git": "^2.23.0",
     "sinon": "^4.1.6",
     "style-loader": "^0.19.0",
     "svg-url-loader": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint:js:changed": "npx vagov-eslint lint:js:changed",
     "lint:js:changed:fix": "npx vagov-eslint lint:js:changed:fix",
     "postinstall": "yarn bootstrap && node ./scripts/check-node-version.js",
-    "prepublish": "node ./scripts/prepublish.js",
+    "prepublishOnly": "node ./scripts/prepublish.js",
     "publish": "lerna publish",
     "version": "lerna version --no-git-tag-version",
     "test-debug": "lerna run test-debug --scope=@department-of-veterans-affairs/formation-react",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "resolve-url-loader": "^2.2.0",
     "sass-loader": "^6.0.7",
     "semver": "^7.3.2",
-    "simple-git": "^2.23.0",
     "sinon": "^4.1.6",
     "style-loader": "^0.19.0",
     "svg-url-loader": "^2.3.0",

--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "build": "node ./scripts/build.js",
+    "prepublishOnly": "node ../../scripts/prepublish.js",
     "release": "PACKAGE=formation-react VERSION=$npm_package_version node ../../scripts/release.js",
     "test-watch": "karma start testing/karma.conf.js --auto-watch",
     "test": "karma start testing/karma.conf.js --single-run",

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "build": "node ./scripts/build.js",
     "prepare": "node ./scripts/build.js",
+    "prepublishOnly": "node ../../scripts/prepublish.js",
     "release": "PACKAGE=formation VERSION=$npm_package_version node ../../scripts/release.js",
     "test": "jest"
   },

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -1,0 +1,21 @@
+/**
+ * Ensure that we're publishing from the master branch.
+ */
+
+const simpleGit = require('simple-git');
+const chalk = require('chalk');
+
+const git = simpleGit();
+
+(async () => {
+  await git.init();
+  const branchName = (await git.branch()).current;
+
+  if (branchName !== 'master') {
+    // eslint-disable-next-line no-console
+    console.log(
+      chalk.yellow('Please check out the master branch before publishing.\n'),
+    );
+    process.exit(1);
+  }
+})();

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /**
  * Ensure that we're publishing from the master branch.
  */
@@ -5,14 +6,16 @@
 const { execSync } = require('child_process');
 const chalk = require('chalk');
 
-(async () => {
-  const branchName = execSync('git branch --show-current');
+const branchName = execSync('git branch --show-current');
 
-  if (branchName !== 'master') {
-    // eslint-disable-next-line no-console
-    console.log(
-      chalk.yellow('Please check out the master branch before publishing.\n'),
-    );
-    process.exit(1);
-  }
-})();
+if (branchName !== 'master') {
+  console.log(``);
+  console.log(
+    chalk.yellow(
+      `You're currently on branch ${chalk.cyan(
+        branchName,
+      )}Please check out ${chalk.cyan('master')} before publishing.\n`,
+    ),
+  );
+  process.exit(1);
+}

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -2,14 +2,11 @@
  * Ensure that we're publishing from the master branch.
  */
 
-const simpleGit = require('simple-git');
+const { execSync } = require('child_process');
 const chalk = require('chalk');
 
-const git = simpleGit();
-
 (async () => {
-  await git.init();
-  const branchName = (await git.branch()).current;
+  const branchName = execSync('git branch --show-current');
 
   if (branchName !== 'master') {
     // eslint-disable-next-line no-console

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -9,7 +9,6 @@ const chalk = require('chalk');
 const branchName = execSync('git branch --show-current');
 
 if (branchName !== 'master') {
-  console.log(``);
   console.log(
     chalk.yellow(
       `You're currently on branch ${chalk.cyan(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1157,18 +1157,6 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/yargs" "^12.0.9"
 
-"@kwsites/file-exists@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@kwsites/file-exists/-/file-exists-1.1.1.tgz#ad1efcac13e1987d8dbaf235ef3be5b0d96faa99"
-  integrity sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==
-  dependencies:
-    debug "^4.1.1"
-
-"@kwsites/promise-deferred@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz#8ace5259254426ccef57f3175bc64ed7095ed919"
-  integrity sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==
-
 "@lerna/add@3.13.1":
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.13.1.tgz#2cd7838857edb3b43ed73e3c21f69a20beb9b702"
@@ -4486,13 +4474,6 @@ debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
-
-debug@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
-  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
-  dependencies:
-    ms "2.1.2"
 
 debuglog@^1.0.1:
   version "1.0.1"
@@ -8916,15 +8897,15 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-ms@2.1.2, ms@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
-  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
-
 ms@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
+
+ms@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
 multimatch@^2.1.0:
   version "2.1.0"
@@ -11606,15 +11587,6 @@ simple-concat@^1.0.0:
   resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.0.tgz#7344cbb8b6e26fb27d66b2fc86f9f6d5997521c6"
   integrity sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=
 
-simple-git@^2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-2.23.0.tgz#b15844956da63575ae81a9339e4eab29e8141182"
-  integrity sha512-s/gEkxFV2WGTN4kO1uQoA4cE4rq0FRzQPR5Yhgg8JUuA4IhOeccjlKSFhwF3rrpo7797ZvQc7L6hJJNA4szHCw==
-  dependencies:
-    "@kwsites/file-exists" "^1.1.1"
-    "@kwsites/promise-deferred" "^1.1.1"
-    debug "^4.3.1"
-
 sinon@^4.1.6:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/sinon/-/sinon-4.5.0.tgz#427ae312a337d3c516804ce2754e8c0d5028cb04"
@@ -12794,7 +12766,7 @@ uuid@^3.0.1, uuid@^3.3.2:
     eslint-plugin-react "^7.12.4"
     eslint-plugin-react-hooks "^1.6.0"
     eslint-plugin-scanjs-rules "^0.2.1"
-    eslint-plugin-va-enzyme "file:../../.cache/yarn/v6/npm-vagov-eslint-1.0.0-a3b476d4-6bf5-4300-ad47-3ae484393754-1605903249535/node_modules/vagov-eslint/custom-eslint/va-enzyme"
+    eslint-plugin-va-enzyme "file:../../.cache/yarn/v6/npm-vagov-eslint-1.0.0-5f5bc1a7-a57a-4b1c-88fe-0d292ddb9599-1605916864124/node_modules/vagov-eslint/custom-eslint/va-enzyme"
     prettier "^1.16.4"
     shelljs "0.8.4"
     window-or-global "^1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1157,6 +1157,18 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/yargs" "^12.0.9"
 
+"@kwsites/file-exists@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@kwsites/file-exists/-/file-exists-1.1.1.tgz#ad1efcac13e1987d8dbaf235ef3be5b0d96faa99"
+  integrity sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==
+  dependencies:
+    debug "^4.1.1"
+
+"@kwsites/promise-deferred@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz#8ace5259254426ccef57f3175bc64ed7095ed919"
+  integrity sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==
+
 "@lerna/add@3.13.1":
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.13.1.tgz#2cd7838857edb3b43ed73e3c21f69a20beb9b702"
@@ -4474,6 +4486,13 @@ debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
 
 debuglog@^1.0.1:
   version "1.0.1"
@@ -8897,15 +8916,15 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
+ms@2.1.2, ms@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
 ms@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
-
-ms@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
-  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
 multimatch@^2.1.0:
   version "2.1.0"
@@ -11587,6 +11606,15 @@ simple-concat@^1.0.0:
   resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.0.tgz#7344cbb8b6e26fb27d66b2fc86f9f6d5997521c6"
   integrity sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=
 
+simple-git@^2.23.0:
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-2.23.0.tgz#b15844956da63575ae81a9339e4eab29e8141182"
+  integrity sha512-s/gEkxFV2WGTN4kO1uQoA4cE4rq0FRzQPR5Yhgg8JUuA4IhOeccjlKSFhwF3rrpo7797ZvQc7L6hJJNA4szHCw==
+  dependencies:
+    "@kwsites/file-exists" "^1.1.1"
+    "@kwsites/promise-deferred" "^1.1.1"
+    debug "^4.3.1"
+
 sinon@^4.1.6:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/sinon/-/sinon-4.5.0.tgz#427ae312a337d3c516804ce2754e8c0d5028cb04"
@@ -12766,7 +12794,7 @@ uuid@^3.0.1, uuid@^3.3.2:
     eslint-plugin-react "^7.12.4"
     eslint-plugin-react-hooks "^1.6.0"
     eslint-plugin-scanjs-rules "^0.2.1"
-    eslint-plugin-va-enzyme "file:../../../Library/Caches/Yarn/v6/npm-vagov-eslint-1.0.0-061a18ab-1526-4bde-b21c-31e780e66128-1604523896069/node_modules/vagov-eslint/custom-eslint/va-enzyme"
+    eslint-plugin-va-enzyme "file:../../.cache/yarn/v6/npm-vagov-eslint-1.0.0-a3b476d4-6bf5-4300-ad47-3ae484393754-1605903249535/node_modules/vagov-eslint/custom-eslint/va-enzyme"
     prettier "^1.16.4"
     shelljs "0.8.4"
     window-or-global "^1.0.1"


### PR DESCRIPTION
## Description
Like it says on the tin, this PR adds a `prepublishOnly` script to check if the branch is `master` to prevent publishing from non-master branches (which has happened a few times now).

## Testing done
See screenshots.

## Screenshots
Test that the prepublish script exits with a status code 1 for non-master branches, but status code 0 on `master`.
![image](https://user-images.githubusercontent.com/12970166/99859183-2d237100-2b44-11eb-85e8-152a5c13cdb4.png)
**Note:** I updated the script name to `prepublish.js` after taking this screenshot.

Test that the `prepublishOnly` hook disallows publishing when not on `master`.
![image](https://user-images.githubusercontent.com/12970166/99859251-622fc380-2b44-11eb-95b9-27497918b3e7.png)


## Acceptance criteria
- [x] Attempting to publish from `master` is successful
- [x] Attempting to publish from a branch other than `master` fails with a warning message