### PR TITLE
Focused item MUST be contained by focus outline, pagination Next &gt;

### DIFF
--- a/packages/formation/sass/modules/_m-responsive-tables.scss
+++ b/packages/formation/sass/modules/_m-responsive-tables.scss
@@ -17,15 +17,6 @@ table.responsive {
   td::first-letter {
     text-transform: capitalize;
   }
-
-  thead button.sort {
-    display: flex;
-    align-items: center;
-  }
-
-  thead svg.usa-icon.sort {
-    width: 24px;
-  }
 }
 
 @media screen and (max-width: $medium-screen) {

--- a/packages/formation/sass/modules/_m-responsive-tables.scss
+++ b/packages/formation/sass/modules/_m-responsive-tables.scss
@@ -17,6 +17,15 @@ table.responsive {
   td::first-letter {
     text-transform: capitalize;
   }
+
+  thead button.sort {
+    display: flex;
+    align-items: center;
+  }
+
+  thead svg.usa-icon.sort {
+    width: 24px;
+  }
 }
 
 @media screen and (max-width: $medium-screen) {

--- a/packages/formation/sass/modules/_va-pagination.scss
+++ b/packages/formation/sass/modules/_va-pagination.scss
@@ -20,7 +20,7 @@
 
     &:not(:empty) {
       @media (min-width: $small-screen) {
-        &a::before {
+        a::before {
           content: "\2039\a0\a0";
         }
       }
@@ -35,7 +35,7 @@
 
     &:not(:empty) {
       @media (min-width: $small-screen) {
-        &a::after {
+        a::after {
           content: "\a0\a0\203a";
         }
       }

--- a/packages/formation/sass/modules/_va-pagination.scss
+++ b/packages/formation/sass/modules/_va-pagination.scss
@@ -20,7 +20,7 @@
 
     &:not(:empty) {
       @media (min-width: $small-screen) {
-        &::before {
+        &a::before {
           content: "\2039\a0\a0";
         }
       }
@@ -35,7 +35,7 @@
 
     &:not(:empty) {
       @media (min-width: $small-screen) {
-        &::after {
+        &a::after {
           content: "\a0\a0\203a";
         }
       }


### PR DESCRIPTION
## Description
Closes <https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/248>

When focus is on the last item in the pagination the `>` is outside of the focus outline, but should be within (the 'Next' link). Example:

![image](https://user-images.githubusercontent.com/9326247/134542337-952573a2-a451-4652-947f-3ac006af3239.png)

The ticket doesn't mention it, but the same is true for the 'Previous' link.

I fixed the issue with both 'Next >' and '< Previous'.

## Screenshots
![image](https://user-images.githubusercontent.com/9326247/134541445-8e6c0df9-8a5b-4355-9b64-db395612c906.png)

