### PR TITLE
add deprecation messages to unit testing sections

### DIFF
--- a/packages/documentation/src/pages/getting-started/common-tasks/debugging-tests.mdx
+++ b/packages/documentation/src/pages/getting-started/common-tasks/debugging-tests.mdx
@@ -5,7 +5,13 @@ tags: unit test, debugging, mocha, e2e
 
 # Debugging tests
 
-*** Unit Tests ***
+## Unit Tests
+
+<div class="deprecation-message">
+    <h3>We're moving our docs!</h3>
+    <h4>Find <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Debugging-unit-tests.1836286010.html">the latest version of this section</a> on the Platform website.</h4>
+    <h4>Still can't find what you're looking for? Reach out to <a href="https://dsva.slack.com/archives/CBU0KDSB1">#vfs-platform-support</a> on Slack.</h4>
+</div>
 
 - To run tests with some extra debugging info, you can pass a `--log-level`:
 
@@ -57,7 +63,7 @@ tags: unit test, debugging, mocha, e2e
       ```
     - Now you can add breakpoints or debugger statements to debug your code through the VSCode debugger tools.
 
-*** End to End tests
+## End to End tests
 
 - It's possible to set an infinite pause (`.pause()`) in the test code and then see what's happening at a given point in the browser where the test is running.
 

--- a/packages/documentation/src/pages/getting-started/common-tasks/test.mdx
+++ b/packages/documentation/src/pages/getting-started/common-tasks/test.mdx
@@ -28,6 +28,12 @@ Some tests require [running or building](/getting-started/common-tasks/run-build
 
 ## Unit tests
 
+<div class="deprecation-message">
+    <h3>We're moving our docs!</h3>
+    <h4>Find <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Unit-tests.1836187655.html">the latest version of this section</a> on the Platform website.</h4>
+    <h4>Still can't find what you're looking for? Reach out to <a href="https://dsva.slack.com/archives/CBU0KDSB1">#vfs-platform-support</a> on Slack.</h4>
+</div>
+
 - Run all [Mocha](https://mochajs.org/)/[Chai](http://chaijs.com/)/[Sinon](https://sinonjs.org/)-based unit tests with the file extension `.unit.spec.js(x)`
 - Use [JSDom](https://github.com/jsdom/jsdom) and [Enzyme](https://airbnb.io/enzyme/) to test browser and React behavior
 - Are located in `test/` directories near the code they're testing in `src/`

--- a/packages/documentation/src/scss/_deprecation-message.scss
+++ b/packages/documentation/src/scss/_deprecation-message.scss
@@ -2,7 +2,7 @@
     background-color: #e1f3f8;
     padding: 1rem;
 
-    h2 {
+    h2, h3 {
         margin-top: 0;
     }
 }


### PR DESCRIPTION
## Description
This PR adds deprecation messages with links to the new location for the unit testing sections of a couple of shared testing documents

The list of documents that need to be deprecated can be found here: https://docs.google.com/spreadsheets/d/1vDQlI_lk9GTQuqw4eMmDe8CAHvNjVmjW3CGRDp0I9iU/edit#gid=1510466462

## Testing done
Checked each link to make sure they direct the user to the correct document

## Screenshots
<img width="711" alt="image" src="https://user-images.githubusercontent.com/12739849/132716096-089d8804-0e06-40f9-b93d-0fbfe43cb1b9.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
