### PR TITLE
Run breakpointCheck even when footer is not present

### DIFF
--- a/packages/formation/__tests__/js/back-to-top/back-to-top.test.js
+++ b/packages/formation/__tests__/js/back-to-top/back-to-top.test.js
@@ -82,6 +82,15 @@ describe('static page back to top widget', () => {
       .to.be.true;
   });
 
+  it('should toggle button transition class even when footer is not present', () => {
+    global.window.scrollY = 601;
+
+    closure(testButton, testButtonContainer, null, buttonClasses)();
+
+    expect(testButton.classList.toggle.calledWith(buttonClasses.transitionIn))
+      .to.be.true;
+  });
+
   it('should not toggle button container relative class when footer is out of view', () => {
     closure(
       testButton,

--- a/packages/formation/js/back-to-top.js
+++ b/packages/formation/js/back-to-top.js
@@ -42,7 +42,7 @@ export function closure(button, buttonContainer, footer, buttonClasses) {
       hasHitBreakpoint = !hasHitBreakpoint;
     }
 
-    if (footerCheck() !== footerVisChanged) {
+    if (footer && footerCheck() !== footerVisChanged) {
       buttonContainer.classList.toggle(buttonClasses.containerRelative);
       footerVisChanged = !footerVisChanged;
     }
@@ -58,7 +58,6 @@ export default function setup() {
   // The current page likely does not contain a "Back to top" button in its layout.
 
   const footer = document.getElementById('footerNav');
-  if (!footer) return;
 
   const buttonClasses = {
     transitionIn: 'va-top-button-transition-in',

--- a/packages/formation/js/back-to-top.js
+++ b/packages/formation/js/back-to-top.js
@@ -20,7 +20,12 @@ function navigateToTop() {
 }
 
 function isScrolledIntoView(el) {
-  const elemTop = el.getBoundingClientRect().top;
+  const elemTop = el?.getBoundingClientRect().top;
+
+  if (!elemTop && elemTop !== 0) {
+    return false;
+  }
+
   // Only partially || completely visible elements return true
   return elemTop >= 0 && elemTop <= window.innerHeight;
 }
@@ -42,7 +47,7 @@ export function closure(button, buttonContainer, footer, buttonClasses) {
       hasHitBreakpoint = !hasHitBreakpoint;
     }
 
-    if (footer && footerCheck() !== footerVisChanged) {
+    if (footerCheck() !== footerVisChanged) {
       buttonContainer.classList.toggle(buttonClasses.containerRelative);
       footerVisChanged = !footerVisChanged;
     }

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.16.3",
+  "version": "6.16.4",
   "description": "The VA design system",
   "keywords": [
     "va",


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/25103

This is a follow up on https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/648 which ensured IE compatibility for the back to top component. The issue still persists and it appears to be a result of an unrelated check for the existence of the footer component before executing the breakpoint check on scroll. Currently we run checks for 2 separate elements before running the code that relies on the existence of either of them. This PR removes the too early check for `footer` and moves that check to where it's needed. See the video for the effect of both lines in this pr on IE11

https://user-images.githubusercontent.com/3144003/128720680-4ddc51fa-95b3-41c5-be64-523fb5e56649.mov

## Testing done
local via browserstack and unit

## Screenshots
<img width="1278" alt="Screen Shot 2021-08-03 at 11 53 23 AM" src="https://user-images.githubusercontent.com/3144003/128046913-fa1233dc-1de2-45f3-bc9e-277a204f3d2b.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
