### PR TITLE
[Print view] Prepend website domain only when links start with "/"

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.13.0",
+  "version": "6.13.1",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/modules/_m-print.scss
+++ b/packages/formation/sass/modules/_m-print.scss
@@ -20,12 +20,12 @@
   }
 
   /* Relative URLs - include the HREF with the domain prepended */
-  a:not([href^="#"]):not([href^="tel"]):not([href^="http"]):after {
+  a[href^="/"]:after {
     content: " (https://www.va.gov" attr(href) ")";
   }
 
   /* Absolute URLs - show the HREF without prepending the domain. */
-  a[href^="tel"]:after, a[href^="http"]:after {
+  a[href^="http"]:after {
     content: " (" attr(href) ")";
   }
 }

--- a/packages/formation/sass/modules/_m-print.scss
+++ b/packages/formation/sass/modules/_m-print.scss
@@ -8,19 +8,24 @@
   header, footer, nav {
     display: none;
   }
-  
+
   .schemaform-title,
   .schemaform-subtitle,
   .screen-only {
     display: none;
   }
-  
+
   .print-only {
     display: block;
   }
-  
-  /* Include href when printing */
-  a:not([href^="tel"]):after {
-    content: " (https://va.gov" attr(href) ")";
+
+  /* Relative URLs - include the HREF with the domain prepended */
+  a:not([href^="#"]):not([href^="tel"]):not([href^="http"]):after {
+    content: " (https://www.va.gov" attr(href) ")";
+  }
+
+  /* Absolute URLs - show the HREF without prepending the domain. */
+  a[href^="tel"]:after, a[href^="http"]:after {
+    content: " (" attr(href) ")";
   }
 }


### PR DESCRIPTION
## Description
Currently, in print preview, we append `https://va.gov${href}` during print preview, so that the printed page still tells users where the links go. This PR does not debate whether we should really be doing that or not -  it's just fixing some obvious issues. See [Slack discussion](https://dsva.slack.com/archives/C7NJWUA8K/p1611093271006000) with design system council.

The issues this fixes are -
- Prepend the domain onto the HREF if the HREF starts with a leading `/`
- Show the plain HREF if the HREF starts with `http`

https://github.com/department-of-veterans-affairs/va.gov-team/issues/18337
## Testing done
Observed `/coronavirus-veteran-frequently-asked-questions/` using the ["print" render mode](https://stackoverflow.com/questions/9540990/using-chromes-element-inspector-in-print-preview-mode)

## Screenshots
#### Anchor links

##### Bug
![image](https://user-images.githubusercontent.com/1915775/105731170-21b24480-5efd-11eb-8aa4-203eceb9d112.png)

##### Fixed
![image](https://user-images.githubusercontent.com/1915775/105731303-49091180-5efd-11eb-8c12-cb5fd5e45c04.png)


#### Absolute URLs

##### Bug
![image](https://user-images.githubusercontent.com/1915775/105731231-3262ba80-5efd-11eb-9109-f32ec2000a80.png)

##### Fixed
![image](https://user-images.githubusercontent.com/1915775/105731372-57572d80-5efd-11eb-83ed-c78bec6226a3.png)


## Acceptance criteria
- [ ] Obvious issues with prepending the domain during print view are fixed

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
