### PR TITLE
Update creating release documentation

### DIFF
--- a/packages/documentation/src/pages/getting-started/workflow/deploy.mdx
+++ b/packages/documentation/src/pages/getting-started/workflow/deploy.mdx
@@ -84,6 +84,7 @@ If the commit you are trying to release to does not have an official release tag
 8. You should now see it in the [vets-website release log](https://github.com/department-of-veterans-affairs/vets-website/releases) and can follow the normal rollback steps.
 
 This should create a new release, and deploy it to va.gov.
+**Note:** Verify that there are no scheduled content releases around the time of creating a release. A following release can override your manual release if started before your release has finished.
 
 ## Hotfixes
 

--- a/packages/documentation/src/pages/getting-started/workflow/deploy.mdx
+++ b/packages/documentation/src/pages/getting-started/workflow/deploy.mdx
@@ -85,7 +85,7 @@ If the commit you are trying to release to does not have an official release tag
 
 This should create a new release, and deploy it to va.gov.
 
-**Note:** Verify that there are no scheduled [content releases](http://jenkins.vfs.va.gov/job/deploys/job/vets-website-content-autodeploy/) around the time of creating a release. A following release can override your manual release if started before your release has finished.
+**Note:** Verify that there are no [scheduled](#automated-deployment-schedule) [content releases](http://jenkins.vfs.va.gov/job/deploys/job/vets-website-content-autodeploy/) around the time of creating a release. A following release can override your manual release if started before your release has finished.
 
 ## Hotfixes
 

--- a/packages/documentation/src/pages/getting-started/workflow/deploy.mdx
+++ b/packages/documentation/src/pages/getting-started/workflow/deploy.mdx
@@ -84,6 +84,7 @@ If the commit you are trying to release to does not have an official release tag
 8. You should now see it in the [vets-website release log](https://github.com/department-of-veterans-affairs/vets-website/releases) and can follow the normal rollback steps.
 
 This should create a new release, and deploy it to va.gov.
+
 **Note:** Verify that there are no scheduled content releases around the time of creating a release. A following release can override your manual release if started before your release has finished.
 
 ## Hotfixes

--- a/packages/documentation/src/pages/getting-started/workflow/deploy.mdx
+++ b/packages/documentation/src/pages/getting-started/workflow/deploy.mdx
@@ -85,7 +85,7 @@ If the commit you are trying to release to does not have an official release tag
 
 This should create a new release, and deploy it to va.gov.
 
-**Note:** Verify that there are no scheduled content releases around the time of creating a release. A following release can override your manual release if started before your release has finished.
+**Note:** Verify that there are no scheduled [content releases](http://jenkins.vfs.va.gov/job/deploys/job/vets-website-content-autodeploy/) around the time of creating a release. A following release can override your manual release if started before your release has finished.
 
 ## Hotfixes
 


### PR DESCRIPTION
## Description
Add a note to the _Creating a Release_ section about  potential overriding releases.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
