### PR TITLE
Add deprecation message to deploy doc

### DIFF
--- a/packages/documentation/src/pages/getting-started/workflow/deploy.mdx
+++ b/packages/documentation/src/pages/getting-started/workflow/deploy.mdx
@@ -5,6 +5,12 @@ tags: build, rollback, manual deploy, automatic deploy, static page deploy, depl
 
 # Deploy
 
+<div class="deprecation-message">
+    <h2>We're moving our docs!</h2>
+    <h3>Find <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Deployments.1844641889.html">the latest version of this page</a> on the Platform website.</h3>
+    <h3>Still can't find what you're looking for? Reach out to <a href="https://dsva.slack.com/archives/CBU0KDSB1">#vfs-platform-support</a> on Slack.</h3>
+</div>
+
 Code goes through several steps to get to production. This document describes this process. It should also be noted that this is the same flow for both content and code changes.
 
 ## Table of Contents

--- a/packages/documentation/src/pages/platform/architecture/build-deploy-flows.mdx
+++ b/packages/documentation/src/pages/platform/architecture/build-deploy-flows.mdx
@@ -5,6 +5,12 @@ tags: Jenkins, drupal, metalsmith, cache, master
 
 # Build and deploy process flows
 
+<div class="deprecation-message">
+    <h2>We're moving our docs!</h2>
+    <h3>Find <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Build-and-deploy-process-flows.1844346924.html">the latest version of this page</a> on the Platform website.</h3>
+    <h3>Still can't find what you're looking for? Reach out to <a href="https://dsva.slack.com/archives/CBU0KDSB1">#vfs-platform-support</a> on Slack.</h3>
+</div>
+
 Here you'll find flow diagrames for the different types of build and deploy flows we have for VA.gov. Those different flows are:
 
 - [Standard master/PR build](#standard-masterpr-build)


### PR DESCRIPTION
## Description

[Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/28990) associated with

This PR adds the deprecation banner to deploy documentation which has been recently [published](https://depo-platform-documentation.scrollhelp.site/developer-docs/Deployments.1844641889.html) [here](https://depo-platform-documentation.scrollhelp.site/developer-docs/Build-and-deploy-process-flows.1844346924.html)


## Testing done

N/A. Snippet copied from [here](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/046910f8838d1a30fe77a39214370ef0626e83a3/packages/documentation/src/pages/getting-started/workflow/overview.mdx)

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
