### PR TITLE
Add dropdownpanel classnames

### DIFF
--- a/packages/formation-react/package.json
+++ b/packages/formation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation-react",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "React implementation of patterns in Formation",
   "keywords": [
     "react",

--- a/packages/formation-react/src/components/DropDownPanel/DropDownPanel.jsx
+++ b/packages/formation-react/src/components/DropDownPanel/DropDownPanel.jsx
@@ -33,7 +33,7 @@ export default class DropDownPanel extends React.Component {
 
     return (
       <div
-        className={`va-dropdown ${this.props.className}`}
+        className="va-dropdown"
         ref={(div) => {
           this.dropdownDiv = div;
         }}
@@ -51,7 +51,7 @@ export default class DropDownPanel extends React.Component {
           </span>
         </button>
         <div
-          className="va-dropdown-panel"
+          className={`va-dropdown-panel ${this.props.dropdownPanelClassNames}`}
           id={this.props.id}
           hidden={!this.props.isOpen}
         >
@@ -69,11 +69,6 @@ DropDownPanel.propTypes = {
   buttonText: PropTypes.string.isRequired,
 
   /**
-   * The string of classnames for the container.
-   */
-  className: PropTypes.string,
-
-  /**
    * A function called when the drop down button is clicked. This is often used
    * to set the open state in the parent component, which passes down the new
    * isOpen prop.
@@ -84,6 +79,12 @@ DropDownPanel.propTypes = {
    * Any CSS classes to apply to the button itself.
    */
   cssClass: PropTypes.string,
+
+
+  /**
+   * The string of classnames for the dropdown panel container.
+   */
+  dropdownPanelClassNames: PropTypes.string,
 
   /**
    * An SVG icon to render before the button text.
@@ -107,6 +108,6 @@ DropDownPanel.propTypes = {
 };
 
 DropDownPanel.defaultProps = {
-  className: "",
+  dropdownPanelClassNames: "",
   disabled: false,
 };

--- a/packages/formation-react/src/components/DropDownPanel/DropDownPanel.jsx
+++ b/packages/formation-react/src/components/DropDownPanel/DropDownPanel.jsx
@@ -33,8 +33,8 @@ export default class DropDownPanel extends React.Component {
 
     return (
       <div
-        className="va-dropdown"
-        ref={div => {
+        className={`va-dropdown ${this.props.className}`}
+        ref={(div) => {
           this.dropdownDiv = div;
         }}
       >
@@ -67,6 +67,11 @@ DropDownPanel.propTypes = {
    * The text of the drop down button.
    */
   buttonText: PropTypes.string.isRequired,
+
+  /**
+   * The string of classnames for the container.
+   */
+  className: PropTypes.string,
 
   /**
    * A function called when the drop down button is clicked. This is often used
@@ -102,5 +107,6 @@ DropDownPanel.propTypes = {
 };
 
 DropDownPanel.defaultProps = {
+  className: "",
   disabled: false,
 };


### PR DESCRIPTION
## Description
Add class name prop to DropDownPanel for styling purposes

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [X] Add class name prop to DropDownPanel

## Links
here is the vets-website PR that is relying on the change:
https://github.com/department-of-veterans-affairs/vets-website/pull/15347

And here is the ticket that is being addressed:
https://github.com/department-of-veterans-affairs/va.gov-team/issues/16965

## Definition of done
- [X] Changes have been tested in vets-website
- [X] Changes have been tested in IE11, if applicable
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
