### PR TITLE
Update date widget css

### DIFF
--- a/packages/formation/sass/_shame.scss
+++ b/packages/formation/sass/_shame.scss
@@ -85,7 +85,6 @@ body {
 .usa-input-error {
   select {
     border: 3px solid $color-secondary-dark;
-    width: calc(100% + 1.5rem);
   }
 }
 

--- a/packages/formation/sass/modules/_m-form-elements.scss
+++ b/packages/formation/sass/modules/_m-form-elements.scss
@@ -115,6 +115,13 @@ button.form-button-disabled {
   margin-top: 0;
 }
 
+// override width set to calc(100% + 1.9rem) for dates
+.usa-input-error.form-error-date {
+  input, select {
+    width: 100%;
+  }
+}
+
 @include media($medium-large-screen) {
   .form-select-medium {
     max-width: 12rem;

--- a/packages/formation/sass/modules/_m-form-elements.scss
+++ b/packages/formation/sass/modules/_m-form-elements.scss
@@ -55,7 +55,7 @@ button.form-button-disabled {
 }
 
 .form-datefield-month {
-  width: 10rem;
+  width: 12rem;
 }
 
 .form-datefield-day {


### PR DESCRIPTION
## Description

This PR fixes two issues with the date widget:

- The full month name is now contained within the month select, but the `10rem` width isn't adequate for longer month names. Increased to `12rem`.
- Error states change the width of the form elements in two areas:
  - Selects were set to `calc(100% + 1.5rem)` in the formation styling - removed
  - USWDS styles sets an error state of the select and input to `calc(100% + 1.9rem)` - overridden by higher-specificity selectors

Related:
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/394
- https://github.com/department-of-veterans-affairs/vets-website/pull/15935#discussion_r570664989
- https://github.com/department-of-veterans-affairs/vets-website/pull/15935#discussion_r573985356

## Testing done

Visual only

## Screenshots

![Screen Shot 2021-02-10 at 2 46 10 PM](https://user-images.githubusercontent.com/136959/107571087-05c2ca00-6bb0-11eb-8432-c6e0e3205e7c.png)

## Acceptance criteria
- [x] Date widget (Month, day & year) elements maintain their error state width
- [x] Month select width is adjusted to allow for longer month names

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
