### PR TITLE
Added revproxy deployment docs

### DIFF
--- a/packages/documentation/src/pages/platform/architecture/reverse-proxy.mdx
+++ b/packages/documentation/src/pages/platform/architecture/reverse-proxy.mdx
@@ -39,3 +39,17 @@ Nginx conf files containing the properties for each environment:
 Our current nginx config only provides for proxying to s3 buckets that have the same name as the site for which 
 they are being proxied. However, in order to use a specific S3 bucket a new proxy header was created to handle t
 his by not overriding the [host header for s3 requests](https://github.com/department-of-veterans-affairs/devops/blob/master/ansible/deployment/config/revproxy-vagov/files/proxy-headers-s3.conf).
+
+## Deployment
+
+If you update the revproxy in the devops repository from inside the [/ansible/deployments](https://github.com/department-of-veterans-affairs/devops/tree/master/ansible/deployment) 
+directory you will need to trigger a deployment of the reverse proxy to see your changes in the appropriate environment.
+
+1. Visit the deployment job for the relevant environment: [dev](http://jenkins.vfs.va.gov/job/deploys/job/revproxy-vagov-dev/), [staging](http://jenkins.vfs.va.gov/job/deploys/job/revproxy-vagov-staging/), or [production](http://jenkins.vfs.va.gov/job/deploys/job/revproxy-vagov-prod/)
+2. Find the latest successful deployment; it will be at the top of the dashboard with all steps successful.
+3. Click on the deployment number to visit the landing page for that deployment.
+4. Click "Replay" in the sidebar to deploy your changes. If you don't see, "Replay," "Rebuild" can also be 
+used. If you don't see either option and you think you should please 
+[file an issue with the Operations team](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=&labels=operations%2C+devops%2C+needs-grooming&template=ops_issue_template.md&title=).
+The deployment process should take about 10 minutes.
+

--- a/packages/documentation/src/pages/platform/architecture/reverse-proxy.mdx
+++ b/packages/documentation/src/pages/platform/architecture/reverse-proxy.mdx
@@ -37,8 +37,7 @@ Nginx conf files containing the properties for each environment:
 ## Proxy headers
 
 Our current nginx config only provides for proxying to s3 buckets that have the same name as the site for which 
-they are being proxied. However, in order to use a specific S3 bucket a new proxy header was created to handle t
-his by not overriding the [host header for s3 requests](https://github.com/department-of-veterans-affairs/devops/blob/master/ansible/deployment/config/revproxy-vagov/files/proxy-headers-s3.conf).
+they are being proxied. However, in order to use a specific S3 bucket a new proxy header was created to handle this by not overriding the [host header for s3 requests](https://github.com/department-of-veterans-affairs/devops/blob/master/ansible/deployment/config/revproxy-vagov/files/proxy-headers-s3.conf).
 
 ## Deployment
 


### PR DESCRIPTION
## Description
Added documentation on how to deploy the reverse proxy.

Intentionally left out build & deploy instructions as it seems like that is very tied to the operations team.

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/7646