### PR TITLE
Add Autosuggest docs (include customMatcher)

### DIFF
--- a/packages/documentation/src/pages/forms/about-the-schema-and-uischema-objects.mdx
+++ b/packages/documentation/src/pages/forms/about-the-schema-and-uischema-objects.mdx
@@ -309,7 +309,25 @@ The VAFS code includes additional `uiSchema` functionality not found in the RJSF
     // information for multiple dependents, are displayed in a separate section on the
     // review page. To keep the information in a single section on a review page, set
     // this property to `true`.
-    keepInPageOnReview: true
+    keepInPageOnReview: true,
+
+    // *** Autosuggest field options ***
+    labels: {}, // custom labels or use schema.enumNames
+    maxOptions: 0, // set to 0 to show all
+    freeInput: true, // true = allow input not in enum list
+    // internally modify user input used for suggestions, text within the input
+    // is not modified
+    inputTransformers: [ userInput => userInput ],
+    // set to true to call the below getOptions
+    queryForResults: false,
+    // Async method to get list of options
+    getOptions: () => {},
+    // debounce time before updating suggestions
+    debounceRate: 1000, // default
+    // most basic example (leave undefined to use default matcher which uses
+    // a fast Levenshtein algorithm)
+    customMatcher: (userInput, fullList) =>
+      fullList.filter(item => item.includes(userInput)),
   }
 }
 ```


### PR DESCRIPTION
## Description

Add Autosuggest Field docs, and include `customMatcher` option from https://github.com/department-of-veterans-affairs/vets-website/pull/18786

## Testing done

N/A - docs only

## Screenshots

N/A

## Acceptance criteria
- [x] Add Autosuggest field `ui:options` to uischema example docs

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
