### PR TITLE
Remove the horizontal padding for action links

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.16.0",
+  "version": "6.16.1",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/modules/_m-action-link.scss
+++ b/packages/formation/sass/modules/_m-action-link.scss
@@ -10,7 +10,7 @@ a.vads-c-action-link--blue, a.vads-c-action-link--green, a.vads-c-action-link--w
     height: 0px; // So the height doesn't mess with the focus halo
   }
   font-weight: bold;
-  padding: 8px;
+  padding: 8px 0px;
 }
 
 a.vads-c-action-link--blue:before {


### PR DESCRIPTION
## Description
To align the link vertically, this removes the horizontal padding. Crystabel brought it to my attention in [this Slack thread](https://dsva.slack.com/archives/G01BJ3ESXL4/p1618432757012100).

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/114787854-461c0100-9d35-11eb-9aab-b964e663b9d3.png)
Note how the darkened background doesn't extend to the sides of the link on hover.