### PR TITLE
account for no github login info in support dashboard

### DIFF
--- a/packages/documentation/src/components/dashboard/CommitsTable.jsx
+++ b/packages/documentation/src/components/dashboard/CommitsTable.jsx
@@ -91,7 +91,7 @@ export default function CommitsTable({
                 const { author = {}, committer = {}, message = '' } = commit;
                 const { name } = author;
                 const { date } = committer;
-                const { login } = githubAuthor;
+                const login = githubAuthor?.login;
 
                 if (sha === devRef) isOnDev = true;
                 if (sha === stagingRef) isOnStaging = true;
@@ -101,9 +101,11 @@ export default function CommitsTable({
                   <tr key={sha}>
                     <td className="dash-td-center">
                       <div className="dash-github-info">
-                          <a href={`https://www.github.com/${login}`} rel="noreferrer" target="_blank">
-                            <img className="dash-github-image" src={`https://www.github.com/${login}.png`} alt="github"></img> 
-                          </a>
+                          {login ? (
+                            <a href={`https://www.github.com/${login}`} rel="noreferrer" target="_blank">
+                              <img className="dash-github-image" src={`https://www.github.com/${login}.png`} alt="github"></img> 
+                            </a>
+                          ) : false }
                           <a href={`https://www.github.com/${login}`} rel="noreferrer" target="_blank">
                             <div className="dash-github-name">{name}</div>
                           </a>


### PR DESCRIPTION
## Description
The Frontend Support Dashboard is currently broken because we have commits coming through with no author information. This change updates our code to account for that

## Testing done
visual

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
