### PR TITLE
Update accordion content docs

### DIFF
--- a/packages/documentation/src/pages/forms/about-the-schema-and-uischema-objects.mdx
+++ b/packages/documentation/src/pages/forms/about-the-schema-and-uischema-objects.mdx
@@ -170,9 +170,9 @@ The VAFS code includes additional `uiSchema` functionality not found in the RJSF
   }) => (
     <>
       <div className="form-review-panel-page-header-row">
-        <h3 className="form-review-panel-page-header vads-u-font-size--h5">
+        <h4 className="form-review-panel-page-header vads-u-font-size--h5">
           {title}
-        </h3>
+        </h4>
         /* use the `defaultEditButton` function, or create a custom edit button
           if the value is not included, it will fall back to its default
           {defaultEditButton({
@@ -253,9 +253,9 @@ The VAFS code includes additional `uiSchema` functionality not found in the RJSF
     viewField: RowViewComponent,
 
     // For array fields, this will toggle the auto-scroll that happens when an item is added
-    // to the list. This setting will toggle the scroll for both the original page and the review page. 
+    // to the list. This setting will toggle the scroll for both the original page and the review page.
     doNotScroll: true,
-    
+
     // To show a field only when another field is true, set this option to the property name.
     // It wraps the fields with an ExpandingGroup component using the `expandUnder` field as
     // the first question.


### PR DESCRIPTION
## Description

Updating docs to match the use of `H4`s inside the form review & submit accordion content.

Related:
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/368
- https://github.com/department-of-veterans-affairs/vets-website/pull/15717
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/17846

## Testing done

N/A - doc update only

## Screenshots

N/A

## Acceptance criteria
- [x] Show use of `H4` inside review & submit accordions

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
