### PR TITLE
Add `selectedProps` documentation

### DIFF
--- a/packages/documentation/src/pages/forms/available-features-and-usage-guidelines.mdx
+++ b/packages/documentation/src/pages/forms/available-features-and-usage-guidelines.mdx
@@ -367,8 +367,8 @@ Your config file might look like this:
       'ui:widget': 'yesNo',
       'ui:options': {
         widgetProps: {
-          Y: { 'aria-describedby': 'some_id' },
-          N: { 'aria-describedby': 'different_id' },
+          Y: { 'data-info': 'yes' },
+          N: { 'data-info': 'no' },
         },
         // Only added to the radio when it is selected
         // a11y requirement: aria-describedby ID's *must* exist on the page; and

--- a/packages/documentation/src/pages/forms/available-features-and-usage-guidelines.mdx
+++ b/packages/documentation/src/pages/forms/available-features-and-usage-guidelines.mdx
@@ -188,6 +188,15 @@ uiSchema: {
       sloth: 'Sloth'
     },
     widgetProps: {
+      dog: { 'data-info': 'dog_1' },
+      cat: { 'data-info': 'cat_2' },
+      octopus: { 'data-info': 'octopus_3' },
+      sloth: { 'data-info': 'sloth_4' },
+    },
+    // Only added to the radio when it is selected
+    // a11y requirement: aria-describedby ID's *must* exist on the page; and we
+    // conditionally add content based on the selection
+    selectedProps: {
       dog: { 'aria-describedby': 'some_id_1' },
       cat: { 'aria-describedby': 'some_id_2' },
       octopus: { 'aria-describedby': 'some_id_3' },
@@ -358,6 +367,13 @@ Your config file might look like this:
       'ui:widget': 'yesNo',
       'ui:options': {
         widgetProps: {
+          Y: { 'aria-describedby': 'some_id' },
+          N: { 'aria-describedby': 'different_id' },
+        },
+        // Only added to the radio when it is selected
+        // a11y requirement: aria-describedby ID's *must* exist on the page; and
+        // we conditionally add content based on the selection
+        selectedProps: {
           Y: { 'aria-describedby': 'some_id' },
           N: { 'aria-describedby': 'different_id' },
         }

--- a/packages/documentation/src/pages/forms/available-widgets.mdx
+++ b/packages/documentation/src/pages/forms/available-widgets.mdx
@@ -85,7 +85,7 @@ Renders a `TextWidget` with additional logic to strip non-numeric characters fro
 Renders a single radio button for each `enum` value. This overrides the default `SelectWidget` that is normally rendered where `enum` exists.
 
 - **File:** [RadioWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/widgets/RadioWidget.jsx)
-- **Usage:** In the `uiSchema`, specify `'ui:widget': 'radio'` for the given field. Usually used with `'ui:options': { labels: {}}` so you can specify the label for each radio button. To see a code example, refer to [radio button group in form features](/forms/available-features-and-usage-guidelines#radio-button-group). Include additional properties on the radio input by including `widgetProps` within the `ui:options`; the key for each input will match the custom option values.
+- **Usage:** In the `uiSchema`, specify `'ui:widget': 'radio'` for the given field. Usually used with `'ui:options': { labels: {}}` so you can specify the label for each radio button. To see a code example, refer to [radio button group in form features](/forms/available-features-and-usage-guidelines#radio-button-group). Include additional properties on the radio input by including `widgetProps` and `selectedProps` within the `ui:options`; the key for each input will match the custom option values.
 
 ## `SelectWidget`
 
@@ -113,5 +113,5 @@ Renders a `<input>` HTML element, and is the default widget for data of `type: '
 Renders two radio buttons, one with a value of "Yes" and one with a value of "No".
 
 - **File:** [YesNoWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/widgets/YesNoWidget.jsx)
-- **Usage:** In the `uiSchema`, specify `'ui:widget': 'yesNo'` for the given field. Include additional properties on the radio input by including `widgetProps` within the `ui:options`; the key for each input will match the option values of `Y` and `N`.
+- **Usage:** In the `uiSchema`, specify `'ui:widget': 'yesNo'` for the given field. Include additional properties on the radio input by including `widgetProps` and `selectedProps` within the `ui:options`; the key for each input will match the option values of `Y` and `N`.
 

--- a/packages/documentation/src/pages/forms/form-tutorial-advanced.mdx
+++ b/packages/documentation/src/pages/forms/form-tutorial-advanced.mdx
@@ -146,6 +146,13 @@ const formConfig = {
             widgetProps: {
               Y: { 'aria-describedby': 'some_id' },
               N: { 'aria-describedby': 'different_id' },
+            },
+            // Only added to the radio when it is selected
+            // a11y requirement: aria-describedby ID's *must* exist on the page;
+            // and we conditionally add content based on the selection
+            selectedProps: {
+              Y: { 'aria-describedby': 'some_id' },
+              N: { 'aria-describedby': 'different_id' },
             }
           }
         },

--- a/packages/documentation/src/pages/forms/form-tutorial-advanced.mdx
+++ b/packages/documentation/src/pages/forms/form-tutorial-advanced.mdx
@@ -144,8 +144,8 @@ const formConfig = {
               N: 'No, I do not want this',
             },
             widgetProps: {
-              Y: { 'aria-describedby': 'some_id' },
-              N: { 'aria-describedby': 'different_id' },
+              Y: { 'data-info': 'yes' },
+              N: { 'data-info': 'no' },
             },
             // Only added to the radio when it is selected
             // a11y requirement: aria-describedby ID's *must* exist on the page;

--- a/packages/documentation/src/pages/forms/form-tutorial-basic.mdx
+++ b/packages/documentation/src/pages/forms/form-tutorial-basic.mdx
@@ -199,8 +199,15 @@ page1: {
       'ui:widget': 'radio',
       'ui:options': {
         widgetProps: {
+          'First option': { 'data-info': 'first_1' },
+          'Second option': { 'data-info': 'second_2' }
+        },
+        // Only added to the radio when it is selected
+        // a11y requirement: aria-describedby ID's *must* exist on the page;
+        // and we conditionally add content based on the selection
+        selectedProps:  {
           'First option': { 'aria-describedby': 'some_id_1' },
-          'Second option': { 'aria-describedby': 'some_id_2' },
+          'Second option': { 'aria-describedby': 'some_id_2' }
         }
       }
     }

--- a/packages/documentation/src/pages/forms/form-tutorial-intermediate.mdx
+++ b/packages/documentation/src/pages/forms/form-tutorial-intermediate.mdx
@@ -275,8 +275,8 @@ page1: {
           N: 'No, I do not want this',
         },
         widgetProps: {
-          Y: { 'aria-describedby': 'some_id' },
-          N: { 'aria-describedby': 'different_id' }
+          Y: { 'data-info': 'yes' },
+          N: { 'data-info': 'no' }
         },
         // Only added to the radio when it is selected
         // a11y requirement: aria-describedby ID's *must* exist on the page;

--- a/packages/documentation/src/pages/forms/form-tutorial-intermediate.mdx
+++ b/packages/documentation/src/pages/forms/form-tutorial-intermediate.mdx
@@ -168,8 +168,8 @@ page1: {
           N: 'No, I do not want this',
         },
         widgetProps: {
-          Y: { 'aria-describedby': 'some_id' },
-          N: { 'aria-describedby': 'different_id' }
+          Y: { 'data-info': 'yes' },
+          N: { 'data-info': 'no' }
         },
         // Only added to the radio when it is selected
         // a11y requirement: aria-describedby ID's *must* exist on the page;
@@ -221,8 +221,8 @@ page1: {
           N: 'No, I do not want this',
         },
         widgetProps: {
-          Y: { 'aria-describedby': 'some_id' },
-          N: { 'aria-describedby': 'different_id' }
+          Y: { 'data-info': 'yes' },
+          N: { 'data-info': 'no' }
         },
         // Only added to the radio when it is selected
         // a11y requirement: aria-describedby ID's *must* exist on the page;

--- a/packages/documentation/src/pages/forms/form-tutorial-intermediate.mdx
+++ b/packages/documentation/src/pages/forms/form-tutorial-intermediate.mdx
@@ -169,7 +169,14 @@ page1: {
         },
         widgetProps: {
           Y: { 'aria-describedby': 'some_id' },
-          N: { 'aria-describedby': 'different_id' },
+          N: { 'aria-describedby': 'different_id' }
+        },
+        // Only added to the radio when it is selected
+        // a11y requirement: aria-describedby ID's *must* exist on the page;
+        // and we conditionally add content based on the selection
+        selectedProps: {
+          Y: { 'aria-describedby': 'some_id' },
+          N: { 'aria-describedby': 'different_id' }
         }
       }
     },
@@ -215,7 +222,14 @@ page1: {
         },
         widgetProps: {
           Y: { 'aria-describedby': 'some_id' },
-          N: { 'aria-describedby': 'different_id' },
+          N: { 'aria-describedby': 'different_id' }
+        },
+        // Only added to the radio when it is selected
+        // a11y requirement: aria-describedby ID's *must* exist on the page;
+        // and we conditionally add content based on the selection
+        selectedProps: {
+          Y: { 'aria-describedby': 'some_id' },
+          N: { 'aria-describedby': 'different_id' }
         }
       }
     },
@@ -262,7 +276,14 @@ page1: {
         },
         widgetProps: {
           Y: { 'aria-describedby': 'some_id' },
-          N: { 'aria-describedby': 'different_id' },
+          N: { 'aria-describedby': 'different_id' }
+        },
+        // Only added to the radio when it is selected
+        // a11y requirement: aria-describedby ID's *must* exist on the page;
+        // and we conditionally add content based on the selection
+        selectedProps: {
+          Y: { 'aria-describedby': 'some_id' },
+          N: { 'aria-describedby': 'different_id' }
         }
       }
     }


### PR DESCRIPTION
## Description

Add documentation for the `selectedProps` `ui:option` - specific to the `RadioWidget` and `YesNoWidget`

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/19733
- https://github.com/department-of-veterans-affairs/vets-website/pull/16641

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] Documentation updated

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
