### PR TITLE
Update new-application.mdx

### DIFF
--- a/packages/documentation/src/pages/getting-started/common-tasks/new-application.mdx
+++ b/packages/documentation/src/pages/getting-started/common-tasks/new-application.mdx
@@ -35,7 +35,7 @@ Here are the steps for manually setting up a new application. We're going to wal
 }
 ```
 
-3. Add an entry to `src/applications/registry.json`. This file contains information that the content build needs to create the landing page for your application:
+3. Add an entry to `src/applications/registry.json` in the `content-build` directory. This file contains information that the content build needs to create the landing page for your application:
 
 ```js
 {


### PR DESCRIPTION
## Description
Update the [Creating a new application](https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/getting-started/common-tasks/new-application/) docs to specify `registry.json` lives in the `content-build` directory.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
