### PR TITLE
Remove Form controls from the Storybook side nav

### DIFF
--- a/packages/formation-react/src/components/ErrorableCheckbox/ErrorableCheckbox.stories.jsx
+++ b/packages/formation-react/src/components/ErrorableCheckbox/ErrorableCheckbox.stories.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ErrorableCheckbox from './ErrorableCheckbox';
 
 export default {
-  title: 'Library/Form controls/ErrorableCheckbox',
+  title: 'Library/ErrorableCheckbox',
   component: ErrorableCheckbox,
 };
 

--- a/packages/formation-react/src/components/ErrorableCheckboxGroup/ErrorableCheckboxGroup.stories.jsx
+++ b/packages/formation-react/src/components/ErrorableCheckboxGroup/ErrorableCheckboxGroup.stories.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ErrorableCheckboxGroup from './ErrorableCheckboxGroup';
 
 export default {
-  title: 'Library/Form controls/ErrorableCheckboxGroup',
+  title: 'Library/ErrorableCheckboxGroup',
   component: ErrorableCheckboxGroup,
   argTypes: {
     options: {

--- a/packages/formation-react/src/components/ErrorableDate/ErrorableDate.stories.jsx
+++ b/packages/formation-react/src/components/ErrorableDate/ErrorableDate.stories.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import ErrorableDate from './ErrorableDate';
 
 export default {
-  title: 'Library/Form controls/ErrorableDate',
+  title: 'Library/ErrorableDate',
   component: ErrorableDate,
 };
 

--- a/packages/formation-react/src/components/ErrorableFileInput/ErrorableFileInput.stories.jsx
+++ b/packages/formation-react/src/components/ErrorableFileInput/ErrorableFileInput.stories.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ErrorableFileInput from './ErrorableFileInput';
 
 export default {
-  title: 'Library/Form controls/ErrorableFileInput',
+  title: 'Library/ErrorableFileInput',
   component: ErrorableFileInput,
 };
 

--- a/packages/formation-react/src/components/ErrorableMonthYear/ErrorableMonthYear.stories.jsx
+++ b/packages/formation-react/src/components/ErrorableMonthYear/ErrorableMonthYear.stories.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import ErrorableMonthYear from './ErrorableMonthYear';
 
 export default {
-  title: 'Library/Form controls/ErrorableMonthYear',
+  title: 'Library/ErrorableMonthYear',
   component: ErrorableMonthYear,
 };
 

--- a/packages/formation-react/src/components/ErrorableNumberInput/ErrorableNumberInput.stories.jsx
+++ b/packages/formation-react/src/components/ErrorableNumberInput/ErrorableNumberInput.stories.jsx
@@ -3,14 +3,13 @@ import React, { useState } from 'react';
 import ErrorableNumberInput from './ErrorableNumberInput';
 
 export default {
-  title: 'Library/Form controls/ErrorableNumberInput',
+  title: 'Library/ErrorableNumberInput',
   component: ErrorableNumberInput,
 };
 
 const Template = args => {
   const [field, setField] = useState(args.field);
   const onValueChange = newField => {
-    console.log('value changed:', newField);
     setField(newField);
   };
 

--- a/packages/formation-react/src/components/ErrorableRadioButtons/ErrorableRadioButtons.stories.jsx
+++ b/packages/formation-react/src/components/ErrorableRadioButtons/ErrorableRadioButtons.stories.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import ErrorableRadioButtons from './ErrorableRadioButtons';
 
 export default {
-  title: 'Library/Form controls/ErrorableRadioButtons',
+  title: 'Library/ErrorableRadioButtons',
   component: ErrorableRadioButtons,
 };
 

--- a/packages/formation-react/src/components/ErrorableSelect/ErrorableSelect.stories.jsx
+++ b/packages/formation-react/src/components/ErrorableSelect/ErrorableSelect.stories.jsx
@@ -3,14 +3,13 @@ import React, { useState } from 'react';
 import ErrorableSelect from './ErrorableSelect';
 
 export default {
-  title: 'Library/Form controls/ErrorableSelect',
+  title: 'Library/ErrorableSelect',
   component: ErrorableSelect,
 };
 
 const Template = args => {
   const [value, setValue] = useState(args.value);
   const onValueChange = newValue => {
-    console.log('value changed:', newValue);
     setValue(newValue);
   };
 

--- a/packages/formation-react/src/components/ErrorableTextArea/ErrorableTextArea.stories.jsx
+++ b/packages/formation-react/src/components/ErrorableTextArea/ErrorableTextArea.stories.jsx
@@ -3,14 +3,13 @@ import React, { useState } from 'react';
 import ErrorableTextArea from './ErrorableTextArea';
 
 export default {
-  title: 'Library/Form controls/ErrorableTextArea',
+  title: 'Library/ErrorableTextArea',
   component: ErrorableTextArea,
 };
 
 const Template = args => {
   const [field, setField] = useState(args.field);
   const onValueChange = newField => {
-    console.log('value changed:', newField);
     setField(newField);
   };
 

--- a/packages/formation-react/src/components/ErrorableTextInput/ErrorableTextInput.stories.jsx
+++ b/packages/formation-react/src/components/ErrorableTextInput/ErrorableTextInput.stories.jsx
@@ -3,14 +3,13 @@ import React, { useState } from 'react';
 import ErrorableTextInput from './ErrorableTextInput';
 
 export default {
-  title: 'Library/Form controls/ErrorableTextInput',
+  title: 'Library/ErrorableTextInput',
   component: ErrorableTextInput,
 };
 
 const Template = args => {
   const [field, setField] = useState(args.field);
   const onValueChange = newField => {
-    console.log('value changed:', newField);
     setField(newField);
   };
 


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/18145

Moved the `Errorable*` components out of the `Form controls` directory in Storybook.

**Note:** We're moving all the `Usage` documents in a separate PR, so I left it alone for now to avoid merge conflicts.

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/103833182-2c339980-5035-11eb-9be8-149a1e2df9f2.png)