### PR TITLE
Auto-expand accordion panels by URL hash

### DIFF
--- a/packages/formation/js/accordion.js
+++ b/packages/formation/js/accordion.js
@@ -160,10 +160,27 @@ const addAccordionClickHandler = () => {
   }
 };
 
+function autoExpandAccordionPanelByUrlHash() {
+  const hash = document.location.hash;
+
+  if (!hash) {
+    return;
+  }
+
+  const anchorId = document.location.hash.slice(1);
+  const accordionButtonSelector = `.usa-accordion li[id="${anchorId}"] .usa-accordion-button`;
+  const accordionButton = document.querySelector(accordionButtonSelector);
+
+  if (accordionButton) {
+    accordionButton.click();
+  }
+}
+
 const loadAccordionHandler = () => {
   addAriaHiddenAttr();
   addAriasExpandedAttr();
   addAccordionClickHandler();
+  autoExpandAccordionPanelByUrlHash();
 };
 
 export default loadAccordionHandler;

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.10.3",
+  "version": "6.11.0",
   "description": "The VA design system",
   "keywords": [
     "va",


### PR DESCRIPTION
## Description
This PR adds onto the Formation bundle's accordion JS. If the hash in the document's URL matches an accordion panel's element ID, the accordion panel will automatically expand open on page load. This is so content editors can link to specific accordion panels and have the panel's content automatically revealed.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/15798

## Testing done
I tested against my local vets-website by changing the site-wide import to use my local Formation repo.

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/104957805-d64be380-599c-11eb-90d9-11e4a5ee5cd0.png)


## Acceptance criteria
- [ ] Accordion panels reveal content automatically when matching URL hash

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
