### PR TITLE
Increase width of month select box

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.15.1",
+  "version": "6.15.2",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/modules/_m-form-elements.scss
+++ b/packages/formation/sass/modules/_m-form-elements.scss
@@ -55,7 +55,7 @@ button.form-button-disabled {
 }
 
 .form-datefield-month {
-  width: 12rem;
+  width: 13rem;
 }
 
 .form-datefield-day {


### PR DESCRIPTION
## Description
Closes https://app.zenhub.com/workspaces/vsp-design-system-5f8de67192551b0012ebb802/issues/department-of-veterans-affairs/va.gov-team/20546

## Testing done
Manual. Linked to vets-website and checked form to make sure width was enough to account for longer month names.

To test:
- [ ] pull down this branch locally and run `yarn build` inside the `packages/formation` directory
- [ ] run `yarn link` inside the `packages/formation` director
- [ ] In a separate terminal window, navigate to your local vets-website project directory (this should be a sibling directory to your veteran-facing-services-tools project directory) and run `yarn link "@department-of-veterans-affairs/formation"`
- [ ] Run `yarn watch` to start up the vets-website project
- [ ] Go to http://localhost:3001/ask-a-question/veteran-information
- [ ] Check that the width of the month select box is 13rem and that the months "September", "November", and "December" appear without being cut off at all.

## Screenshots
Before:
<img width="138" alt="image" src="https://user-images.githubusercontent.com/12739849/114566570-6b7b1300-9c40-11eb-938e-7461e45f36c8.png">

After:
<img width="351" alt="image" src="https://user-images.githubusercontent.com/12739849/114566625-759d1180-9c40-11eb-8c84-7a2ce4b14892.png">

## Acceptance criteria
- [ ] Month select box should be wide enough to account for longer month names

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
