### PR TITLE
Docs: Add `goBack` path parameter

### DIFF
--- a/packages/documentation/src/pages/forms/bypassing-schemaform.mdx
+++ b/packages/documentation/src/pages/forms/bypassing-schemaform.mdx
@@ -71,7 +71,8 @@ There are a few important things going on here:
 - `uploadFile`: Function
      - The function to call to upload a file
      - Not supplied when `CustomPage` is rendered on the review page
-- `goBack`: () => void
+- `goBack`: Function
+     - When a valid path is passed to this function, calling this function will return you to that page. Invalid paths will return you to the root (introduction) page, so be careful
      - The function to call to move back a page in the form
      - Not supplied when `CustomPage` is rendered on the review page
 - `goForward`: () => void

--- a/packages/documentation/src/pages/forms/bypassing-schemaform.mdx
+++ b/packages/documentation/src/pages/forms/bypassing-schemaform.mdx
@@ -72,8 +72,8 @@ There are a few important things going on here:
      - The function to call to upload a file
      - Not supplied when `CustomPage` is rendered on the review page
 - `goBack`: Function
-     - When a valid path is passed to this function, calling this function will return you to that page. Invalid paths will return you to the root (introduction) page, so be careful
      - The function to call to move back a page in the form
+     - When a valid path is passed to this function, calling this function will return you to that page. Invalid paths will return you to the root (introduction) page, so be careful. For example, `goBack('main-page')`
      - Not supplied when `CustomPage` is rendered on the review page
 - `goForward`: () => void
      - The function to call to move forward a page in the form


### PR DESCRIPTION
## Description

Add `goBack` path parameter documentation for this change - https://github.com/department-of-veterans-affairs/vets-website/pull/19315

Original ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/31700

## Testing done

N/A

## Screenshots

![Screen Shot 2021-11-04 at 3 20 25 PM](https://user-images.githubusercontent.com/136959/140413918-a0f1f295-7c5e-4046-96de-30d3eeef06cf.png)

## Acceptance criteria
- [x] Documentation for `goBack` updated

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
