### PR TITLE
Update Veteran Facing E2E page for Cypress

### DIFF
--- a/packages/documentation/src/pages/getting-started/common-tasks/new-end-to-end-test.mdx
+++ b/packages/documentation/src/pages/getting-started/common-tasks/new-end-to-end-test.mdx
@@ -69,15 +69,15 @@ Below are some of the commonly used Cypress mocks (accessible from the link abov
 
 Cypress supports extending its client api with [custom commands](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/cypress/support/commands).
 
-Below are some of the commonly used custom Cypress commands (accessible from the link above).
+Below are some of the commonly used custom Cypress commands.
 
-- axeCheck
-- expandAccordions
-- injectAxeThenAxeCheck
-- login
-- syncFixtures
-- upload
-- viewportPreset
+- [axeCheck](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/cypress/support/commands/axeCheck.js) - Callback from a11y check that logs aXe violations to console output.
+- [expandAccordions](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/cypress/support/commands/expandAccordions.js) - Expands all accordions and AdditionalInfo components.
+- [injectAxeThenAxeCheck](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/cypress/support/commands/hasCount.js) - Combines two common, sequentially called functions.
+- [login](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/cypress/support/commands/login.js) - Simulates a logged in session.
+- [syncFixtures](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/cypress/support/commands/syncFixtures.js) - Runs task to sync fixtures under a temp path in the Cypress fixtures folder then overwrites `cy.fixture` and the fixture shorthand in `cy.route` to look for fixtures under that temp path.
+- [upload](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/cypress/support/commands/upload.js) - Workaround to support file upload functionality in tests, which is currently not officially implemented.
+- [viewportPreset](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/cypress/support/commands/viewportPreset.js) - Sets the viewport by preset name.
 
 ## Helpers
 

--- a/packages/documentation/src/pages/getting-started/common-tasks/new-end-to-end-test.mdx
+++ b/packages/documentation/src/pages/getting-started/common-tasks/new-end-to-end-test.mdx
@@ -1,18 +1,19 @@
 ---
 title: Writing an end-to-end test
-tags: Nightwatch, mockapi, e2e, axe
+tags: Cypress, Nightwatch, mockapi, e2e, axe
 ---
 
 # Writing an end-to-end test
 
 Front end engineers use end-to-end (e2e) tests in `vets-website` to validate multipage applications with client-side routing. They are primarily used to assert that:
+
 - client applications render their inputs
 - client-side navigation occurs when the required fields are populated
 
 ## End-to-end testing overview
 
-- `vets-website` uses [Nightwatch](https://nightwatchjs.org) to run some of the older end-to-end tests
-  - New end-to-end tests should be written in Cypress going forward.
+- `vets-website` uses [Cypress](https://www.cypress.io/) to write end-to-end tests. See [Cypress Best Practices on VSP](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/testing/end-to-end/cypress-best-practices-on-vsp.md) and [Cypress Resources Reference Guide](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/testing/end-to-end/vsp-cypress-resources.md) for detailed use cases and documented helpers/mocks.
+  - Some older end-to-end tests were written in [Nightwatch](https://nightwatchjs.org) prior to Cypress. All new tests should be written using Cypress moving forward and Nightwatch tests are in the process of being deprecated/migrated to Cypress.
   - Refer to the [Cypress migration guide](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/testing/end-to-end/cypress-migration-guide.md) to convert old tests or write new tests.
 - end-to-end tests are **collocated in application folder** with the application they test
 - Two node apps run with the end-to-end tests:
@@ -23,124 +24,50 @@ Front end engineers use end-to-end (e2e) tests in `vets-website` to validate mul
 
 ## End-to-end tests conventions
 
-**00-main-test-file.e2e.spec.js**
-```
-const E2eHelpers = require('platform/testing/e2e/helpers')
-const Timeouts = require('platform/testing/e2e/timeouts.js');
-const MyApplicationHelpers = require('./my-application-helpers.js');
-const testData = require('./schema/maximal-test.json');
-const FormsTestHelpers = require('platform/testing/e2e/form-helpers');
+- Use a comment to indicate what page is being tested
+- Disable scrolling
+- Assert navigation is successful
+- Use functions from the helper file to perform all actions on the page
 
-// export the test using E2eHelpers.createE2eTest
-module.exports = E2eHelpers.createE2eTest(client => {
-  // mock api responses
-  client.mockData({
-  // path to mock
-    path: '/v0/my-application',
-  // verb to mock
-    verb: 'post',
-  // mock response
-    value: {
-      formSubmissionId: '123fake-submission-id-567',
-      timestamp: '2016-05-16',
-    },
-  });
-
-  // use a comment to indicate what page is being tested
-  // Introduction page
-  client
-    .openUrl(`${E2eHelpers.baseUrl}/my-application`)
-    // use Timeouts constants
-    .waitForElementVisible('body', Timeouts.normal)
-    .assert.title('My Application Title | Veterans Affairs')
-    .click('.schemaform-start-button');
-
-  // disable scrolling
-  FormsTestHelpers.overrideFormsScrolling(client);
-
-  // assert navigation is successful
-  E2eHelpers.expectNavigateAwayFrom(client, '/introduction');
-
-  // Personal Information page.
-  client.expect.element('input[name="root_veteranFullName_first"]').to.be
-    .visible;
-  // use functions from the helper file to perform all actions on the page
-  MyApplicationHelpers.completePersonalInformation(client, testData.data);
-  client.axeCheck('.main').click('.form-panel .usa-button-primary');
-  E2eHelpers.expectNavigateAwayFrom(
-    client,
-    '/my-application/personal-information',
-  );
-  ```
-
-**my-application-helpers.js**
-```
-const mock = require('platform/testing/e2e/mock-helpers');
-const Timeouts = require('platform/testing/e2e/timeouts.js');
-const Auth = require('platform/testing/e2e/auth.js');
-const moment = require('moment');
-
-function completePersonalInformation(client, data) {
-  client
-    .waitForElementVisible(
-      'input[name="root_veteranFullName_first"]',
-      Timeouts.normal,
-    )
-    .fill(
-      'input[name="root_veteranFullName_first"]',
-      data.veteranFullName.first,
-    )
-    .fill('input[name="root_veteranFullName_last"]', data.veteranFullName.last)
-}
-```
 _These are recommendations not requirements._
 
-- separate navigation from field input
-  - use a **main test file** for navigation, assertions, and calls helpers
-  - use a **helper file** for filling out forms
-- create separate, numbered **main test files** to organize tests by their focus:
-  - **00-all-fields.e2e.spec.js** - required and optional fields
-  - **01-required.e2e.spec.js** - only required fields
-  - **02-accessibility.e2e.spec.js** - validates accessibility
-  - **03-auth.e2e.spec.js** - validates authentication
-  - **04-cross-cutting-feature.e2e.spec.js** - validates one feature used across several pages (e.g. save in progress)
-- export the end-to-end test using `E2eHelpers.createE2eTest()`- see [Helpers](#helpers)
-- group tests by pages and use a comment to indicate what page is being tested
-- mock all api responses before starting the test. See [Mocking API responses](#mocking-api-responses)
-- use `waitForElementVisible` before interacting with any element on the page
-- use `Timeouts` constants for setting timeouts (`platform/testing/e2e/timeouts.js`)
-- use helpers for filling data and performing actions on the page
-- perform `axeCheck` on the main body of the application on each page - see [Custom Nightwatch commands](#custom-nightwatch-commands)
-- assert that each navigation is successful
+- Separate navigation from field input
+  - Use a **main test file** for navigation, assertions, and calls helpers
+  - Use a **helper file** for filling out forms
+- Create separate, numbered **main test files** to organize tests by their focus:
+  - **00-all-fields.cypress.spec.js** - required and optional fields
+  - **01-required.cypress.spec.js** - only required fields
+  - **02-accessibility.cypress.spec.js** - validates accessibility
+  - **03-auth.cypress.spec.js** - validates authentication
+  - **04-cross-cutting-feature.cypress.spec.js** - validates one feature used across several pages (e.g. save in progress)
+- Group tests by pages and use a comment to indicate what page is being tested
+- Mock all api responses before starting the test. See [Mock API responses](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/testing/end-to-end#mocks)
+- Use `waitForElementVisible` before interacting with any element on the page
+- Use `Timeouts` constants for setting timeouts (`platform/testing/e2e/timeouts.js`)
+- Use helpers for filling data and performing actions on the page
+- Perform `axeCheck` on the main body of the application on each page - see [axeCheck](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/cypress/support/commands/axeCheck.js)
+- Assert that each navigation is successful
 
 ## Mocking API responses
 
 A mock server runs with the end-to-end tests to allow tests to make production-like calls.
 
-- [`mockData(data, token = nul)`](https://github.com/department-of-veterans-affairs/vets-website/blob/6d97a63bd60d79864661cc757814ca041648d5c9/src/platform/testing/e2e/nightwatch-commands/mockData.js#L12-L14)
-  - custom Nighwatch command that mocks the data at the endpoint provided
-  - mock server is started as part of the end-to-end testing script
+See the [Mocks section of Cypress Resources Reference Guide](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/testing/end-to-end#mocks) for detailed mock API examples currently used.
 
-## Custom Nightwatch commands
+## Custom Cypress commands
 
-Nightwatch supports extending its client api with [custom commands](https://nightwatchjs.org/guide/#writing-custom-commands). Custom commands are located in `src/platform/testing/e2e/nightwatch-commands`
+Cypress supports extending its client api with [custom commands](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/cypress/support/commands).
 
-_Command commands are available on the Nightwatch client e.g. `client.axeCheck()`. Below are some of the commonly used custom Nightwatch commands._
+Below are some of the commonly used custom Nightwatch commands (accessible from the link above).\_
 
-- [`axeCheck(selector)`](https://github.com/department-of-veterans-affairs/vets-website/blob/d721cf0581c6b7d6f26903540dfc27f26a16a7be/src/platform/testing/e2e/nightwatch-commands/axeCheck.js#L4-L7) - uses the [`axe-core`](https://github.com/dequelabs/axe-core/blob/master/doc/developer-guide.md) library to run a series of tests to check for accessibility of content and functionality for DOM nodes in the selector
-- [`clickIf(selector, predicate, ...predicateArguments)`](https://github.com/department-of-veterans-affairs/vets-website/blob/d721cf0581c6b7d6f26903540dfc27f26a16a7be/src/platform/testing/e2e/nightwatch-commands/clickIf.js#L4-L7) - clicks the input at the selector when the predicate returns true
-- [`fill(selector, value, callback)`](https://github.com/department-of-veterans-affairs/vets-website/blob/d721cf0581c6b7d6f26903540dfc27f26a16a7be/src/platform/testing/e2e/nightwatch-commands/fill.js#L5-L6) - clears the current value and sets to the value provided
-- [`fillAddress(baseName, address}`)](https://github.com/department-of-veterans-affairs/vets-website/blob/d721cf0581c6b7d6f26903540dfc27f26a16a7be/src/platform/testing/e2e/nightwatch-commands/fillAddress.js#L2-L5) - fills an address widget with the value provided
-- [`fillCheckbox(selector, predicate, ...predicateParams`)](https://github.com/department-of-veterans-affairs/vets-website/blob/343d77e2d7509cdcecee4b41c723d01ca0147881/src/platform/testing/e2e/nightwatch-commands/fillCheckbox.js#L4-L7) - clicks the checkbox at the selector when the predicate returns true
-- [`fillDate(fieldName, dateString}`)](https://github.com/department-of-veterans-affairs/vets-website/blob/d721cf0581c6b7d6f26903540dfc27f26a16a7be/src/platform/testing/e2e/nightwatch-commands/fillDate.js#L4-L6) - fills a date widget at the fieldName with the dateString provided e.g. 1990-1-28
-- [`openUrl(url, disableForesee = true)`](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/nightwatch-commands/openUrl.js) - navigates to url and disables user feedback module (this can interfere with end-to-end tests)
-- [`selectRadio(fieldName, value)`](https://github.com/department-of-veterans-affairs/vets-website/blob/d721cf0581c6b7d6f26903540dfc27f26a16a7be/src/platform/testing/e2e/nightwatch-commands/selectRadio.js#L2-L6) - selects the provided option on yesNo widget at the field name
-- [`selectYesNo(fieldName, predicate)`](https://github.com/department-of-veterans-affairs/vets-website/blob/d721cf0581c6b7d6f26903540dfc27f26a16a7be/src/platform/testing/e2e/nightwatch-commands/selectYesNo.js#L2-L6) - selects the provided options on yesNo widget at the field name when the predicate returns true
+- axeCheck
+- expandAccordions
+- injectAxeThenAxeCheck
+- login
+- syncFixtures
+- upload
+- viewportPreset
 
 ## Helpers
 
-`src/platform/testing/e2e` contains other useful helpers
-
-- [`createE2eTest(beginApplication)`](https://github.com/department-of-veterans-affairs/vets-website/blob/d721cf0581c6b7d6f26903540dfc27f26a16a7be/src/platform/testing/e2e/helpers.js#L78-L81) - disables smooth scrolling and starts and ends test
-- [`overrideSmoothFormsScrolling(client)` and `overrideFormsScrolling(client)`](https://github.com/department-of-veterans-affairs/vets-website/blob/d721cf0581c6b7d6f26903540dfc27f26a16a7be/src/platform/testing/e2e/nightwatch-commands/selectYesNo.js#L2-L6) - disables smooth scrolling during end-to-end testing
-- [`expectNavigationAwayFrom(client, urlString)`](https://github.com/department-of-veterans-affairs/vets-website/blob/d721cf0581c6b7d6f26903540dfc27f26a16a7be/src/platform/testing/e2e/helpers.js#L94) - asserts the current page is not at the `urlString`
+The [Cypress Resources Reference Guide](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/testing/end-to-end) contains a list of currently utilized Cypress & VAOS Helpers adn Appointment Helpers.

--- a/packages/documentation/src/pages/getting-started/common-tasks/new-end-to-end-test.mdx
+++ b/packages/documentation/src/pages/getting-started/common-tasks/new-end-to-end-test.mdx
@@ -48,13 +48,28 @@ _These are recommendations not requirements._
 
 A mock server runs with the end-to-end tests to allow tests to make production-like calls.
 
-See the [Mocks section of Cypress Resources Reference Guide](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/testing/end-to-end#mocks) for detailed mock API examples currently used.
+See the [Mocks section of Cypress Resources Reference Guide](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/testing/end-to-end/vsp-cypress-resources.md#mocks) for detailed mock API examples currently used.
+
+Below are some of the commonly used Cypress mocks (accessible from the link above).
+
+- confirmedVA
+- confirmedCC
+- requests
+- cancelReasons
+- supportedSites
+- facilities
+- facilities983
+- clinicList983
+- slots
+- getVAAppointmentMock
+- getExpressCareRequestCriteriaMock
+- getParentSiteMock
 
 ## Custom Cypress commands
 
 Cypress supports extending its client api with [custom commands](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/cypress/support/commands).
 
-Below are some of the commonly used custom Nightwatch commands (accessible from the link above).\_
+Below are some of the commonly used custom Cypress commands (accessible from the link above).
 
 - axeCheck
 - expandAccordions

--- a/packages/documentation/src/pages/getting-started/common-tasks/new-end-to-end-test.mdx
+++ b/packages/documentation/src/pages/getting-started/common-tasks/new-end-to-end-test.mdx
@@ -15,12 +15,8 @@ Front end engineers use end-to-end (e2e) tests in `vets-website` to validate mul
 - `vets-website` uses [Cypress](https://www.cypress.io/) to write end-to-end tests. See [Cypress Best Practices on VSP](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/testing/end-to-end/cypress-best-practices-on-vsp.md) and [Cypress Resources Reference Guide](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/testing/end-to-end/vsp-cypress-resources.md) for detailed use cases and documented helpers/mocks.
   - Some older end-to-end tests were written in [Nightwatch](https://nightwatchjs.org) prior to Cypress. All new tests should be written using Cypress moving forward and Nightwatch tests are in the process of being deprecated/migrated to Cypress.
   - Refer to the [Cypress migration guide](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/testing/end-to-end/cypress-migration-guide.md) to convert old tests or write new tests.
-- end-to-end tests are **collocated in application folder** with the application they test
-- Two node apps run with the end-to-end tests:
-  - `mockapi.js` - hosts mock responses (see [Mocking API responses](#mocking-api-responses))
-  - `test-server.js` - builds a server that handles client side routes
-- `vets-website` must be started before end-to-end tests are run
-- `vets-api` should not be running when end-to-end tests are run
+- End-to-end tests are **collocated in application folder** with the application they test
+- Cypress tests can be run using the command `yarn cy:run` (after `yarn watch` to `yarn build`).
 
 ## End-to-end tests conventions
 


### PR DESCRIPTION
## Description
Resolves https://app.zenhub.com/workspaces/vsp-5cedc9cce6e3335dc5a49fc4/issues/department-of-veterans-affairs/va.gov-team/16476

Feature updates E2E testing documentation to point to single source of truth for Cypress test documentation and deprecates prior Nightwatch testing instructions.

## Acceptance criteria
- [x]  Determine where the documentation should live and consolidate it. (Perhaps it should live on the va.gov-team repo and be referenced from the department-of-veterans-affairs.github.io website.)
- [x] Update or delete the Writing an end-to-end test documentation -- https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/getting-started/common-tasks/new-end-to-end-test/ -- which currently documents how to write tests using Selenium and Nightwatch.
- [x] Update the End-to-end testing (Frontend) landing page to reference the new documentation.

## Definition of done
- [x ] Changes have been tested in vets-website
- [x ] Changes have been tested in IE11, if applicable
- [x ] Documentation has been updated, if applicable
- [x ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
