### PR TITLE
Fix dashboard links

### DIFF
--- a/packages/documentation/src/pages/index.jsx
+++ b/packages/documentation/src/pages/index.jsx
@@ -35,19 +35,26 @@ export default function Index({ location }) {
             .
           </li>
           <li>
-            For information about the unit test coverage report by application, see the{' '}
-            <Link to="/unit-test-coverage-report">
+            For information about the unit test coverage report by application,
+            see the{' '}
+            <Link to="/frontend-support-dashboard/unit-test-coverage-report">
               Unit Test Coverage Report
             </Link>
             .
           </li>
           <li>
             For information about the performance report by application, see the{' '}
-            <Link to="/lighthouse-performance-report">Performance Report</Link>.
+            <Link to="/frontend-support-dashboard/lighthouse-performance-report">
+              Performance Report
+            </Link>
+            .
           </li>
           <li>
             For information about cross app import statistics, see the{' '}
-            <Link to="/cross-app-import-report">Cross App Import Report</Link>.
+            <Link to="/frontend-support-dashboard/cross-app-import-report">
+              Cross App Import Report
+            </Link>
+            .
           </li>
         </ul>
       </div>


### PR DESCRIPTION
## Description
The dashboard links on the documentation homepage aren't working because they aren't prepended with `frontend-support-dashboard`.

## Testing done
Tested locally.

## Acceptance criteria
- [x] Dashboard links on the homepage should go to the correct URL.

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
