### PR TITLE
Fallback to window.pageYOffset for IE11

### DIFF
--- a/packages/formation/__tests__/js/back-to-top/back-to-top.test.js
+++ b/packages/formation/__tests__/js/back-to-top/back-to-top.test.js
@@ -1,0 +1,122 @@
+/* eslint-disable no-unused-expressions */
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { closure } from '../../../js/back-to-top';
+
+describe('static page back to top widget', () => {
+  const testButton = {
+    classList: {
+      toggle: sinon.spy(),
+    },
+  };
+  const testButtonContainer = {
+    classList: {
+      toggle: sinon.spy(),
+    },
+  };
+  const buttonClasses = {
+    transitionIn: 'test-transition',
+    containerRelative: 'test-container-relative',
+  };
+
+  const windowClone = global.window;
+
+  afterEach(() => {
+    global.window = windowClone;
+    testButton.classList.toggle.resetHistory();
+    testButtonContainer.classList.toggle.resetHistory();
+  });
+
+  it('should not toggle button transition class when at top of page', () => {
+    global.window.scrollY = 0;
+
+    closure(
+      testButton,
+      testButtonContainer,
+      {
+        getBoundingClientRect: () => ({
+          top: 0,
+        }),
+      },
+      buttonClasses,
+    )();
+
+    expect(testButton.classList.toggle.calledWith(buttonClasses.transitionIn))
+      .not.to.be.true;
+  });
+
+  it('should toggle button transition class when scrolled past breakpoint', () => {
+    global.window.scrollY = 601;
+
+    closure(
+      testButton,
+      testButtonContainer,
+      {
+        getBoundingClientRect: () => ({
+          top: 601,
+        }),
+      },
+      buttonClasses,
+    )();
+
+    expect(testButton.classList.toggle.calledWith(buttonClasses.transitionIn))
+      .to.be.true;
+  });
+
+  it('should toggle button transition class when scrolled past breakpoint in IE11', () => {
+    global.window.scrollY = undefined;
+    global.window.pageYOffset = 601;
+
+    closure(
+      testButton,
+      testButtonContainer,
+      {
+        getBoundingClientRect: () => ({
+          top: 601,
+        }),
+      },
+      buttonClasses,
+    )();
+
+    expect(testButton.classList.toggle.calledWith(buttonClasses.transitionIn))
+      .to.be.true;
+  });
+
+  it('should not toggle button container relative class when footer is out of view', () => {
+    closure(
+      testButton,
+      testButtonContainer,
+      {
+        getBoundingClientRect: () => ({
+          top: 800,
+        }),
+      },
+      buttonClasses,
+    )();
+
+    expect(
+      testButtonContainer.classList.toggle.calledWith(
+        buttonClasses.containerRelative,
+      ),
+    ).not.to.be.true;
+  });
+
+  it('should toggle button container relative class when footer is in view', () => {
+    closure(
+      testButton,
+      testButtonContainer,
+      {
+        getBoundingClientRect: () => ({
+          top: 0,
+        }),
+      },
+      buttonClasses,
+    )();
+
+    expect(
+      testButtonContainer.classList.toggle.calledWith(
+        buttonClasses.containerRelative,
+      ),
+    ).to.be.true;
+  });
+});

--- a/packages/formation/js/back-to-top.js
+++ b/packages/formation/js/back-to-top.js
@@ -25,9 +25,12 @@ function isScrolledIntoView(el) {
   return elemTop >= 0 && elemTop <= window.innerHeight;
 }
 
-function closure(button, buttonContainer, footer, buttonClasses) {
+export function closure(button, buttonContainer, footer, buttonClasses) {
   const scrollBreakpoint = 600;
-  const breakpointCheck = () => window.scrollY > scrollBreakpoint;
+  // Fallback to window.pageYOffset for IE11
+  // https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY#browser_compatibility
+  const breakpointCheck = () =>
+    (window.scrollY || window.pageYOffset) > scrollBreakpoint;
   let hasHitBreakpoint = false;
 
   const footerCheck = () => isScrolledIntoView(footer);


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/25103
I believe this is the result of `window.scrollY` being undefined in IE11: https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY#browser_compatibility

## Testing done
unit testing

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
