### PR TITLE
Update old instances of watch command to start

### DIFF
--- a/packages/documentation/src/pages/forms/form-tutorial-basic.mdx
+++ b/packages/documentation/src/pages/forms/form-tutorial-basic.mdx
@@ -44,7 +44,7 @@ After answering the questions, the generator will create several source files fo
 
 Next you'll need to start the site up locally (restart this task if it is already running):
 ```bash
-yarn watch
+yarn start
 ```
 
 Then navigate to http://localhost:3001/new-form.

--- a/packages/documentation/src/pages/getting-started/common-tasks/new-end-to-end-test.mdx
+++ b/packages/documentation/src/pages/getting-started/common-tasks/new-end-to-end-test.mdx
@@ -16,7 +16,7 @@ Front end engineers use end-to-end (e2e) tests in `vets-website` to validate mul
   - Some older end-to-end tests were written in [Nightwatch](https://nightwatchjs.org) prior to Cypress. All new tests should be written using Cypress moving forward and Nightwatch tests are in the process of being deprecated/migrated to Cypress.
   - Refer to the [Cypress migration guide](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/testing/end-to-end/cypress-migration-guide.md) to convert old tests or write new tests.
 - End-to-end tests are **collocated in application folder** with the application they test
-- Cypress tests can be run using the command `yarn cy:run` (after `yarn watch` to `yarn build`).
+- Cypress tests can be run using the command `yarn cy:run` (after `yarn start` to `yarn build`).
 
 ## End-to-end tests conventions
 

--- a/packages/documentation/src/pages/getting-started/common-tasks/run-build.mdx
+++ b/packages/documentation/src/pages/getting-started/common-tasks/run-build.mdx
@@ -13,7 +13,8 @@ tags: watch
 
 Start the watch task:
 ```bash
-yarn watch
+yarn watch # Start watch task in content-build
+yarn start # Start webpack-dev-server in vets-wensite
 ```
 ### Build
 

--- a/packages/documentation/src/pages/getting-started/index.mdx
+++ b/packages/documentation/src/pages/getting-started/index.mdx
@@ -105,12 +105,12 @@ These instructions cover building and running VA.gov locally, including configur
 9a. Start the local development server. If you are applying CSS and/or JS changes to a static page/template that renders 
 in `content-build`, we recommend leaving this command running so you will be able to see the changes in `content-build`.
    ```bash
-   $ yarn watch
+   $ yarn serve
    ```
 
    The watch is complete when the CLI says `Compiled successfully`.
 
-   If you would like webpack to open a browser window for you, please run `yarn watch --open`. We use [Webpack DevServer](https://webpack.js.org/configuration/dev-server/) to watch and serve the files locally; all the same options and documentation should apply.
+   If you would like webpack to open a browser window for you, please run `yarn serve --open`. We use [Webpack DevServer](https://webpack.js.org/configuration/dev-server/) to watch and serve the files locally; all the same options and documentation should apply.
 
 10a. Open [http://localhost:3001](http://localhost:3001) in a browser if you are working on an app; 
 otherwise, continue on to the [content-build](#content-build) section for viewing changes in the browser.


### PR DESCRIPTION
## Description
Update instances in the documentation  of `yarn watch` to `yarn start` in the vets-website repo.
Related to https://github.com/department-of-veterans-affairs/vets-website/pull/17981

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
