### PR TITLE
Update docs for custom radio props

### DIFF
--- a/packages/documentation/src/pages/forms/available-features-and-usage-guidelines.mdx
+++ b/packages/documentation/src/pages/forms/available-features-and-usage-guidelines.mdx
@@ -186,6 +186,12 @@ uiSchema: {
       cat: 'Cat',
       octopus: 'Octopus',
       sloth: 'Sloth'
+    },
+    widgetProps: {
+      dog: { 'aria-describedby': 'some_id_1' },
+      cat: { 'aria-describedby': 'some_id_2' },
+      octopus: { 'aria-describedby': 'some_id_3' },
+      sloth: { 'aria-describedby': 'some_id_4' }
     }
   }
 }
@@ -349,7 +355,13 @@ Your config file might look like this:
   uiSchema: {
     hasPet: {
       'ui:title': 'Do you have a pet?'
-      'ui:widget': 'yesNo'
+      'ui:widget': 'yesNo',
+      'ui:options': {
+        widgetProps: {
+          Y: { 'aria-describedby': 'some_id' },
+          N: { 'aria-describedby': 'different_id' },
+        }
+      }
     },
     petName: {
       'ui:title': 'What is your pet‘s name?',

--- a/packages/documentation/src/pages/forms/available-widgets.mdx
+++ b/packages/documentation/src/pages/forms/available-widgets.mdx
@@ -85,7 +85,7 @@ Renders a `TextWidget` with additional logic to strip non-numeric characters fro
 Renders a single radio button for each `enum` value. This overrides the default `SelectWidget` that is normally rendered where `enum` exists.
 
 - **File:** [RadioWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/widgets/RadioWidget.jsx)
-- **Usage:** In the `uiSchema`, specify `'ui:widget': 'radio'` for the given field. Usually used with `'ui:options': { labels: {}}` so you can specify the label for each radio button. To see a code example, refer to [radio button group in form features](/forms/available-features-and-usage-guidelines#radio-button-group).
+- **Usage:** In the `uiSchema`, specify `'ui:widget': 'radio'` for the given field. Usually used with `'ui:options': { labels: {}}` so you can specify the label for each radio button. To see a code example, refer to [radio button group in form features](/forms/available-features-and-usage-guidelines#radio-button-group). Include additional properties on the radio input by including `widgetProps` within the `ui:options`; the key for each input will match the custom option values.
 
 ## `SelectWidget`
 
@@ -113,5 +113,5 @@ Renders a `<input>` HTML element, and is the default widget for data of `type: '
 Renders two radio buttons, one with a value of "Yes" and one with a value of "No".
 
 - **File:** [YesNoWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/widgets/YesNoWidget.jsx)
-- **Usage:** In the `uiSchema`, specify `'ui:widget': 'yesNo'` for the given field.
+- **Usage:** In the `uiSchema`, specify `'ui:widget': 'yesNo'` for the given field. Include additional properties on the radio input by including `widgetProps` within the `ui:options`; the key for each input will match the option values of `Y` and `N`.
 

--- a/packages/documentation/src/pages/forms/form-tutorial-advanced.mdx
+++ b/packages/documentation/src/pages/forms/form-tutorial-advanced.mdx
@@ -137,7 +137,17 @@ const formConfig = {
       uiSchema: {
         myField: {
           'ui:title': 'My field',
-          'ui:widget': 'yesNo'
+          'ui:widget': 'yesNo',
+          'ui:options': {
+            labels: {
+              Y: 'Yes, this is what I want',
+              N: 'No, I do not want this',
+            },
+            widgetProps: {
+              Y: { 'aria-describedby': 'some_id' },
+              N: { 'aria-describedby': 'different_id' },
+            }
+          }
         },
         veteranFullName: set('ui:options.expandUnder', 'myField', fullNameUI)
       },

--- a/packages/documentation/src/pages/forms/form-tutorial-basic.mdx
+++ b/packages/documentation/src/pages/forms/form-tutorial-basic.mdx
@@ -196,7 +196,13 @@ page1: {
   uiSchema: {
     myField: {
       'ui:title': 'My field label',
-      'ui:widget': 'radio'
+      'ui:widget': 'radio',
+      'ui:options': {
+        widgetProps: {
+          'First option': { 'aria-describedby': 'some_id_1' },
+          'Second option': { 'aria-describedby': 'some_id_2' },
+        }
+      }
     }
   },
   schema: {

--- a/packages/documentation/src/pages/forms/form-tutorial-intermediate.mdx
+++ b/packages/documentation/src/pages/forms/form-tutorial-intermediate.mdx
@@ -162,6 +162,16 @@ page1: {
     myField: {
       'ui:title': 'My field',
       'ui:widget': 'yesNo'
+      'ui:options': {
+        labels: {
+          Y: 'Yes, this is what I want',
+          N: 'No, I do not want this',
+        },
+        widgetProps: {
+          Y: { 'aria-describedby': 'some_id' },
+          N: { 'aria-describedby': 'different_id' },
+        }
+      }
     },
     myConditionalField: {
       'ui:title': 'My conditional field',
@@ -197,7 +207,17 @@ page1: {
   uiSchema: {
     myField: {
       'ui:title': 'My field',
-      'ui:widget': 'yesNo'
+      'ui:widget': 'yesNo',
+      'ui:options': {
+        labels: {
+          Y: 'Yes, this is what I want',
+          N: 'No, I do not want this',
+        },
+        widgetProps: {
+          Y: { 'aria-describedby': 'some_id' },
+          N: { 'aria-describedby': 'different_id' },
+        }
+      }
     },
     myConditionalField: {
       'ui:title': 'My conditional field',
@@ -234,7 +254,17 @@ page1: {
   uiSchema: {
     myField: {
       'ui:title': 'My field',
-      'ui:widget': 'yesNo'
+      'ui:widget': 'yesNo',
+      'ui:options': {
+        labels: {
+          Y: 'Yes, this is what I want',
+          N: 'No, I do not want this',
+        },
+        widgetProps: {
+          Y: { 'aria-describedby': 'some_id' },
+          N: { 'aria-describedby': 'different_id' },
+        }
+      }
     }
   },
   schema: {


### PR DESCRIPTION
## Description

Add docs for the new `radio` and `yesNo` widget `ui:options`. This change will allow custom widget properties (`widgetProps`) to be included on each input. Specifically this was meant to enable adding `aria-describedby` properties to specific inputs to improve accessibility.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/316
- https://github.com/department-of-veterans-affairs/vets-website/pull/15586

## Testing done

N/A - doc updates only

## Screenshots

N/A

## Acceptance criteria
- [x] Documentation for the `widgetProps` addition are available

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
