### PR TITLE
Update navigateToTop for back to top component

### DIFF
--- a/packages/formation/js/back-to-top.js
+++ b/packages/formation/js/back-to-top.js
@@ -7,7 +7,12 @@ function navigateToTop() {
   // Focus the h1 tag on the page.
   const el = document.querySelector('h1');
   if (el) {
+    // Prepare the element so that it can accept focus properly.
+    el.setAttribute('tabindex', '-1');
     el.focus();
+
+    // Cleanup the tabindex on blur.
+    el.addEventListener('blur', () => el.removeAttribute('tabindex'));
   }
 
   // Scroll to the top.

--- a/packages/formation/js/back-to-top.js
+++ b/packages/formation/js/back-to-top.js
@@ -4,16 +4,13 @@
  */
 
 function navigateToTop() {
-  const el = document.querySelector('body');
+  // Focus the h1 tag on the page.
+  const el = document.querySelector('h1');
   if (el) {
-    // Prepare the element so that it can accept focus properly
-    el.setAttribute('tabindex', '-1');
     el.focus();
-
-    // Cleanup
-    el.addEventListener('blur', () => el.removeAttribute('tabindex'));
   }
 
+  // Scroll to the top.
   return window.scrollTo(0, 0);
 }
 


### PR DESCRIPTION
# Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/22546

**Slack:** https://dsva.slack.com/archives/C52CL1PKQ/p1622128639266400

## Acceptance Criteria

- [x] Focus h1 tag instead of body when navigating to the top of the page on back to top button click.