### PR TITLE
Add custom viewports & set a named default

### DIFF
--- a/packages/formation-react/.storybook/preview.js
+++ b/packages/formation-react/.storybook/preview.js
@@ -55,7 +55,7 @@ export const parameters = {
   },
   viewport: {
     viewports,
-    defaultViewport: 'smallDesktop',
+    defaultViewport: 'small',
   },
 };
 

--- a/packages/formation-react/.storybook/preview.js
+++ b/packages/formation-react/.storybook/preview.js
@@ -55,7 +55,7 @@ export const parameters = {
   },
   viewport: {
     viewports,
-    defaultViewport: 'medium',
+    defaultViewport: 'smallDesktop',
   },
 };
 

--- a/packages/formation-react/.storybook/preview.js
+++ b/packages/formation-react/.storybook/preview.js
@@ -2,6 +2,49 @@ import '@department-of-veterans-affairs/formation/dist/formation.min.css';
 import '@department-of-veterans-affairs/formation/dist/formation';
 import { withHTML } from '@whitespace/storybook-addon-html/react';
 
+const viewports = {
+  xsmall: {
+    name: 'XSmall Screen',
+    styles: {
+      height: '568px',
+      width: '320px',
+    },
+    type: 'mobile',
+  },
+  small: {
+    name: 'Small Screen',
+    styles: {
+      height: '896px',
+      width: '481px',
+    },
+    type: 'mobile',
+  },
+  medium: {
+    name: 'Medium',
+    styles: {
+      height: '1112px',
+      width: '768px',
+    },
+    type: 'tablet',
+  },
+  smallDesktop: {
+    name: 'Small Desktop',
+    styles: {
+      height: '1400px',
+      width: '1008px',
+    },
+    type: 'desktop',
+  },
+  large: {
+    name: 'Large',
+    styles: {
+      height: '1600px',
+      width: '1601px',
+    },
+    type: 'desktop',
+  },
+};
+
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   options: {
@@ -9,6 +52,10 @@ export const parameters = {
       method: 'alphabetical',
       order: ['About', ['Introduction']],
     },
+  },
+  viewport: {
+    viewports,
+    defaultViewport: 'medium',
   },
 };
 


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/18147

This should provide a better user experience for our Storybook users. It sets custom viewports based off of [breakpoints from the design system](https://design.va.gov/design/breakpoints). Additionally, it uses the `medium` viewport as a default, which means that the responsive viewports button gets a label when you first open the page.

By setting a named default, the viewport is ironically no longer responsive (see third screenshot). However, `Reset viewport` can be used to turn the viewport responsive again.


## Testing done

Local storybook


## Screenshots

### Custom viewports

![image](https://user-images.githubusercontent.com/2008881/102571638-cfc90400-409e-11eb-8cf7-7a232024c150.png)


### Toolbar displaying default viewport name  after a page refresh

![image](https://user-images.githubusercontent.com/2008881/102571833-6269a300-409f-11eb-987d-ff810850c796.png)

### Non-responsive viewport example

![image](https://user-images.githubusercontent.com/2008881/102571983-cab88480-409f-11eb-9f39-d08684c2b328.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
