### PR TITLE
Updated OMB to be more dynamic. 

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "5.9.0",
+  "version": "5.10.0",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/OMBInfo/OMBInfo.jsx
+++ b/packages/formation-react/src/components/OMBInfo/OMBInfo.jsx
@@ -109,23 +109,17 @@ class OMBInfo extends React.Component {
 
 OMBInfo.propTypes = {
   /**
-   * Respondent burden. How many minutes the form is expected to take. If this
-   * omitted, it will not show in the rendered component. Be sure to get
-   * approval from the design council before leaving it out.
+   * Respondent burden. How many minutes the form is expected to take.
    */
   resBurden: PropTypes.number,
 
   /**
-   * OMB control number / form number. If this
-   * omitted, it will not show in the rendered component. Be sure to get
-   * approval from the design council before leaving it out.
+   * OMB control number / form number
    */
   ombNumber: PropTypes.string,
 
   /**
-   * Form expiration date. If this
-   * omitted, it will not show in the rendered component. Be sure to get
-   * approval from the design council before leaving it out.
+   * Form expiration date.
    */
   expDate: PropTypes.string.isRequired,
 };

--- a/packages/formation-react/src/components/OMBInfo/OMBInfo.jsx
+++ b/packages/formation-react/src/components/OMBInfo/OMBInfo.jsx
@@ -74,12 +74,16 @@ class OMBInfo extends React.Component {
             Respondent burden: <strong>{resBurden} minutes</strong>
           </div>
         )}
-        <div>
-          OMB Control #: <strong>{ombNumber}</strong>
-        </div>
-        <div>
-          Expiration date: <strong>{expDate}</strong>
-        </div>
+        {ombNumber && (
+          <div>
+            OMB Control #: <strong>{ombNumber}</strong>
+          </div>
+        )}
+        {expDate && (
+          <div>
+            Expiration date: <strong>{expDate}</strong>
+          </div>
+        )}
         <div>
           <button className="va-button-link" onClick={this.openModal}>
             Privacy Act Statement
@@ -108,14 +112,18 @@ OMBInfo.propTypes = {
   resBurden: PropTypes.number,
 
   /**
-   * OMB control number / form number
+   * OMB control number / form number. If this
+   * omitted, it will not show in the rendered component. Be sure to get
+   * approval from the design council before leaving it out.
    */
-  ombNumber: PropTypes.string.isRequired,
+  ombNumber: PropTypes.string,
 
   /**
-   * Form expiration date
+   * Form expiration date. If this
+   * omitted, it will not show in the rendered component. Be sure to get
+   * approval from the design council before leaving it out.
    */
-  expDate: PropTypes.string.isRequired,
+  expDate: PropTypes.string,
 };
 
 export default OMBInfo;

--- a/packages/formation-react/src/components/OMBInfo/OMBInfo.jsx
+++ b/packages/formation-react/src/components/OMBInfo/OMBInfo.jsx
@@ -2,55 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Modal from '../Modal/Modal';
 
