### PR TITLE
Fix the storybook build in Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,9 +101,9 @@ workflows:
   publish-dev:
     jobs:
       - needs-to-publish-storybook:
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
           doc_site: dev-design.va.gov
       - publish-storybook:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,6 @@ jobs:
     steps:
       - checkout
       - aws-cli/setup
-      - run: yarn install
       - run:
           working_directory: ./packages/formation-react
           command: yarn install
@@ -110,8 +109,8 @@ workflows:
           #     only: master
           doc_site: dev-design.va.gov
       - publish-storybook:
-          requires:
-            - needs-to-publish-storybook
+          # requires:
+          #   - needs-to-publish-storybook
           bucket: dev-design.va.gov
           context:
             - Platform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,9 @@ jobs:
       - aws-cli/setup
       - run: yarn install
       - run:
+          working_directory: ./packages/formation-react
+          command: yarn install
+      - run:
           name: "Build Storybook"
           command: cd packages/formation-react && yarn build-storybook
       - write-build-info:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,7 @@ jobs:
     steps:
       - checkout
       - aws-cli/setup
+      - run: yarn install
       - run:
           working_directory: ./packages/formation-react
           command: yarn install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,13 +105,13 @@ workflows:
   publish-dev:
     jobs:
       - needs-to-publish-storybook:
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
           doc_site: dev-design.va.gov
       - publish-storybook:
-          # requires:
-          #   - needs-to-publish-storybook
+          requires:
+            - needs-to-publish-storybook
           bucket: dev-design.va.gov
           context:
             - Platform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,8 @@ jobs:
           command: yarn install
       - run:
           name: "Build Storybook"
-          command: cd packages/formation-react && yarn build-storybook
+          working_directory: ./packages/formation-react
+          command: yarn build-storybook
       - write-build-info:
           dest: "packages/formation-react/storybook-static"
       - copy-to-s3:

--- a/packages/formation-react/.storybook/preview.js
+++ b/packages/formation-react/.storybook/preview.js
@@ -1,5 +1,5 @@
 import '@department-of-veterans-affairs/formation/dist/formation.min.css';
-import '@department-of-veterans-affairs/formation/dist/formation';
+import '@department-of-veterans-affairs/formation/dist/formation.js';
 import { withHTML } from '@whitespace/storybook-addon-html/react';
 
 export const parameters = {

--- a/packages/formation-react/.storybook/preview.js
+++ b/packages/formation-react/.storybook/preview.js
@@ -1,5 +1,5 @@
 import '@department-of-veterans-affairs/formation/dist/formation.min.css';
-import '@department-of-veterans-affairs/formation/dist/formation.js';
+import '@department-of-veterans-affairs/formation/dist/formation';
 import { withHTML } from '@whitespace/storybook-addon-html/react';
 
 export const parameters = {


### PR DESCRIPTION
## Description

We noticed that after #546 was merged, CircleCI was failing to build storybook due to some issues with trying to load things from `formation`.

https://app.circleci.com/pipelines/github/department-of-veterans-affairs/veteran-facing-services-tools/94/workflows/08264a3e-e36d-4e48-9246-150c739f4e82/jobs/132

The problem was that we have a repo-level `package.json` with some of the dependencies, and then in `packages/formation-react` we have another `package.json` with some more dependencies. These weren't being installed, which means storybook didn't have access to formation.

https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/93827b0c15be749c7180525759a06d44df447820/packages/formation-react/package.json#L45

This PR makes sure that the `formation-react` dependencies are installed.
## Testing done

CircleCI & local builds

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
