### PR TITLE
Revert "Add Storybook Link to Visual Design page"

### DIFF
--- a/packages/documentation/src/pages/visual-design/index.mdx
+++ b/packages/documentation/src/pages/visual-design/index.mdx
@@ -19,7 +19,3 @@ If you need to use Formation on a project outside of the vets-website repository
 Separately from the main `formation` module, we also have `formation-react`, which contains React implementations of many of the components described in the design system. This is already set up for you to use in vets-website; for uses outside of vets-website, see the module [readme](https://www.npmjs.com/package/@department-of-veterans-affairs/formation-react).
 
 You can view documentation for each of the components in `formation-react` by clicking on one in the sidebar on the left of the page.
-
-### Storybook
-
-The Design System team is working on moving the component documentation to [Storybook](https://design.va.gov/storybook).


### PR DESCRIPTION
Reverts department-of-veterans-affairs/veteran-facing-services-tools#555

Related to https://github.com/department-of-veterans-affairs/vets-design-system-documentation/pull/370

From that PR:

> This triggered a deploy which accidentally removed the thing we were linking to. Removing the link so we have more time to troubleshoot.

Removing the link here as well