-const modalContents = minutes => (
-  <div>
-    <h3>Privacy Act Statement</h3>
-    {minutes && (
-      <p>
-        <strong>Respondent Burden:</strong> We need this information to
-        determine your eligibility for education benefits (38 U.S.C. 3471).
-        Title 38, United States Code, allows us to ask for this information. We
-        estimate that you will need an average of {minutes} minutes to review
-        the instructions, find the information, and complete this form. The VA
-        cannot conduct or sponsor a collection of information unless a valid OMB
-        (Office of Management and Budget) control number is displayed. You are
-        not required to respond to a collection of information if this number is
-        not displayed. Valid OMB control numbers can be located on the OMB
-        Internet Page at www.reginfo.gov/public/do/PRAMain. If desired, you can
-        call <a href="+18008271000">1-800-827-1000</a> to get information on
-        where to send comments or suggestions about this form.
-      </p>
-    )}
-    <p>
-      <strong>Privacy Act Notice:</strong> The VA will not disclose information
-      collected on this form to any source other than what has been authorized
-      under the Privacy Act of 1974 or title 38, Code of Federal Regulations,
-      section 1.576 for routine uses (e.g., the VA sends educational forms or
-      letters with a veteran’s identifying information to the Veteran’s school
-      or training establishment to (1) assist the veteran in the completion of
-      claims forms or (2) for the VA to obtain further information as may be
-      necessary from the school for VA to properly process the Veteran’s
-      education claim or to monitor his or her progress during training) as
-      identified in the VA system of records, 58VA21/22/28, Compensation,
-      Pension, Education, and Vocational Rehabilitation and Employment Records -
-      VA, and published in the Federal Register. Your obligation to respond is
-      required to obtain or retain education benefits. Giving us your SSN
-      account information is voluntary. Refusal to provide your SSN by itself
-      will not result in the denial of benefits. The VA will not deny an
-      individual benefits for refusing to provide his or her SSN unless the
-      disclosure of the SSN is required by a Federal Statute of law enacted
-      before January 1, 1975, and still in effect. The requested information is
-      considered relevant and necessary to determine the maximum benefits under
-      the law. While you do not have to respond, VA cannot process your claim
-      for education assistance unless the information is furnished as required
-      by existing law (38 U.S.C. 3471). The responses you submit are considered
-      confidential (38 U.S.C. 5701). Any information provided by applicants,
-      recipients, and others may be subject to verification through computer
-      matching programs with other agencies.
-    </p>
-  </div>
-);
-
 class OMBInfo extends React.Component {
   constructor(props) {
     super(props);
@@ -65,6 +16,57 @@ class OMBInfo extends React.Component {
   closeModal = () => {
     this.setState({ modalOpen: false });
   };
+
+  modalContents = minutes => (
+    <div>
+      <h3>Privacy Act Statement</h3>
+      {minutes && (
+        <p>
+          <strong>Respondent Burden:</strong> We need this information to
+          determine your eligibility for education benefits (38 U.S.C. 3471).
+          Title 38, United States Code, allows us to ask for this information.
+          We estimate that you will need an average of {minutes} minutes to
+          review the instructions, find the information, and complete this form.
+          The VA cannot conduct or sponsor a collection of information unless a
+          valid OMB (Office of Management and Budget) control number is
+          displayed. You are not required to respond to a collection of
+          information if this number is not displayed. Valid OMB control numbers
+          can be located on the OMB Internet Page at
+          www.reginfo.gov/public/do/PRAMain. If desired, you can call{' '}
+          <a href="+18008271000">1-800-827-1000</a> to get information on where
+          to send comments or suggestions about this form.
+        </p>
+      )}
+      <p>
+        <strong>Privacy Act Notice:</strong> The VA will not disclose
+        information collected on this form to any source other than what has
+        been authorized under the Privacy Act of 1974 or title 38, Code of
+        Federal Regulations, section 1.576 for routine uses (e.g., the VA sends
+        educational forms or letters with a veteran’s identifying information to
+        the Veteran’s school or training establishment to (1) assist the veteran
+        in the completion of claims forms or (2) for the VA to obtain further
+        information as may be necessary from the school for VA to properly
+        process the Veteran’s education claim or to monitor his or her progress
+        during training) as identified in the VA system of records,
+        58VA21/22/28, Compensation, Pension, Education, and Vocational
+        Rehabilitation and Employment Records - VA, and published in the Federal
+        Register. Your obligation to respond is required to obtain or retain
+        education benefits. Giving us your SSN account information is voluntary.
+        Refusal to provide your SSN by itself will not result in the denial of
+        benefits. The VA will not deny an individual benefits for refusing to
+        provide his or her SSN unless the disclosure of the SSN is required by a
+        Federal Statute of law enacted before January 1, 1975, and still in
+        effect. The requested information is considered relevant and necessary
+        to determine the maximum benefits under the law. While you do not have
+        to respond, VA cannot process your claim for education assistance unless
+        the information is furnished as required by existing law (38 U.S.C.
+        3471). The responses you submit are considered confidential (38 U.S.C.
+        5701). Any information provided by applicants, recipients, and others
+        may be subject to verification through computer matching programs with
+        other agencies.
+      </p>
+    </div>
+  );
 
   render() {
     const { resBurden, ombNumber, expDate } = this.props;
@@ -81,11 +83,9 @@ class OMBInfo extends React.Component {
             OMB Control #: <strong>{ombNumber}</strong>
           </div>
         )}
-        {expDate && (
-          <div>
-            Expiration date: <strong>{expDate}</strong>
-          </div>
-        )}
+        <div>
+          Expiration date: <strong>{expDate}</strong>
+        </div>
         <div>
           <button className="va-button-link" onClick={this.openModal}>
             Privacy Act Statement
@@ -94,7 +94,9 @@ class OMBInfo extends React.Component {
         <Modal
           cssClass="va-modal-large"
           contents={
-            this.props.children ? this.props.children : modalContents(resBurden)
+            this.props.children
+              ? this.props.children
+              : this.modalContents(resBurden)
           }
           id="omb-modal"
           visible={this.state.modalOpen}
@@ -125,7 +127,7 @@ OMBInfo.propTypes = {
    * omitted, it will not show in the rendered component. Be sure to get
    * approval from the design council before leaving it out.
    */
-  expDate: PropTypes.string,
+  expDate: PropTypes.string.isRequired,
 };
 
 export default OMBInfo;

--- a/packages/formation-react/src/components/OMBInfo/OMBInfo.jsx
+++ b/packages/formation-react/src/components/OMBInfo/OMBInfo.jsx
@@ -5,20 +5,22 @@ import Modal from '../Modal/Modal';
 const modalContents = minutes => (
   <div>
     <h3>Privacy Act Statement</h3>
-    <p>
-      <strong>Respondent Burden:</strong> We need this information to determine
-      your eligibility for education benefits (38 U.S.C. 3471). Title 38, United
-      States Code, allows us to ask for this information. We estimate that you
-      will need an average of {minutes} minutes to review the instructions, find
-      the information, and complete this form. The VA cannot conduct or sponsor
-      a collection of information unless a valid OMB (Office of Management and
-      Budget) control number is displayed. You are not required to respond to a
-      collection of information if this number is not displayed. Valid OMB
-      control numbers can be located on the OMB Internet Page at
-      www.reginfo.gov/public/do/PRAMain. If desired, you can call{' '}
-      <a href="+18008271000">1-800-827-1000</a> to get information on where to
-      send comments or suggestions about this form.
-    </p>
+    {minutes && (
+      <p>
+        <strong>Respondent Burden:</strong> We need this information to
+        determine your eligibility for education benefits (38 U.S.C. 3471).
+        Title 38, United States Code, allows us to ask for this information. We
+        estimate that you will need an average of {minutes} minutes to review
+        the instructions, find the information, and complete this form. The VA
+        cannot conduct or sponsor a collection of information unless a valid OMB
+        (Office of Management and Budget) control number is displayed. You are
+        not required to respond to a collection of information if this number is
+        not displayed. Valid OMB control numbers can be located on the OMB
+        Internet Page at www.reginfo.gov/public/do/PRAMain. If desired, you can
+        call <a href="+18008271000">1-800-827-1000</a> to get information on
+        where to send comments or suggestions about this form.
+      </p>
+    )}
     <p>
       <strong>Privacy Act Notice:</strong> The VA will not disclose information
       collected on this form to any source other than what has been authorized

--- a/packages/formation-react/src/components/OMBInfo/OMBInfo.mdx
+++ b/packages/formation-react/src/components/OMBInfo/OMBInfo.mdx
@@ -23,7 +23,7 @@ import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo'
 |-|-|-|:-:|
 |resBurden| String or Number | The number of minutes the form is expected to take. If left falsy, this will not show.| No|
 |ombNumber | String | The form's OMB (Office of Management and Budget) control number | No |
-| expDate | Date as a string | This should be a formated date, in the format of `MMMM DD YYYY`| No |
+| expDate | Date as a string | This should be a formated date, in the format of `MMMM DD YYYY`| Yes |
 |children | JSX | Any children nodes will should up in the Privacy Statement Act model | No|
 
 ### Rendered Component

--- a/packages/formation-react/src/components/OMBInfo/OMBInfo.mdx
+++ b/packages/formation-react/src/components/OMBInfo/OMBInfo.mdx
@@ -22,8 +22,8 @@ import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo'
 | Name | Type | Description | Required|
 |-|-|-|:-:|
 |resBurden| String or Number | The number of minutes the form is expected to take. If left falsy, this will not show.| No|
-|ombNumber | String | The form's OMB (Office of Management and Budget) control number | Yes |
-| expDate | Date as a string | This should be a formated date, in the format of `MMMM DD YYYY`| Yes |
+|ombNumber | String | The form's OMB (Office of Management and Budget) control number | No |
+| expDate | Date as a string | This should be a formated date, in the format of `MMMM DD YYYY`| No |
 |children | JSX | Any children nodes will should up in the Privacy Statement Act model | No|
 
 ### Rendered Component

--- a/packages/formation-react/src/components/OMBInfo/OMBInfo.unit.spec.jsx
+++ b/packages/formation-react/src/components/OMBInfo/OMBInfo.unit.spec.jsx
@@ -60,14 +60,18 @@ describe('<OMBInfo/>', () => {
     expect(tree.text()).to.not.contain('OMB Number');
     tree.unmount();
   });
-  it('should render expiration date', () => {
-    const tree = shallow(<OMBInfo expDate="Expiration date" />);
-    expect(tree.text()).to.contain('Expiration date');
+  it('modal should have response burden', () => {
+    const tree = shallow(<OMBInfo resBurden="10" />);
+    tree.find('button').simulate('click');
+    expect(tree.text()).to.contain('Privacy Act Statement');
+    expect(tree.text()).to.contain('Respondent Burden');
     tree.unmount();
   });
-  it('should not render expiration date', () => {
+  it('modal should not have response burden', () => {
     const tree = shallow(<OMBInfo />);
-    expect(tree.text()).to.not.contain('Expiration date');
+    tree.find('button').simulate('click');
+    expect(tree.text()).to.contain('Privacy Act Statement');
+    expect(tree.text()).to.not.contain('Respondent Burden');
     tree.unmount();
   });
 });

--- a/packages/formation-react/src/components/OMBInfo/OMBInfo.unit.spec.jsx
+++ b/packages/formation-react/src/components/OMBInfo/OMBInfo.unit.spec.jsx
@@ -6,7 +6,7 @@ import { axeCheck } from '../../helpers/test-helpers';
 import OMBInfo from './OMBInfo.jsx';
 
 describe('<OMBInfo/>', () => {
-  it('should render', () => {
+  it('should render all data', () => {
     const tree = shallow(
       <OMBInfo
         resBurden={15}
@@ -15,9 +15,15 @@ describe('<OMBInfo/>', () => {
       />,
     );
     expect(tree.text()).to.contain('Expiration date');
+    expect(tree.text()).to.contain('OMB Number');
+    expect(tree.text()).to.contain('Respondent burden');
     tree.unmount();
   });
-
+  it('should render just privacy', () => {
+    const tree = shallow(<OMBInfo />);
+    expect(tree.text()).to.contain('Privacy Act Statement');
+    tree.unmount();
+  });
   it('should pass aXe check', () =>
     axeCheck(
       <OMBInfo
@@ -42,6 +48,26 @@ describe('<OMBInfo/>', () => {
       <OMBInfo ombNumber="OMB Number" expDate="Expiration date" />,
     );
     expect(tree.text()).to.not.contain('Respondent burden');
+    tree.unmount();
+  });
+  it('should render omb number', () => {
+    const tree = shallow(<OMBInfo ombNumber="OMB Number" />);
+    expect(tree.text()).to.contain('OMB Number');
+    tree.unmount();
+  });
+  it('should not render omb number', () => {
+    const tree = shallow(<OMBInfo />);
+    expect(tree.text()).to.not.contain('OMB Number');
+    tree.unmount();
+  });
+  it('should render expiration date', () => {
+    const tree = shallow(<OMBInfo expDate="Expiration date" />);
+    expect(tree.text()).to.contain('Expiration date');
+    tree.unmount();
+  });
+  it('should not render expiration date', () => {
+    const tree = shallow(<OMBInfo />);
+    expect(tree.text()).to.not.contain('Expiration date');
     tree.unmount();
   });
 });

--- a/packages/formation-react/src/components/OMBInfo/OMBInfo.unit.spec.jsx
+++ b/packages/formation-react/src/components/OMBInfo/OMBInfo.unit.spec.jsx
@@ -62,16 +62,24 @@ describe('<OMBInfo/>', () => {
   });
   it('modal should have response burden', () => {
     const tree = shallow(<OMBInfo resBurden="10" />);
-    tree.find('button').simulate('click');
-    expect(tree.text()).to.contain('Privacy Act Statement');
-    expect(tree.text()).to.contain('Respondent Burden');
+    const instance = tree.instance();
+    const modelContent = shallow(
+      instance.modalContents(instance.props.resBurden),
+    );
+    expect(modelContent.text()).to.contain('Privacy Act Statement');
+    expect(modelContent.text()).to.contain('Respondent Burden');
+    modelContent.unmount();
     tree.unmount();
   });
   it('modal should not have response burden', () => {
     const tree = shallow(<OMBInfo />);
-    tree.find('button').simulate('click');
-    expect(tree.text()).to.contain('Privacy Act Statement');
-    expect(tree.text()).to.not.contain('Respondent Burden');
+    const instance = tree.instance();
+    const modelContent = shallow(
+      instance.modalContents(instance.props.resBurden),
+    );
+    expect(modelContent.text()).to.contain('Privacy Act Statement');
+    expect(modelContent.text()).to.not.contain('Respondent Burden');
+    modelContent.unmount();
     tree.unmount();
   });
 });


### PR DESCRIPTION
## Description
The OMB number component needs to have a little more flexible to meet requirements

- For forms with no OMB number, those fields should be hidden
- The content in the `Privacy Act Statement` should reflect the form being used. So if there is no res burden, then do not show the res burden section.  

## Testing done
- [x] updated unit tests for hiding and displaying data
- [x] Added tests for modal

## Acceptance criteria
- [x] tests pass
- [x] approved by the powers that be. 

## Definition of done
- [x] [Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/16591)