### PR TITLE
bumped up from size on <pre>

### DIFF
--- a/packages/documentation/src/scss/_code.scss
+++ b/packages/documentation/src/scss/_code.scss
@@ -3,7 +3,7 @@ pre {
   margin-right: 0;
   margin-top: 1.45rem;
   margin-bottom: 1.45rem;
-  font-size: 0.85rem;
+  font-size: 1.35rem;
   line-height: 1.42;
   background: hsla(0, 0%, 0%, 0.04);
   border-radius: 3px;


### PR DESCRIPTION
## Description
The font size on pre element is pretty small, I just updated it.

## Screenshots

Before:
 
<img width="432" alt="Screen Shot 2021-02-11 at 3 48 43 PM" src="https://user-images.githubusercontent.com/459581/107697017-ab456e80-6c80-11eb-9327-f8f6691dc5b3.png">

After:

<img width="421" alt="Screen Shot 2021-02-11 at 3 48 35 PM" src="https://user-images.githubusercontent.com/459581/107697021-ae405f00-6c80-11eb-8602-ba66cfebed7d.png">

