### PR TITLE
Update GHA deploy job to use token

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -87,42 +87,39 @@ jobs:
       - name: Build
         run: GITHUB_API_KEY=${{ env.VA_VSP_BOT_GITHUB_TOKEN }} npm run build
 
-  # deploy:
-  #   name: Deploy
-  #   runs-on: ubuntu-latest
-  #   needs: [linting, testing, build]
-  #   if: github.ref == 'refs/heads/master'
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v2
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: [linting, testing, build]
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
-  #     - name: Install dependencies
-  #       uses: ./.github/workflows/install
-  #       with:
-  #         key: ${{ hashFiles('yarn.lock') }}
-  #         yarn_cache_folder: .cache/yarn
-  #         path: |
-  #           .cache/yarn
-  #           node_modules
+      - name: Install dependencies
+        uses: ./.github/workflows/install
+        with:
+          key: ${{ hashFiles('yarn.lock') }}
+          yarn_cache_folder: .cache/yarn
+          path: |
+            .cache/yarn
+            node_modules
 
-  #     - name: Configure AWS credentials
-  #       uses: aws-actions/configure-aws-credentials@v1
-  #       with:
-  #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         aws-region: us-gov-west-1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
 
-  #     - name: Get va github token
-  #       uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
-  #       with:
-  #         ssm_parameter: /devops/service_account/svc-gha-frontendteam-user/github-token 
-  #         env_variable_name: VA_GITHUB_TOKEN
+      - name: Get va-vsp-bot token
+        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
-  #     - name: Config Git
-  #       run: |
-  #         git config --global user.email james.kassemi+vabot@adhocteam.us
-  #         git config --global user.name va-bot
-  #         git config --global credential.helper '${{ github.workspace }}/scripts/credential-helper.sh'
+      - name: Config Git
+        run: git remote set-url origin https://git:${{ env.VA_VSP_BOT_GITHUB_TOKEN }}@github.com/veteran-facing-services-tools.git
 
-  #     - name: Deploy
-  #       run: GITHUB_API_KEY=${{ env.VA_GITHUB_TOKEN }} npm run deploy
+      - name: Deploy
+        run: GITHUB_API_KEY=${{ env.VA_VSP_BOT_GITHUB_TOKEN }} npm run deploy

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,21 +41,21 @@ pipeline {
       }
     }
 
-   stage('deploy') {
-    when { branch 'master' }
-    steps {
-      sh 'git config --global user.email james.kassemi+vabot@adhocteam.us'
-      sh 'git config --global user.name va-bot'
-      sh 'git config --global credential.helper "/bin/bash ' + env.WORKSPACE + '/scripts/credential-helper.sh"'
-      withCredentials([[
-        $class: 'UsernamePasswordMultiBinding',
-        credentialsId: 'va-bot',
-        usernameVariable: 'GIT_USERNAME',
-        passwordVariable: 'GIT_PASSWORD'
-      ]]) {
-        sh "GITHUB_API_KEY=${env.GIT_PASSWORD} npm run deploy"
-      }
-    }
-   }
+   //stage('deploy') {
+   //  when { branch 'master' }
+   //  steps {
+   //    sh 'git config --global user.email james.kassemi+vabot@adhocteam.us'
+   //    sh 'git config --global user.name va-bot'
+   //    sh 'git config --global credential.helper "/bin/bash ' + env.WORKSPACE + '/scripts/credential-helper.sh"'
+   //    withCredentials([[
+   //      $class: 'UsernamePasswordMultiBinding',
+   //      credentialsId: 'va-bot',
+   //      usernameVariable: 'GIT_USERNAME',
+   //      passwordVariable: 'GIT_PASSWORD'
+   //    ]]) {
+   //      sh "GITHUB_API_KEY=${env.GIT_PASSWORD} npm run deploy"
+   //    }
+   //  }
+   //}
   }
 }


### PR DESCRIPTION
## Description
This PR updates the `Deploy` job in GitHub Actions to properly use the token for publishing the documentation site to GitHub Pages.

## Testing done
Will test once merged in `master`.

## Acceptance criteria
- [x] GitHub Actions deploy properly uses token for deploys.

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
