### PR TITLE
Remove focus outline from .hub-page-link-list__title

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.17.2",
+  "version": "6.17.3",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/modules/_m-hub-page-link-list.scss
+++ b/packages/formation/sass/modules/_m-hub-page-link-list.scss
@@ -2,20 +2,25 @@
   // override default ul styles
   list-style: none;
   padding: 0;
+
   &__item {
     margin-bottom: 1em;
     margin: 1.6rem 0;
     > a {
       text-decoration: none;
-      &:hover, &:focus {
+
+      &:hover,
+      &:focus {
         .all-link-arrow {
           margin-left: 10px;
-          content: url("#{$formation-image-path}/arrow-right.svg");
+          content: url('#{$formation-image-path}/arrow-right.svg');
         }
+
         .hub-page-link-list__header {
           text-decoration: underline;
         }
       }
+
       .all-link-arrow {
         width: 11px;
         margin-left: 5px;
@@ -24,11 +29,19 @@
       }
     }
   }
+
   &__header {
     font-weight: bold;
   }
+
   &__description {
     color: $color-black;
     margin: 0;
+  }
+
+  &__title {
+    &:focus {
+      outline: none;
+    }
   }
 }


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/15244

From [comment](https://github.com/department-of-veterans-affairs/va.gov-team/issues/15244#issuecomment-929364244)
would it be possible for us to remove the focus halo from the heading? Since it is not an interactive element, previous VA guidance has recommended not to have the focus halo around it even if we send focus to it.

## Testing done
local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
