### PR TITLE
Button focus

### DIFF
--- a/packages/formation/sass/base/_b-mixins.scss
+++ b/packages/formation/sass/base/_b-mixins.scss
@@ -74,7 +74,7 @@
     padding: 0;
     border: 0;
     margin: -1px;
-    content: "this will open a new website";
+    content: 'this will open a new website';
   }
 }
 
@@ -102,9 +102,14 @@
   @include focus-gold-light-outline;
 }
 
+@mixin focus-dark-outline($offset: 2) {
+  outline: $color-primary-darker;
+  outline-offset: #{$offset}px;
+}
+
 @mixin color-transition {
   -webkit-transition-duration: 0.3s;
-    transition-duration: 0.3s;
+  transition-duration: 0.3s;
 
   -webkit-transition-timing-function: ease-in-out;
   transition-timing-function: ease-in-out;
@@ -117,8 +122,16 @@
 @mixin linear-gradient-background($from, $to) {
   background: $from; /* Old browsers */
   background: -moz-linear-gradient(top, $from 0%, $to 63%); /* FF3.6-15 */
-  background: -webkit-linear-gradient(top, $from 0%,$to 63%); /* Chrome10-25,Safari5.1-6 */
-  background: linear-gradient(to bottom, $from 0%,$to 63%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+  background: -webkit-linear-gradient(
+    top,
+    $from 0%,
+    $to 63%
+  ); /* Chrome10-25,Safari5.1-6 */
+  background: linear-gradient(
+    to bottom,
+    $from 0%,
+    $to 63%
+  ); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr=$from, endColorstr=$to,GradientType=0 ); /* IE6-9 */
 }
 
@@ -153,7 +166,7 @@
     background: $color-link-default-hover;
   }
   &:focus {
-    @include focus-gold-light-outline;
+    @include focus-dark-outline;
     outline-offset: 0;
   }
   &:disabled {

--- a/packages/formation/sass/base/_b-mixins.scss
+++ b/packages/formation/sass/base/_b-mixins.scss
@@ -102,11 +102,6 @@
   @include focus-gold-light-outline;
 }
 
-@mixin focus-dark-outline($offset: 2) {
-  outline: $color-primary-darker;
-  outline-offset: #{$offset}px;
-}
-
 @mixin color-transition {
   -webkit-transition-duration: 0.3s;
   transition-duration: 0.3s;
@@ -166,7 +161,7 @@
     background: $color-link-default-hover;
   }
   &:focus {
-    @include focus-dark-outline;
+    @include focus-gold-light-outline;
     outline-offset: 0;
   }
   &:disabled {

--- a/packages/formation/sass/modules/_m-button.scss
+++ b/packages/formation/sass/modules/_m-button.scss
@@ -16,20 +16,20 @@ button,
 
 .usa-button-primary {
   color: $color-white !important;
-  &[href^=http] {
+  &[href^="http"] {
     @include no-sr-content;
 
     background-image: none;
     // TODO: clean up #content .main.interior a then remove !important
     text-decoration: none !important;
-
   }
 }
 
 // @todo Remove this once the USWDS upgrade is complete.
 .usa-accordion {
   .usa-button-secondary:focus {
-    box-shadow: inset 0 0 0 2px $color-primary-darkest, 0 0 3px $color-focus, 0 0 7px $color-focus;
+    box-shadow: inset 0 0 0 2px $color-primary-darkest, 0 0 3px $color-focus,
+      0 0 7px $color-focus;
   }
 }
 
@@ -85,7 +85,7 @@ button.short {
 
   span {
     display: inline-block;
-    padding-left: .5rem;
+    padding-left: 0.5rem;
     text-decoration: underline;
   }
 }
@@ -104,7 +104,7 @@ button.short {
     @include media($medium-large-screen) {
       display: block;
       height: 1.5rem;
-      margin-right: .25rem;
+      margin-right: 0.25rem;
       pointer-events: none;
       width: 1.5rem;
     }

--- a/packages/formation/sass/modules/_m-button.scss
+++ b/packages/formation/sass/modules/_m-button.scss
@@ -18,6 +18,10 @@ button,
   }
 }
 
+.usa-button:focus {
+  background: $color-primary-darker;
+}
+
 .usa-button-primary {
   color: $color-white !important;
   &[href^='http'] {

--- a/packages/formation/sass/modules/_m-button.scss
+++ b/packages/formation/sass/modules/_m-button.scss
@@ -3,20 +3,24 @@
 .usa-button:visited,
 .usa-button-primary:visited,
 button,
-[type="button"],
-[type="submit"],
-[type="reset"],
-[type="image"] {
+[type='button'],
+[type='submit'],
+[type='reset'],
+[type='image'] {
   background-color: $color-primary;
 
   &.usa-button-secondary {
     background: transparent;
+    &:focus,
+    &:hover {
+      background-color: $color-cool-blue-lightest;
+    }
   }
 }
 
 .usa-button-primary {
   color: $color-white !important;
-  &[href^="http"] {
+  &[href^='http'] {
     @include no-sr-content;
 
     background-image: none;
@@ -62,7 +66,7 @@ button.short {
 
 // For links and buttons that look like links and have an icon.
 .va-icon-link,
-.va-icon-link[type="button"] {
+.va-icon-link[type='button'] {
   background: transparent;
   border-radius: 0;
   color: $color-primary !important;


### PR DESCRIPTION
## Description
Resolves https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/235 by making focus & hover states the same background shade for primary buttons and gives hover & focus a background shade for secondary buttons.

## Testing done
Reviewed in Storybook component (see screenshots below)

## Screenshots
Focus & Hover now have same background for Secondary Buttons.
![image](https://user-images.githubusercontent.com/72466113/135501145-fa24072f-84de-40c1-9c7f-edee8b717b7f.png)
Blue Default buttons now have same background color on hover and focus.
![image](https://user-images.githubusercontent.com/72466113/135501161-36e56d56-2ed1-45d7-abc5-2d26345e82c4.png)


## Acceptance criteria
x Blue button has the same background color on hover and focus
x Blue button retains the yellow halo on focus
x Outlined secondary button has the same darker border and text on hover and focus
x Outlined secondary button retains the yellow halo on focus
x Create and/or modify unit tests for this component to include an aXe scan

