### PR TITLE
Add docs for saveInProgress form restart options

### DIFF
--- a/packages/documentation/src/pages/forms/config-options.mdx
+++ b/packages/documentation/src/pages/forms/config-options.mdx
@@ -79,6 +79,11 @@ const formConfig = {
     noAuth: errorMessages.savedFormNoAuth,
   },
 
+  // Defaults to WIZARD_STATUS in 'applications/static-pages/wizard'. Added
+  // here if your form uses a unique sessionStorage key (currently only used by
+  // the save-in-progress component)
+  wizardStorageKey: 'wizardStatus',
+
   // Legacy SiP configuration such as savedFormMessages will be moved into saveInProgress.
   // All new SiP configuration will go here.
   saveInProgress: {
@@ -92,13 +97,11 @@ const formConfig = {
       saved: 'Your education benefits application has been saved.',
     },
     // *** Form restart-specific options ***
-    // Defaults to WIZARD_STATUS in 'applications/static-pages/wizard'. Added
-    // here if your form uses a unique sessionStorage key
-    restartWizardKey: 'wizardStatus',
-    // state parameter is either 'restarting' (from FormStartControls component)
-    // or 'restarted' (from RoutedSavableApp component)
-    // Return the destination route ('/' is the introduction page) or null to
-    // continue with the default behavior
+    // This callback is _only_ called by the RoutedSavableApp, so if the wizard
+    // is being rendered by the outer form App file, this callback won't work
+    // If the wizard is being rendered within the Intro page (like 0996 HLR),
+    // then have the function return either a destination route ('/' is the
+    // introduction page) or null to continue with the default behavior
     restartFormCallback: state => '/',
   },
   prefillEnabled: false,

