### PR TITLE
[Process List] Remove font-size style rule

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.14.0",
+  "version": "6.14.1",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/modules/_m-process-list.scss
+++ b/packages/formation/sass/modules/_m-process-list.scss
@@ -14,7 +14,6 @@
 
   h2, h3, h4, h5 {
     margin-top: 0;
-    font-size: $h4-font-size;
     clear: none;
     padding-top: 0.3em;
   }


### PR DESCRIPTION
## Description
This PR removed the font-size style rule from headings inside of process lists so that heading hierarchies are distinguishable visually.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/7770

## Testing done
Pointed my local website at the SCSS file being edited. Tested against `/decision-reviews/supplemental-claim/`

## Screenshots
Tested against `/decision-reviews/supplemental-claim/`

### Problem
Since H4s have the same font-size as H3s inside of process lists we have to use `<strong>` tags instead to help distinguish the content them visually.  This looks fine but produces a screen-reader error because the strong tag doesn't carry meaning like a heading does.

![image](https://user-images.githubusercontent.com/1915775/112052058-07759b00-8b29-11eb-91e2-4ffeeb8b6593.png)

### Solution
We should just remove the font-size declaration from the SCSS for headings inside of process lists. The style w/o that rule still looks good. 

![image](https://user-images.githubusercontent.com/1915775/112053829-3bea5680-8b2b-11eb-956b-d877bdbad508.png)


## Acceptance criteria
- [x] Heading tags inside of process lists are distinguishable visually

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
