### PR TITLE
Add code to expand `va-accordion-item` from hash

### DIFF
--- a/packages/formation/__tests__/js/accordion/accordion-legacy.test.js
+++ b/packages/formation/__tests__/js/accordion/accordion-legacy.test.js
@@ -107,7 +107,7 @@ document.body.innerHTML = `
 
 require('../../../js');
 
-describe('accordion', () => {
+describe('accordion (legacy)', () => {
   it('should set aria-expanded attribute on load if non exists', () => {
     const a1Element = document.querySelector('[aria-controls="a1"]');
 

--- a/packages/formation/__tests__/js/accordion/accordion-wc.test.js
+++ b/packages/formation/__tests__/js/accordion/accordion-wc.test.js
@@ -1,0 +1,44 @@
+// Mock for window.matchMedia
+import '../../matchMedia.mock';
+
+import loadAccordionHandler from '../../../js/accordion';
+
+document.body.innerHTML = `
+<va-accordion>
+  <va-accordion-item header="First Amendment">
+    Congress shall make no law respecting an establishment of religion, or prohibiting the free exercise thereof; or abridging the freedom of speech, or of the press; or the right of the people peaceably to assemble, and to petition the Government for a redress of grievances.
+  </va-accordion-item>
+  <va-accordion-item header="Second Amendment">
+    <div id="4567">A well regulated Militia, being necessary to the security of a free State, the right of the people to keep and bear Arms, shall not be infringed.</div>
+  </va-accordion-item>
+  <va-accordion-item header="Third Amendment">
+    No Soldier shall, in time of peace be quartered in any house, without the consent of the Owner, nor in time of war, but in a manner to be prescribed by law.
+  </va-accordion-item>
+</va-accordion>`;
+
+describe('va-accordion (web-component)', () => {
+  global.scrollTo = jest.fn();
+  it('should render accordion + 3 accordion-items', () => {
+    document.location.hash = '#five';
+    expect(document.querySelectorAll('va-accordion').length).toEqual(1);
+    expect(document.querySelectorAll('va-accordion-item').length).toEqual(3);
+    const isOpen = [...document.querySelectorAll('va-accordion-item')].filter(
+      item => item.getAttribute('open'),
+    );
+    expect(isOpen.length).toEqual(0);
+  });
+
+  it('should open accordion with header text that matches the location hash', () => {
+    document.location.hash = '#third-amend';
+    loadAccordionHandler();
+    const lastItem = [...document.querySelectorAll('va-accordion-item')][2];
+    expect(lastItem.getAttribute('open')).toEqual('true');
+  });
+
+  it('should open accordion with header id that matches the location hash', () => {
+    document.location.hash = '#4567';
+    const secondItem = [...document.querySelectorAll('va-accordion-item')][1];
+    loadAccordionHandler();
+    expect(secondItem.getAttribute('open')).toEqual('true');
+  });
+});

--- a/packages/formation/js/accordion.js
+++ b/packages/formation/js/accordion.js
@@ -160,6 +160,10 @@ const addAccordionClickHandler = () => {
   }
 };
 
+// only keep alpha-numeric characters from header, hash and id
+const normalizeRegexp = /[^\w]/g;
+const normalizeText = id => id.replace(normalizeRegexp, '').toLowerCase();
+
 function autoExpandAccordionPanelByUrlHash() {
   const hash = document.location.hash;
 
@@ -167,12 +171,33 @@ function autoExpandAccordionPanelByUrlHash() {
     return;
   }
 
-  const anchorId = document.location.hash.slice(1);
+  // legacy accordion - target entity ID (id + partial text)
+  const anchorId = hash.slice(1);
   const accordionButtonSelector = `.usa-accordion li[id="${anchorId}"] .usa-accordion-button`;
   const accordionButton = document.querySelector(accordionButtonSelector);
 
   if (accordionButton) {
     accordionButton.click();
+  }
+
+  // <va-accordion-item> web component - match either
+  // 1) partial text of header, e.g. "#contact-us"
+  // 2) the entity ID, e.g. "#1234"
+  const anchorText = normalizeText(anchorId);
+  const accordionItemSelector = 'va-accordion-item';
+  const accordionItems = document.querySelectorAll(accordionItemSelector);
+
+  if (accordionItems) {
+    [...accordionItems].some(accordion => {
+      const idInSlot = accordion?.querySelector('[id]')?.id || null;
+      const headerText = normalizeText(accordion.getAttribute('header') || '');
+      if (headerText.includes(anchorText) || idInSlot === anchorText) {
+        accordion.setAttribute('open', true);
+        window.scrollTo(0, accordion.offsetTop);
+        return true;
+      }
+      return false;
+    });
   }
 }
 

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "6.17.3",
+  "version": "6.17.4",
   "description": "The VA design system",
   "keywords": [
     "va",


### PR DESCRIPTION
## Description

The previous accordion markup included code to auto-expand accordions that matched the url hash. Accordions have since been replaced by the `<va-accordion>` and `<va-accordion-item>` web components and no longer auto-expand.

This PR adds code to check both the header text or entity id of the content and expand the accordion if it matches:
- Partial text of header, e.g. "#contact-us"
- The entity ID added by CMS, e.g. "#1234"

The legacy accordion code was looking for a match on `{header-text}-{entity-id}`, where header-text spaces are replaced by hyphens and limited to 30 characters. I couldn't find this anywhere in the code.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/28658

## Testing done

Added unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] va-accordion-item that partially matches header text or the entity ID will expand and scroll into view
- [x] All test passing

## Definition of done
- [x] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable (web components don't work in IE11)
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
