### PR TITLE
Add margin to Modal body to prevent overlap with Close button

### DIFF
--- a/packages/formation/sass/modules/_m-modal.scss
+++ b/packages/formation/sass/modules/_m-modal.scss
@@ -25,7 +25,7 @@
     p:first-of-type {
       margin-top: 0;
     }
-    margin-right: units(2);
+    margin-right: units(2.5);
   }
 
   &-title {

--- a/packages/formation/sass/modules/_m-modal.scss
+++ b/packages/formation/sass/modules/_m-modal.scss
@@ -25,6 +25,7 @@
     p:first-of-type {
       margin-top: 0;
     }
+    margin-right: units(2);
   }
 
   &-title {


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/225

## Testing done
Manual testing

## Screenshots
Before:

<img width="1155" alt="Screen Shot 2021-09-13 at 4 15 47 PM" src="https://user-images.githubusercontent.com/3535749/133157451-1dfdd765-f3eb-4ff3-8f33-3e9157523b7e.png">

After:

<img width="1157" alt="Screen Shot 2021-09-13 at 4 14 33 PM" src="https://user-images.githubusercontent.com/3535749/133157466-62b7870c-e68f-4f06-be4e-fd441313d538.png">