### PR TITLE
Add styles for white action link

### DIFF
--- a/packages/formation/sass/base/_b-mixins.scss
+++ b/packages/formation/sass/base/_b-mixins.scss
@@ -102,6 +102,18 @@
   @include focus-gold-light-outline;
 }
 
+@mixin color-transition {
+  -webkit-transition-duration: 0.3s;
+    transition-duration: 0.3s;
+
+  -webkit-transition-timing-function: ease-in-out;
+  transition-timing-function: ease-in-out;
+
+  // Transition only these properties.
+  -webkit-transition-property: color, background-color, border-color;
+  transition-property: color, background-color, border-color;
+}
+
 @mixin linear-gradient-background($from, $to) {
   background: $from; /* Old browsers */
   background: -moz-linear-gradient(top, $from 0%, $to 63%); /* FF3.6-15 */
@@ -135,15 +147,7 @@
     color: $color-link-default;
     text-decoration: underline;
     background-color: $color-link-default-hover !important;
-    -webkit-transition-duration: 0.3s;
-    transition-duration: 0.3s;
-
-    -webkit-transition-timing-function: ease-in-out;
-    transition-timing-function: ease-in-out;
-
-    // Transition only these properties.
-    -webkit-transition-property: color, background-color, border-color;
-    transition-property: color, background-color, border-color;
+    @include color-transition;
   }
   &:active {
     background: $color-link-default-hover;

--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -81,16 +81,7 @@ abbr {
 a {
   color: $color-link-default;
   text-decoration: underline;
-
-  -webkit-transition-duration: 0.3s;
-  transition-duration: 0.3s;
-
-  -webkit-transition-timing-function: ease-in-out;
-  transition-timing-function: ease-in-out;
-
-  // Transition only these properties.
-  -webkit-transition-property: color, background-color, border-color;
-  transition-property: color, background-color, border-color;
+  @include color-transition;
 
   &:hover {
     background-color: $color-link-default-hover;

--- a/packages/formation/sass/modules/_m-action-link.scss
+++ b/packages/formation/sass/modules/_m-action-link.scss
@@ -1,4 +1,4 @@
-a.va-action-link--blue, a.va-action-link--green {
+a.va-action-link--blue, a.va-action-link--green, a.va-action-link--white {
   &:before {
     font-family: "Font Awesome 5 Free";
     font-weight: 900;
@@ -19,4 +19,22 @@ a.va-action-link--blue:before {
 
 a.va-action-link--green:before {
   color: $color-green;
+}
+
+a.va-action-link--white {
+  color: $color-white;
+
+  &:before {
+    color: $color-white;
+    @include color-transition;
+  }
+}
+
+a.va-action-link--white:hover {
+  color: $color-gold-light;
+  background-color: transparent;
+
+  &:before {
+    color: $color-gold-light;
+  }
 }

--- a/packages/formation/sass/modules/_m-button.scss
+++ b/packages/formation/sass/modules/_m-button.scss
@@ -70,16 +70,7 @@ button.short {
   line-height: 1.3;
   margin: 0;
   text-align: left;
-
-  -webkit-transition-duration: 0.3s;
-          transition-duration: 0.3s;
-
-  -webkit-transition-timing-function: ease-in-out;
-          transition-timing-function: ease-in-out;
-
-  // Transition only these properties.
-  -webkit-transition-property: color, background-color, border-color;
-          transition-property: color, background-color, border-color;
+  @include color-transition;
 
   white-space: nowrap;
 


### PR DESCRIPTION
## Description
Adds styles for the white action link
https://app.zenhub.com/workspaces/vsp-design-system-5f8de67192551b0012ebb802/issues/department-of-veterans-affairs/va.gov-team/22151

Also adds mixin for color transition.

## Testing done
Visual testing using the `feat/22151--white-action-link` branch on [component-library](https://github.com/department-of-veterans-affairs/component-library/pull/71)

## Screenshots
<img width="459" alt="image" src="https://user-images.githubusercontent.com/12739849/113334747-0f37fb00-92f2-11eb-8c0c-67e1c611ef5a.png">

![white-link-hover](https://user-images.githubusercontent.com/12739849/113335933-a5b8ec00-92f3-11eb-9be8-147adc36a476.gif)


## Acceptance criteria
- [ ] White action link is styled and behaves as detailed at https://design.va.gov/components/action-links

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
