### PR TITLE
Fix the pre-publish script

### DIFF
--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -6,14 +6,16 @@
 const { execSync } = require('child_process');
 const chalk = require('chalk');
 
-const branchName = execSync('git branch --show-current');
+const branchName = execSync('git branch --show-current')
+  .toString('utf8')
+  .trim();
 
 if (branchName !== 'master') {
   console.log(
     chalk.yellow(
       `You're currently on branch ${chalk.cyan(
         branchName,
-      )}Please check out ${chalk.cyan('master')} before publishing.\n`,
+      )}\nPlease check out ${chalk.cyan('master')} before publishing.\n`,
     ),
   );
   process.exit(1);


### PR DESCRIPTION
## Description
Turns out `execSync` returns a buffer, which makes total sense. This buffer contained a newline character, which explained the dumb thing I was doing in the `console.log()`.

## Testing done
The latest `master` needed publishing, so I made the change there and tested by publishing. On this branch, I added a `process.exit(1)` at the end of the pre-publish script for safety and tried publishing again. I got the error I expected (wouldn't let me publish).
![image](https://user-images.githubusercontent.com/12970166/101813886-27310800-3ad2-11eb-8482-a7218b577699.png)