### PR TITLE
Bump Formation to 6.12.0

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.11.0",
+  "version": "6.12.0",
   "description": "The VA design system",
   "keywords": [
     "va",


### PR DESCRIPTION
## Description
Somehow there were two merged to bump Formation to 6.11.0 so now we need a 6.12.0

https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/577
https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/576

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
