### PR TITLE
Removed static page widget docs as it isn't used anymore

### DIFF
--- a/packages/documentation/src/pages/getting-started/common-tasks/new-widget.mdx
+++ b/packages/documentation/src/pages/getting-started/common-tasks/new-widget.mdx
@@ -73,29 +73,6 @@ We should be careful to not create a bad user experience when using React on sta
 2. Make sure the page is still usable if your React code fails to work. This can mean it fails to download, an error occurs, or just handling the different login states a user can be in.
 3. Be aware of how much weight you're adding to the static-pages bundle and code-split/lazy load when it makes sense.
 
-## Common widget code
-
-There's a simple static page widget feature that you can use to help with the first two points above. The code is in `src/applications/static-pages/static-page-widgets.js`. Using this will inline some JS that can handle displaying a loading spinner and showing an error message if something goes wrong before the React code can take over rendering. Several pension pages use this functionality (`pages/pension/index.md`, `pages/pension/apply.md` in `vagov-content`). It's controlled by defining a widgets list in the front matter for the static content page you're on. The options are:
-
-```
-- widgets
-  - root: someId 
-    timeout: 20
-    showSpinnerUnauthed: false
-    slowLoadingThreshold: 6
-    loadingMessage: Loading
-    slowMessage: Sorry, this is taking longer than expected.
-    errorMessage: Sorry, something went wrong.
-```
-
-- root: The id of the div where the React component will mount.
-- timeout: The amount of time in seconds before the error message is shown.
-- showSpinnerUnauthed: By default, a spinner is shown only if a user has a session token. This will override that and show it always.
-- slowLoadingThreshold: The amount of time in seconds before the slow loading message is shown. This is skipped if the threshold is greater than the overall timeout. Defaulted to 6 seconds.
-- slowMessage: Message shown when the slowThreshold is passed. Defaulted to message above.
-- loadingMessage: Message shown while the JS code is loading. This should probably match any loading message in your React code.
-- errorMessage: Message shown when the JS code fails or times out.
-
 ## Running end-to-end tests on a widget
 
 Before running end-to-end (e2e) tests for a widget, you must add an entry for your widget to `src/applications/registry.scaffold.json`. This will allow a landing page to be generated for your widget so you can run end-to-end tests in `vets-website`. An example entry looks something like:


### PR DESCRIPTION
## Description
Found no instances of this feature being used and no legacy files in the file system. Looks like it was removed and the docs were no updated.

Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/9535