--- a/packages/documentation/src/pages/forms/config-options.mdx
+++ b/packages/documentation/src/pages/forms/config-options.mdx
@@ -52,7 +52,7 @@ const formConfig = {
   //
   // Path to vets-api controller for form submission
   submitUrl: `${environment.API_URL}/v0/health_care_applications`,
-  
+
   // Function that is called upon form submission
   submit:  (form, formConfig) => {},
 
@@ -91,6 +91,15 @@ const formConfig = {
         'Your saved education benefits application (22-1995) has expired. If you want to apply for education benefits, please start a new application.',
       saved: 'Your education benefits application has been saved.',
     },
+    // *** Form restart-specific options ***
+    // Defaults to WIZARD_STATUS in 'applications/static-pages/wizard'. Added
+    // here if your form uses a unique sessionStorage key
+    restartWizardKey: 'wizardStatus',
+    // state parameter is either 'restarting' (from FormStartControls component)
+    // or 'restarted' (from RoutedSavableApp component)
+    // Return the destination route ('/' is the introduction page) or null to
+    // continue with the default behavior
+    restartFormCallback: state => '/',
   },
   prefillEnabled: false,
   downtime: {
@@ -144,7 +153,7 @@ const formConfig = {
     appType: 'order',
     appAction: 'placing your order',
   },
-  
+
   // The object that contains the configuration for each chapter.
   chapters: {
     // Each property is the key for a chapter.

--- a/packages/documentation/src/pages/forms/config-options.mdx
+++ b/packages/documentation/src/pages/forms/config-options.mdx
@@ -79,7 +79,7 @@ const formConfig = {
     noAuth: errorMessages.savedFormNoAuth,
   },
 
-  // Defaults to WIZARD_STATUS in 'applications/static-pages/wizard'. Added
+  // Defaults to WIZARD_STATUS in 'platform/site-wide/wizard'. Added
   // here if your form uses a unique sessionStorage key (currently only used by
   // the save-in-progress component)
   wizardStorageKey: 'wizardStatus',
@@ -100,8 +100,8 @@ const formConfig = {
     // This callback is _only_ called by the RoutedSavableApp, so if the wizard
     // is being rendered by the outer form App file, this callback won't work
     // If the wizard is being rendered within the Intro page (like 0996 HLR),
-    // then have the function return either a destination route ('/' is the
-    // introduction page) or null to continue with the default behavior
+    // then have the function return a destination route ('/' is the
+    // introduction page)
     restartFormCallback: state => '/',
   },
   prefillEnabled: false,

--- a/packages/documentation/src/pages/forms/save-in-progress.mdx
+++ b/packages/documentation/src/pages/forms/save-in-progress.mdx
@@ -21,9 +21,22 @@ const formConfig = {
   formId: '1010ez',
   version: 0,
   prefillEnabled: true,
+  // include this storage key only if you're form has a wizard
+  wizardStorageKey: 'wizardStatus', // sessionStorage key for the wizard
   savedFormMessages: {
     notFound: 'Please start over to apply for health care.',
     noAuth: 'Please sign in again to resume your application for health care.'
+  },
+  saveInProgress: {
+    messages: {
+      inProgress:
+        'Your ___ application (XX-XXXX) is in progress.',
+      expired:
+        'Your saved ___ application (XX-XXXX) has expired. If you want to apply for ___, please start a new application.',
+      saved: 'Your ___ application has been saved.',
+    },
+    // return restart destination url
+    restartFormCallback: () => '/', // introduction page
   },
   ...
 }
@@ -32,6 +45,8 @@ const formConfig = {
 This is from our health care application. The most important piece of information is `formId`, which is the key that will be used to save the form data on the backend. Once you choose this, you can't change it in production. We also set a version, typically to 0, which can be incremented if you need to migrate form data in production.
 
 There are also a couple of messages you can set, which show up in various places on the form (primarily on the intro page).
+
+See [form wizard](/forms/wizard) for more details on setting up the wizards and its options.
 
 ## User profile
 

--- a/packages/documentation/src/pages/forms/wizard.mdx
+++ b/packages/documentation/src/pages/forms/wizard.mdx
@@ -1,0 +1,171 @@
+---
+title: Setting up a form wizard
+---
+
+# Setting up a form wizard
+
+## Product details
+
+The design system [wizard pattern documentation](https://design.va.gov/patterns/wizards) provides a general overview of how the wizard should look and work.
+
+More details can be found in these documents:
+
+- Product: https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/public-websites/how-to-apply-wizards
+- [IA documentation](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/information-architecture/ia-reviews/websites-apply-wizard.md) for implementation teams; also includes some UX documenation
+- Additional UX guidance captured in [UXPin documentation](https://preview.uxpin.com/ca08f3dbf63475b2b62f3e8c00050ad1b19c4cb5#/pages/132986657/documentation/no-panels?mode=i) (using Edu flow as an example)
+- Content outlines of wizard user flows
+    - [Education wizard content outline](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/public-websites/how-to-apply-wizards/content-outlines/education-forms-wizard.md)
+- [Usability Study Synthesis](https://github.com/department-of-veterans-affairs/va.gov-team/files/5548107/Wizard.Migration.Usability.Study.Synthesis.pdf)
+- Analytics: https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/analytics/google-analytics/tracking-how-to-wizards.md
+
+## File structure
+
+There isn't a provided template for the wizard, but you can copy the `wizard`
+folder from any of the forms that include one. Given that, this will only be a
+brief review of how to setup the wizard
+
+A `wizard` folder is usually added under the form root folder.
+
+```
+form
+|_ ...
+|_ wizard
+   |_ WizardContainer.jsx
+   |_ WizardLink.jsx
+   |_ /pages
+      |_ index.js (returns an array of all pages)
+      |_ start.jsx (usually named after wizard nodes)
+      |_ ... (other pages)
+```
+
+Within this folder are a `WizardContainer` which renders the content surrounding
+the actual `Wizard` component. A `WizardLink` may be found if the info page needs
+to render a link to the start of your form conditionally (behind a feature flag).
+
+Each wizard page file (not the `index.js`), _must_ export the following object
+which ends up in the array exported by the index.
+
+```js
+export default {
+  name: 'component-name',
+  component: Component,
+};
+```
+
+Each page will most likely contain analytics events, see the link in the product
+details section.
+
+## Setup
+
+Set up the files as described in the previous section.
+
+There is a difference if you decide to render the wizard on either the
+Introduction page, or in the `FormApp` wrapper.
+
+### Render wizard in the Intro page
+
+In the `formConfig` (`config/form.js`), ensure a `wizardStorageKey` is included.
+It should be unique (recomended), and match the `sessionStorage` key used by
+whatever method is used to show or hide the wizard on the intro page.
+
+In the `formConfig` set up a `restartFormCallback` option inside the
+`saveInProgress` settings. Set it as a function that returns a URL destination.
+Most likely it will return `'/'`, which targets the introduction page.
+
+```js
+const formConfig = {
+  // ...
+  wizardStorageKey: 'wizardStatus',
+  saveInProgress: {
+    // return restart destination url; only needed if wizard rendered by Intro
+    restartFormCallback: () => '/', // introduction page
+  },
+  // ...
+};
+```
+
+### Render wizard in the App file
+
+If the wizard is rendered by the main `FormApp.jsx` wrapper, then you'll need to
+check if the form has restarted (using `restartShouldRedirect` helper function),
+then push the restart destination URL to the router
+
+`App.jsx` (example code)
+
+```js
+import WizardContainer from './containers/WizardContainer';
+import { WIZARD_STATUS } from './constants'; // should be unique to the form
+import {
+  WIZARD_STATUS_NOT_STARTED,
+  WIZARD_STATUS_COMPLETE,
+  WIZARD_STATUS_RESTARTED,
+  restartShouldRedirect,
+} from 'applications/static-pages/wizard';
+
+export const FormEntry = ({
+  const [wizardState, setWizardState] = useState(
+    sessionStorage.getItem(WIZARD_STATUS) || WIZARD_STATUS_NOT_STARTED
+  );
+
+  const hasRestarted = () => {
+    setWizardStatus(WIZARD_STATUS_RESTARTED);
+    sessionStorage.setItem(WIZARD_STATUS, value);
+    router.push('/');
+  };
+
+  // ...
+  useEffect(() => {
+    if (restartShouldRedirect(WIZARD_STATUS)) {
+      hasRestarted();
+    }
+    // ...
+  });
+
+  if (wizardState !== WIZARD_STATUS_COMPLETE) {
+    return <WizardContainer />;
+  }
+  // ...
+});
+```
+
+The `formConfig` will also require the wizard status setting so that the form
+restart link properly adjusts the session storage value.
+
+```js
+const formConfig = {
+  // ...
+  wizardStorageKey: 'wizardStatus',
+  // ...
+};
+```
+
+A `restartFormCallback` is not set in this case because we're handling it in the
+app.
+
+
+### Application status
+
+A component to render the `ApplicationStatus` is also contained somewhere within
+the form files. A static page component imports and injects the application
+status component into the form's info page. Within this component are two
+buttons which allow the user to either continue or restart the application.
+
+Too ensure the wizard is properly handled when restarting (clear the wizard
+state) or continuing (set the wizard state to complete), we need to provide the
+`WIZARD_STATUS` session storage key to the component
+
+```js
+<ApplicationStatus
+  formIds="XX-XXXX"
+  formType="What this form does"
+  wizardStatus={WIZARD_STATUS}
+  // ...
+/>
+```
+
+## Tasks
+
+- [ ] Match design spec
+- [ ] Verify wizard flow per [IA documenation](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/information-architecture/ia-reviews/websites-apply-wizard.md)
+- [ ] Ensure [analytics implementation spec](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/analytics/google-analytics/tracking-how-to-wizards.md) is followed
+- [ ] Add unit/e2e tests

--- a/packages/documentation/src/pages/forms/wizard.mdx
+++ b/packages/documentation/src/pages/forms/wizard.mdx
@@ -104,7 +104,7 @@ import {
   WIZARD_STATUS_COMPLETE,
   WIZARD_STATUS_RESTARTED,
   restartShouldRedirect,
-} from 'applications/static-pages/wizard';
+} from 'platform/site-wide/wizard';
 
 export const FormEntry = ({
   const [wizardState, setWizardState] = useState(

--- a/packages/documentation/src/pages/forms/wizard.mdx
+++ b/packages/documentation/src/pages/forms/wizard.mdx
@@ -1,8 +1,8 @@
 ---
-title: Setting up a form wizard
+title: Form wizard
 ---
 
-# Setting up a form wizard
+# Form wizard
 
 ## Product details
 
@@ -29,21 +29,25 @@ A `wizard` folder is usually added under the form root folder.
 ```
 form
 |_ ...
+|_ components
+|  |_ createApplicationStatus.jsx
 |_ wizard
    |_ WizardContainer.jsx
    |_ WizardLink.jsx
-   |_ /pages
+   |_ pages
       |_ index.js (returns an array of all pages)
-      |_ start.jsx (usually named after wizard nodes)
-      |_ ... (other pages)
+      |_ start.jsx (or whatever you name the first page)
+      |_ ... (other pages; usually named after wizard nodes)
 ```
 
 Within this folder are a `WizardContainer` which renders the content surrounding
 the actual `Wizard` component. A `WizardLink` may be found if the info page needs
 to render a link to the start of your form conditionally (behind a feature flag).
 
-Each wizard page file (not the `index.js`), _must_ export the following object
-which ends up in the array exported by the index.
+Within the `pages` folder, are pages that represent each wizard node. The
+`index.js` imports all the pages and exports an array with the first entry being
+the wizard start page. Each page file _must_ export the following object which
+contains the page name and component.
 
 ```js
 export default {
@@ -52,8 +56,8 @@ export default {
 };
 ```
 
-Each page will most likely contain analytics events, see the link in the product
-details section.
+Each page will likely contain analytics events. More details can be found in the
+[wizard analytics spec](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/analytics/google-analytics/tracking-how-to-wizards.md).
 
 ## Setup
 
@@ -145,10 +149,11 @@ app.
 
 ### Application status
 
-A component to render the `ApplicationStatus` is also contained somewhere within
-the form files. A static page component imports and injects the application
-status component into the form's info page. Within this component are two
-buttons which allow the user to either continue or restart the application.
+A component (see `createApplicationStatus` in the file structure section) to
+render the `ApplicationStatus` is also contained somewhere within the form
+files. A static page component imports and injects the application status
+component into the form's info page. Within this component are two buttons which
+allow the user to either continue or restart the application.
 
 Too ensure the wizard is properly handled when restarting (clear the wizard
 state) or continuing (set the wizard state to complete), we need to provide the

--- a/packages/documentation/src/sidebar.js
+++ b/packages/documentation/src/sidebar.js
@@ -173,6 +173,10 @@ module.exports = {
               href: '/forms/available-features-and-usage-guidelines',
             },
             {
+              name: 'Form wizard',
+              href: '/forms/wizard',
+            },
+            {
               name: 'Using available fields',
               href: '/forms/using-available-fields',
             },


### PR DESCRIPTION
## Description

Adding documentation for the two save-in-progress form restart options. These options allow you to add a custom form wizard session storage key & choose a target destination page upon manually restarting a form.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/13814
- https://github.com/department-of-veterans-affairs/vets-website/pull/15821

## Testing done

N/A - doc update

## Screenshots

N/A

## Acceptance criteria
- [x] Provide documentation for the `restartWizardKey` & `restartFormCallback` options added to the form config save-in-progress object

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
