### PR TITLE
Remove gatsby-transformer-javascript-frontmatter

### DIFF
--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -27,7 +27,6 @@
     "gatsby-remark-slug": "^0.1.0",
     "gatsby-source-filesystem": "^2.8.0",
     "gatsby-source-git": "^1.0.2",
-    "gatsby-transformer-javascript-frontmatter": "^2.3.5",
     "gatsby-transformer-react-docgen": "^5.2.5",
     "gatsby-transformer-remark": "^2.13.0",
     "gatsby-transformer-sharp": "^2.9.0",

--- a/packages/documentation/yarn.lock
+++ b/packages/documentation/yarn.lock
@@ -7618,16 +7618,6 @@ gatsby-telemetry@^2.14.0:
     node-fetch "^2.6.1"
     uuid "3.4.0"
 
-gatsby-transformer-javascript-frontmatter@^2.3.5:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/gatsby-transformer-javascript-frontmatter/-/gatsby-transformer-javascript-frontmatter-2.10.0.tgz#4dda2c0884aba27027ed66adde2b3d331684d710"
-  integrity sha512-6cXovyoKdSJ77tQt48S+LBcsxFSUGKSG9lqWFNp1ASGFZy0QPmIMAx2eVA9zX0C62pj52U6aJRDhU3wn52OWGQ==
-  dependencies:
-    "@babel/parser" "^7.12.5"
-    "@babel/runtime" "^7.12.5"
-    "@babel/traverse" "^7.12.5"
-    bluebird "^3.7.2"
-
 gatsby-transformer-react-docgen@^5.2.5:
   version "5.9.0"
   resolved "https://registry.yarnpkg.com/gatsby-transformer-react-docgen/-/gatsby-transformer-react-docgen-5.9.0.tgz#bc121c45e6b1fb4f683d08326c1b5c394c7b80c7"


### PR DESCRIPTION
## Description
Removes the `gatsby-transformer-javascript-frontmatter` plugin since it isn't being used anymore.

## Testing done
Locally and in CI

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
