### PR TITLE
Adding note about the Jenkins pipeline and deploy process

### DIFF
--- a/packages/documentation/src/pages/getting-started/workflow/deploy.mdx
+++ b/packages/documentation/src/pages/getting-started/workflow/deploy.mdx
@@ -51,6 +51,10 @@ Two out-of-cycle deploys are supported in Jenkins:
 - partial deploy including only static page changes (`vagov-content` and `Drupal`)
 - full deploy of VA.gov client app and static pages
 
+**Note**: If a full or partial manual deploy of vets-website is kicked off while a scheduled deploy 
+is in progress (or vice versa), the builds will not conflict. Whichever begins first will deploy 
+first, with the latter queued up behind it.
+
 ### Before deploying
 
 - Wait for **Jenkins** to **build the change** in `vets-website`


### PR DESCRIPTION
## Description
Confirmed that the builds will not conflict, whichever is clicked first, will deploy first. In the screenshot attached a full build is in progress and you can see in the far left that a partial build is queued up behind it.

## Testing done
Asked Ops, and ran a physical test deploying a content-only build during a scheduled deploy.

## Screenshots

![09153e70-93de-4800-8271-fb46b3903a09](https://user-images.githubusercontent.com/459581/105373163-60ca5800-5bd4-11eb-9e38-3f73436dc61f.png)
