### PR TITLE
Build .js files

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/scripts/build.js
+++ b/packages/formation-react/scripts/build.js
@@ -55,7 +55,7 @@ const fileNames = [].concat.apply(
   ],
 );
 
-fileNames.forEach((fileName) => {
+fileNames.forEach(fileName => {
   // read a file into a buffer
   const fileBuffer = fs.readFileSync(fileName);
   // transform the buffer with babel using babelrc

--- a/packages/formation-react/scripts/build.js
+++ b/packages/formation-react/scripts/build.js
@@ -48,7 +48,7 @@ function flattenRequires(bufferString) {
 const fileNames = [].concat.apply(
   [],
   [
-    glob.sync('./src/components/**/*.jsx', {
+    glob.sync('./src/components/**/*.@(js|jsx)', {
       ignore: ['./**/*.unit.spec.jsx', './**/*.stories.jsx'],
     }),
     glob.sync('./src/helpers/*.js'),


### PR DESCRIPTION
## Description
Telephone.js was invalid because it was importing `./contacts`, but `contacts.js` wasn't being built by our build process because it was a `.js` file and not a `.jsx` file. This fixes that.

## Testing done
Built locally and verified `contacts.js` is built as expected.