### PR TITLE
Remove position relative from usa-content in Back to Top component

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.17.0",
+  "version": "6.17.1",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/modules/_m-back-to-top.scss
+++ b/packages/formation/sass/modules/_m-back-to-top.scss
@@ -16,9 +16,6 @@
     }
   }
 
-  .usa-content {
-    position: relative;
-  }
   &:not(.va-top-button-container-relative) {
     button.va-top-button-transition-in {
       transform: translateY(-12px);


### PR DESCRIPTION
## Description
See companion PR in content-build: https://github.com/department-of-veterans-affairs/content-build/pull/505
**The other PR should merge first**

## Testing done
Local

## Screenshots
`/decision-reviews/supplemental-claim/` Before:
<img width="1791" alt="Screen Shot 2021-09-02 at 10 32 01 AM" src="https://user-images.githubusercontent.com/3144003/131864851-b5872d6c-4068-4bb1-ad00-561222d36d25.png">

`/decision-reviews/supplemental-claim/` After: 
<img width="1788" alt="Screen Shot 2021-09-02 at 10 32 22 AM" src="https://user-images.githubusercontent.com/3144003/131864896-0c0ff9bb-3552-49c2-9093-c2d623816f63.png">

`/resources/how-to-get-free-language-assistance-from-va/` Before:
<img width="1789" alt="Screen Shot 2021-09-02 at 10 32 11 AM" src="https://user-images.githubusercontent.com/3144003/131864966-34bb9775-7e06-43c3-ae79-c44aab37147c.png">

`/resources/how-to-get-free-language-assistance-from-va/` After:
<img width="1787" alt="Screen Shot 2021-09-02 at 10 32 37 AM" src="https://user-images.githubusercontent.com/3144003/131865001-e8c2c1c3-2482-4786-a6cf-b798611ae708.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
