### PR TITLE
Set alert icon size to match design system guidelines

### DIFF
--- a/packages/formation/sass/modules/_m-alert.scss
+++ b/packages/formation/sass/modules/_m-alert.scss
@@ -12,7 +12,7 @@
     width: auto;
     background: none;
     font-family: "Font Awesome 5 Free";
-    font-size: 2rem;
+    font-size: 1.6rem;
     margin-right: units(2);
     position: static;
     font-weight: 900;


### PR DESCRIPTION
## Description
This PR normalizes icon sizing on the global alert component. It was reported that these icons were larger than icons used in nearly all other created alert components in the app. This violates the [Design System Guidelines - Category Number 04, Issue Number 07](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/VA.gov-experience-standards.1683980311.html). The reported desired icon size was the smaller size as shown in the screenshot below. 

##Original issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/34168

## Screenshots
![Annotation on 2021-12-09 at 10-26-04](https://user-images.githubusercontent.com/6738544/155553765-ed867cd4-08f8-4295-9dfb-a0c896004fe3.png)

## Acceptance criteria
- [x] Icon size matches other alerts on pages

## Definition of done
- [x] Changes have been tested in vets-website
- [x] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
