### PR TITLE
Add `ui:autocomplete` docs

### DIFF
--- a/packages/documentation/src/pages/forms/about-the-schema-and-uischema-objects.mdx
+++ b/packages/documentation/src/pages/forms/about-the-schema-and-uischema-objects.mdx
@@ -124,6 +124,10 @@ The VAFS code includes additional `uiSchema` functionality not found in the RJSF
   // It can also be a component, which passes the current form data as a property.
   'ui:title': ({ formData }) => <legend>{`A ${formData.thing} title`}</legend>,
 
+  // set "autocomplete" property on input - see
+  // https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#values
+  'ui:autocomplete': 'off',
+
   // Used instead of the `description` property in the JSON Schema. This can be a string
   // or a React component, and is normally used on object fields in the schema to provide
   // description text or HTML before a block of fields.

--- a/packages/documentation/src/pages/forms/available-widgets.mdx
+++ b/packages/documentation/src/pages/forms/available-widgets.mdx
@@ -68,14 +68,14 @@ Renders three separate fields for dates, two `<select>` elements for month and d
 
 ## `EmailWidget`
 
-Renders a `TextWidget` with the `type: "email"` passed to the `<input>` element.
+Renders a `TextWidget` with the `type: "email"` and `autocomplete: 'email'` passed to the `<input>` element.
 
 - **File:** [EmailWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/widgets/EmailWidget.jsx)
 - **Usage:** In the `uiSchema`, specify `'ui:widget': 'email'` for the given field.
 
 ## `PhoneNumberWidget`
 
-Renders a `TextWidget` with additional logic to strip non-numeric characters from the input before saving the input.
+Renders a `TextWidget` with additional logic to strip non-numeric characters from the input before saving the input. The phone number input includes an `autocomplete: 'tel'` setting.
 
 - **File:** [PhoneNumberWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/widgets/PhoneNumberWidget.jsx)
 - **Usage:** In the `uiSchema`, specify `'ui:widget': PhoneNumberWidget` for the given field.

--- a/packages/documentation/src/pages/forms/form-tutorial-advanced.mdx
+++ b/packages/documentation/src/pages/forms/form-tutorial-advanced.mdx
@@ -156,6 +156,8 @@ const formConfig = {
             }
           }
         },
+        // inputs for full name include the appropriate autocomplete properties:
+        // first (given-name), middle (additional-name) and last (family-name)
         veteranFullName: set('ui:options.expandUnder', 'myField', fullNameUI)
       },
       schema: {


### PR DESCRIPTION
## Description

Adding docs for the `ui:autocomplete` enhancement - https://github.com/department-of-veterans-affairs/react-jsonschema-form/pull/14

Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/37849

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] Add docs for `ui:autocomplete`

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
