### PR TITLE
Fix 'ui:validations' name in docs

### DIFF
--- a/packages/documentation/src/pages/forms/form-tutorial-intermediate.mdx
+++ b/packages/documentation/src/pages/forms/form-tutorial-intermediate.mdx
@@ -20,7 +20,7 @@ page1: {
   uiSchema: {
     myField: {
       'ui:title': 'My field label',
-      'ui:validation': [
+      'ui:validations': [
         (errors, field) => {
           if (field && field.startsWith('bad')) {
             errors.addError("Sorry, you can't start this field with 'bad'");
@@ -56,7 +56,7 @@ page1: {
     confirmEmail: {
       'ui:title': 'Confirm email'
     },
-    'ui:validation': [
+    'ui:validations': [
       (errors, field) => {
         if (field.email !== field.confirmEmail) {
           errors.confirmEmail.addError('Sorry, your emails must match');


### PR DESCRIPTION
## Description

The docs are showing a validation example using `ui:validation` instead of `ui:validations`.

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] Docs updated to use `ui:validations`

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
