### PR TITLE
Fix small typo on platform info page

### DIFF
--- a/packages/documentation/src/pages/platform/index.mdx
+++ b/packages/documentation/src/pages/platform/index.mdx
@@ -30,4 +30,4 @@ Drupal content is retrieved via GraphQL and pushed into the Metalsmith pipeline 
 where it is then transformed into static html pages using Liquid templates.
 
 ### TeamSite
-TeamSite is a content management system built with PERL. This is the original system VA.gov was built on. Vets.gov and VA.gov were merged and needed to be integrated to use both systems without feeling like different systems. Some webpages still live under TeamSite and will eventually get ported over into the new Platform. Some components are shared such as the the MegaMenu adn the Footer. These components are injected using a script to render on TeamSite pages.
+TeamSite is a content management system built with PERL. This is the original system VA.gov was built on. Vets.gov and VA.gov were merged and needed to be integrated to use both systems without feeling like different systems. Some webpages still live under TeamSite and will eventually get ported over into the new Platform. Some components are shared such as the the MegaMenu and the Footer. These components are injected using a script to render on TeamSite pages.


### PR DESCRIPTION
## Description
Fixes a small typo: `adn`->`and`