### PR TITLE
Add cursor default to .va-nav-linkslist-link

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.17.1",
+  "version": "6.17.2",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/modules/_m-nav-linkslist.scss
+++ b/packages/formation/sass/modules/_m-nav-linkslist.scss
@@ -57,4 +57,8 @@
     color: $color-base;
     margin: 0;
   }
+
+  &-link {
+    cursor: default;
+  }
 }


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/15244
We are adding links with a non breaking space to in-page links to ensure focus moves correctly, so we want to remove `cursor: pointer` from that space.

See this pr in content-build for usage https://github.com/department-of-veterans-affairs/content-build/pull/575

## Testing done
local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
