### PR TITLE
Remove transition from back to top button for safari

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.16.2",
+  "version": "6.16.3",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/modules/_m-back-to-top.scss
+++ b/packages/formation/sass/modules/_m-back-to-top.scss
@@ -36,7 +36,6 @@
     padding: 0;
     pointer-events: none;
     position: absolute;
-    transition: all 250ms ease-in;
     right: 0;
     width: 44px;
 


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/25001

This PR removes the transition property from the back to top button.

## Testing done
https://github.com/department-of-veterans-affairs/va.gov-team/issues/25001#issuecomment-889413479

## Screenshots
https://github.com/department-of-veterans-affairs/va.gov-team/issues/25001#issuecomment-889413479

## Acceptance criteria
- [x] Back to top button should show outline when focused on Safari

## Definition of done
- [x] Changes have been tested in vets-website
- [x] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
