### PR TITLE
Replace old help desk number

### DIFF
--- a/packages/documentation/src/pages/forms/available-features-and-usage-guidelines.mdx
+++ b/packages/documentation/src/pages/forms/available-features-and-usage-guidelines.mdx
@@ -556,8 +556,8 @@ const SubmitError = () => {
         <p>
           If you feel you’ve entered your information correctly, please call the{' '}
           <a href="https://www.va.gov/">VA.gov</a> help desk at{' '}
-          <a href="tel:8555747286">855-574-7286</a>
-          (TTY: 711). We’re here Monday-Friday, 8:00 a.m.-8:00 p.m. ET.
+          <Telephone contact={CONTACTS.VA_311} /> (TTY: 711). We’re here{' '}
+          <abbr title="24 hours a day, 7 days a week">24/7</abbr>.
         </p>
       </div>
     );

--- a/packages/formation-react/src/components/HelpMenu/HelpMenu.jsx
+++ b/packages/formation-react/src/components/HelpMenu/HelpMenu.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import DropDownPanel from '../DropDownPanel/DropDownPanel';
 import IconHelp from '../IconHelp/IconHelp';
+import Telephone, { CONTACTS } from '../Telephone/Telephone';
 
 class HelpMenu extends React.Component {
   render() {
@@ -21,7 +22,7 @@ class HelpMenu extends React.Component {
             <b>Call the VA.gov Help Desk</b>
           </p>
           <p>
-            <a href="tel:18555747286">1-855-574-7286</a>
+            <Telephone contact={CONTACTS.HELP_DESK} />
           </p>
           <p>
             TTY: <a href="tel:+18008778339">1-800-877-8339</a>

--- a/packages/formation-react/src/components/HelpMenu/HelpMenu.jsx
+++ b/packages/formation-react/src/components/HelpMenu/HelpMenu.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import DropDownPanel from '../DropDownPanel/DropDownPanel';
 import IconHelp from '../IconHelp/IconHelp';
-import Telephone, { CONTACTS } from '../Telephone/Telephone';
+import Telephone, { CONTACTS, PATTERNS } from '../Telephone/Telephone';
 
 class HelpMenu extends React.Component {
   render() {
@@ -25,9 +25,12 @@ class HelpMenu extends React.Component {
             <Telephone contact={CONTACTS.HELP_DESK} />
           </p>
           <p>
-            TTY: <a href="tel:+18008778339">1-800-877-8339</a>
+            TTY:{' '}
+            <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
           </p>
-          <p>Monday &ndash; Friday, 8:00 a.m. &ndash; 8:00 p.m. (ET)</p>
+          <p>
+            We’re here <abbr title="24 hours a day, 7 days a week">24/7</abbr>
+          </p>
         </div>
       </DropDownPanel>
     );


### PR DESCRIPTION
## Description

The old help desk number `855-574-7286` is outdated and needs to be replaced with `800-698-2411`.

Also, changing the TTY number to `711` per the Slack conversation.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/18345
- https://dsva.slack.com/archives/CBU0KDSB1/p1610393236325800
- https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/438 will fix Telephone docs reference

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] Old help desk number should not exist in the code base

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
