### PR TITLE
Update content build master references to main

### DIFF
--- a/packages/documentation/src/pages/frontend-support-dashboard/lighthouse-performance-report/lighthouse-report.json
+++ b/packages/documentation/src/pages/frontend-support-dashboard/lighthouse-performance-report/lighthouse-report.json
@@ -5,206 +5,257 @@
   },
   "/auth/login/callback": {
     "path": "/auth/login/callback",
-    "s3": "/auth/login/callback.html"
+    "s3": "/auth/login/callback.html",
+    "app": "auth"
   },
   "/burials-and-memorials/application/530": {
     "path": "/burials-and-memorials/application/530",
-    "s3": "/burials-and-memorials/application/530.html"
+    "s3": "/burials-and-memorials/application/530.html",
+    "app": "burials"
   },
   "/burials-and-memorials/pre-need/form-10007-apply-for-eligibility": {
     "path": "/burials-and-memorials/pre-need/form-10007-apply-for-eligibility",
-    "s3": "/burials-and-memorials/pre-need/form-10007-apply-for-eligibility.html"
+    "s3": "/burials-and-memorials/pre-need/form-10007-apply-for-eligibility.html",
+    "app": "pre-need"
   },
   "/careers-employment/education-and-career-counseling/apply-career-guidance-form-28-8832": {
     "path": "/careers-employment/education-and-career-counseling/apply-career-guidance-form-28-8832",
-    "s3": "/careers-employment/education-and-career-counseling/apply-career-guidance-form-28-8832.html"
+    "s3": "/careers-employment/education-and-career-counseling/apply-career-guidance-form-28-8832.html",
+    "app": "vre"
   },
   "/careers-employment/vocational-rehabilitation/apply-vre-form-28-1900": {
     "path": "/careers-employment/vocational-rehabilitation/apply-vre-form-28-1900",
-    "s3": "/careers-employment/vocational-rehabilitation/apply-vre-form-28-1900.html"
+    "s3": "/careers-employment/vocational-rehabilitation/apply-vre-form-28-1900.html",
+    "app": "static-pages"
   },
   "/coronavirus-research/volunteer": {
     "path": "/coronavirus-research/volunteer",
-    "s3": "/coronavirus-research/volunteer.html"
+    "s3": "/coronavirus-research/volunteer.html",
+    "app": "coronavirus-research"
   },
   "/covid19screen": {
     "path": "/covid19screen",
-    "s3": "/covid19screen.html"
+    "s3": "/covid19screen.html",
+    "app": "coronavirus-screener"
   },
   "/decision-reviews/board-appeal/request-board-appeal-form-10182": {
     "path": "/decision-reviews/board-appeal/request-board-appeal-form-10182",
-    "s3": "/decision-reviews/board-appeal/request-board-appeal-form-10182.html"
+    "s3": "/decision-reviews/board-appeal/request-board-appeal-form-10182.html",
+    "app": "appeals"
   },
   "/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996": {
     "path": "/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996",
-    "s3": "/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996.html"
+    "s3": "/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996.html",
+    "app": "disability-benefits"
   },
   "/disability/file-disability-claim-form-21-526ez": {
     "path": "/disability/file-disability-claim-form-21-526ez",
-    "s3": "/disability/file-disability-claim-form-21-526ez.html"
+    "s3": "/disability/file-disability-claim-form-21-526ez.html",
+    "app": "disability-benefits"
   },
   "/disability/view-disability-rating/rating": {
     "path": "/disability/view-disability-rating/rating",
-    "s3": "/disability/view-disability-rating/rating.html"
+    "s3": "/disability/view-disability-rating/rating.html",
+    "app": "personalization"
   },
   "/discharge-upgrade-instructions": {
     "path": "/discharge-upgrade-instructions",
-    "s3": "/discharge-upgrade-instructions.html"
+    "s3": "/discharge-upgrade-instructions.html",
+    "app": "discharge-wizard"
   },
   "/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/apply-for-vettec-form-22-0994": {
     "path": "/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/apply-for-vettec-form-22-0994",
-    "s3": "/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/apply-for-vettec-form-22-0994.html"
+    "s3": "/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/apply-for-vettec-form-22-0994.html",
+    "app": "edu-benefits"
   },
   "/education/apply-for-education-benefits/application/1990": {
     "path": "/education/apply-for-education-benefits/application/1990",
-    "s3": "/education/apply-for-education-benefits/application/1990.html"
+    "s3": "/education/apply-for-education-benefits/application/1990.html",
+    "app": "edu-benefits"
   },
   "/education/apply-for-education-benefits/application/1990E": {
     "path": "/education/apply-for-education-benefits/application/1990E",
-    "s3": "/education/apply-for-education-benefits/application/1990E.html"
+    "s3": "/education/apply-for-education-benefits/application/1990E.html",
+    "app": "edu-benefits"
   },
   "/education/apply-for-education-benefits/application/1990N": {
     "path": "/education/apply-for-education-benefits/application/1990N",
-    "s3": "/education/apply-for-education-benefits/application/1990N.html"
+    "s3": "/education/apply-for-education-benefits/application/1990N.html",
+    "app": "edu-benefits"
   },
   "/education/apply-for-education-benefits/application/1995": {
     "path": "/education/apply-for-education-benefits/application/1995",
-    "s3": "/education/apply-for-education-benefits/application/1995.html"
+    "s3": "/education/apply-for-education-benefits/application/1995.html",
+    "app": "edu-benefits"
   },
   "/education/apply-for-education-benefits/application/5490": {
     "path": "/education/apply-for-education-benefits/application/5490",
-    "s3": "/education/apply-for-education-benefits/application/5490.html"
+    "s3": "/education/apply-for-education-benefits/application/5490.html",
+    "app": "edu-benefits"
   },
   "/education/apply-for-education-benefits/application/5495": {
     "path": "/education/apply-for-education-benefits/application/5495",
-    "s3": "/education/apply-for-education-benefits/application/5495.html"
+    "s3": "/education/apply-for-education-benefits/application/5495.html",
+    "app": "edu-benefits"
   },
   "/education/gi-bill/post-9-11/ch-33-benefit/status": {
     "path": "/education/gi-bill/post-9-11/ch-33-benefit/status",
-    "s3": "/education/gi-bill/post-9-11/ch-33-benefit/status.html"
+    "s3": "/education/gi-bill/post-9-11/ch-33-benefit/status.html",
+    "app": "post-911-gib-status"
   },
   "/education/opt-out-information-sharing/opt-out-form-0993": {
     "path": "/education/opt-out-information-sharing/opt-out-form-0993",
-    "s3": "/education/opt-out-information-sharing/opt-out-form-0993.html"
+    "s3": "/education/opt-out-information-sharing/opt-out-form-0993.html",
+    "app": "edu-benefits"
   },
   "/education/other-va-education-benefits/stem-scholarship/apply-for-scholarship-form-22-10203": {
     "path": "/education/other-va-education-benefits/stem-scholarship/apply-for-scholarship-form-22-10203",
-    "s3": "/education/other-va-education-benefits/stem-scholarship/apply-for-scholarship-form-22-10203.html"
+    "s3": "/education/other-va-education-benefits/stem-scholarship/apply-for-scholarship-form-22-10203.html",
+    "app": "edu-benefits"
   },
   "/education/other-va-education-benefits/veteran-rapid-retraining-assistance/apply-for-vrrap-form-22-1990s": {
     "path": "/education/other-va-education-benefits/veteran-rapid-retraining-assistance/apply-for-vrrap-form-22-1990s",
-    "s3": "/education/other-va-education-benefits/veteran-rapid-retraining-assistance/apply-for-vrrap-form-22-1990s.html"
+    "s3": "/education/other-va-education-benefits/veteran-rapid-retraining-assistance/apply-for-vrrap-form-22-1990s.html",
+    "app": "edu-benefits"
   },
   "/education/submit-school-feedback": {
     "path": "/education/submit-school-feedback",
-    "s3": "/education/submit-school-feedback.html"
+    "s3": "/education/submit-school-feedback.html",
+    "app": "edu-benefits"
   },
   "/education/yellow-ribbon-participating-schools": {
     "path": "/education/yellow-ribbon-participating-schools",
-    "s3": "/education/yellow-ribbon-participating-schools.html"
+    "s3": "/education/yellow-ribbon-participating-schools.html",
+    "app": "yellow-ribbon"
   },
   "/family-member-benefits/apply-for-caregiver-assistance-form-10-10cg": {
     "path": "/family-member-benefits/apply-for-caregiver-assistance-form-10-10cg",
-    "s3": "/family-member-benefits/apply-for-caregiver-assistance-form-10-10cg.html"
+    "s3": "/family-member-benefits/apply-for-caregiver-assistance-form-10-10cg.html",
+    "app": "caregivers"
   },
   "/find-locations": {
     "path": "/find-locations",
-    "s3": "/find-locations.html"
+    "s3": "/find-locations.html",
+    "app": "facility-locator"
   },
   "/gi-bill-comparison-tool": {
     "path": "/gi-bill-comparison-tool",
-    "s3": "/gi-bill-comparison-tool.html"
+    "s3": "/gi-bill-comparison-tool.html",
+    "app": "gi"
   },
   "/health-care/apply/application": {
     "path": "/health-care/apply/application",
-    "s3": "/health-care/apply/application.html"
+    "s3": "/health-care/apply/application.html",
+    "app": "hca"
   },
   "/health-care/appointment-check-in": {
     "path": "/health-care/appointment-check-in",
-    "s3": "/health-care/appointment-check-in.html"
+    "s3": "/health-care/appointment-check-in.html",
+    "app": "check-in"
   },
   "/health-care/covid-19-vaccine/sign-up": {
     "path": "/health-care/covid-19-vaccine/sign-up",
-    "s3": "/health-care/covid-19-vaccine/sign-up.html"
+    "s3": "/health-care/covid-19-vaccine/sign-up.html",
+    "app": "coronavirus-vaccination-expansion"
   },
   "/health-care/covid-19-vaccine/stay-informed": {
     "path": "/health-care/covid-19-vaccine/stay-informed",
-    "s3": "/health-care/covid-19-vaccine/stay-informed.html"
+    "s3": "/health-care/covid-19-vaccine/stay-informed.html",
+    "app": "coronavirus-vaccination"
   },
   "/health-care/medical-information-terms-conditions": {
     "path": "/health-care/medical-information-terms-conditions",
-    "s3": "/health-care/medical-information-terms-conditions.html"
+    "s3": "/health-care/medical-information-terms-conditions.html",
+    "app": "terms-and-conditions"
   },
   "/health-care/order-hearing-aid-batteries-and-accessories/order-form-2346": {
     "path": "/health-care/order-hearing-aid-batteries-and-accessories/order-form-2346",
-    "s3": "/health-care/order-hearing-aid-batteries-and-accessories/order-form-2346.html"
+    "s3": "/health-care/order-hearing-aid-batteries-and-accessories/order-form-2346.html",
+    "app": "disability-benefits/2346"
   },
   "/health-care/pay-copay-bill/your-current-balances": {
     "path": "/health-care/pay-copay-bill/your-current-balances",
-    "s3": "/health-care/pay-copay-bill/your-current-balances.html"
+    "s3": "/health-care/pay-copay-bill/your-current-balances.html",
+    "app": "medical-copays"
   },
   "/health-care/schedule-view-va-appointments/appointments": {
     "path": "/health-care/schedule-view-va-appointments/appointments",
-    "s3": "/health-care/schedule-view-va-appointments/appointments.html"
+    "s3": "/health-care/schedule-view-va-appointments/appointments.html",
+    "app": "vaos"
   },
   "/manage-va-debt/request-debt-help-form-5655": {
     "path": "/manage-va-debt/request-debt-help-form-5655",
-    "s3": "/manage-va-debt/request-debt-help-form-5655.html"
+    "s3": "/manage-va-debt/request-debt-help-form-5655.html",
+    "app": "debt-letters"
   },
   "/manage-va-debt/your-debt": {
     "path": "/manage-va-debt/your-debt",
-    "s3": "/manage-va-debt/your-debt.html"
+    "s3": "/manage-va-debt/your-debt.html",
+    "app": "debt-letters"
   },
   "/my-va": {
     "path": "/my-va",
-    "s3": "/my-va.html"
+    "s3": "/my-va.html",
+    "app": "personalization"
   },
   "/pension/application/527EZ": {
     "path": "/pension/application/527EZ",
-    "s3": "/pension/application/527EZ.html"
+    "s3": "/pension/application/527EZ.html",
+    "app": "pensions"
   },
   "/profile": {
     "path": "/profile",
-    "s3": "/profile.html"
+    "s3": "/profile.html",
+    "app": "personalization"
   },
   "/records/download-va-letters/letters": {
     "path": "/records/download-va-letters/letters",
-    "s3": "/records/download-va-letters/letters.html"
+    "s3": "/records/download-va-letters/letters.html",
+    "app": "letters"
   },
   "/records/get-veteran-id-cards/apply": {
     "path": "/records/get-veteran-id-cards/apply",
-    "s3": "/records/get-veteran-id-cards/apply.html"
+    "s3": "/records/get-veteran-id-cards/apply.html",
+    "app": "veteran-id-card"
   },
   "/resources/search": {
     "path": "/resources/search",
-    "s3": "/resources/search.html"
+    "s3": "/resources/search.html",
+    "app": "resources-and-support"
   },
   "/search": {
     "path": "/search",
-    "s3": "/search.html"
+    "s3": "/search.html",
+    "app": "search"
   },
   "/sign-in": {
     "path": "/sign-in",
-    "s3": "/sign-in.html"
+    "s3": "/sign-in.html",
+    "app": "login"
   },
   "/track-claims": {
     "path": "/track-claims",
-    "s3": "/track-claims.html"
+    "s3": "/track-claims.html",
+    "app": "claims-status"
   },
   "/va-payment-history/payments": {
     "path": "/va-payment-history/payments",
-    "s3": "/va-payment-history/payments.html"
+    "s3": "/va-payment-history/payments.html",
+    "app": "disability-benefits"
   },
   "/verify": {
     "path": "/verify",
-    "s3": "/verify.html"
+    "s3": "/verify.html",
+    "app": "verify"
   },
   "/view-change-dependents/add-remove-form-21-686c": {
     "path": "/view-change-dependents/add-remove-form-21-686c",
-    "s3": "/view-change-dependents/add-remove-form-21-686c.html"
+    "s3": "/view-change-dependents/add-remove-form-21-686c.html",
+    "app": "disability-benefits"
   },
   "/view-change-dependents/view": {
     "path": "/view-change-dependents/view",
-    "s3": "/view-change-dependents/view.html"
+    "s3": "/view-change-dependents/view.html",
+    "app": "personalization"
   }
 }

--- a/packages/documentation/src/pages/getting-started/common-tasks/run-build.mdx
+++ b/packages/documentation/src/pages/getting-started/common-tasks/run-build.mdx
@@ -6,62 +6,82 @@ tags: watch
 # Run and build VA.gov
 
 <div class="deprecation-message">
-    <h2>We're moving our docs!</h2>
-    <h3>Find <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Running-VA.gov-locally.1844248620.html">the latest version of this page</a> on the Platform website.</h3>
-    <h3>Still can't find what you're looking for? Reach out to <a href="https://dsva.slack.com/archives/CBU0KDSB1">#vfs-platform-support</a> on Slack.</h3>
+  <h2>We're moving our docs!</h2>
+  <h3>
+    Find{" "}
+    <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Running-VA.gov-locally.1844248620.html">
+      the latest version of this page
+    </a>{" "}
+    on the Platform website.
+  </h3>
+  <h3>
+    Still can't find what you're looking for? Reach out to{" "}
+    <a href="https://dsva.slack.com/archives/CBU0KDSB1">
+      #vfs-platform-support
+    </a>{" "}
+    on Slack.
+  </h3>
 </div>
 
 ## Prerequisite
 
-- Complete the [first](/getting-started) step in *Start up guide*.
+- Complete the [first](/getting-started) step in _Start up guide_.
 
 ## Locally run VA.gov
 
 Start the watch task:
+
 ```bash
 yarn watch
 ```
+
 ### Build
 
 #### vets-website
-  - **Webpack** manages this build pipeline. At a high level, this process:
-    1. Starts **Webpack**'s devevelopment server which
-       - **Builds** the **JavaScript** and **CSS** bundles
-       - **Serves** the **JavaScript** and **CSS** bundles built by Webpack as well as any scaffolded application pages [http://localhost:3001](http://localhost:3001)
+
+- **Webpack** manages this build pipeline. At a high level, this process:
+  1. Starts **Webpack**'s devevelopment server which
+     - **Builds** the **JavaScript** and **CSS** bundles
+     - **Serves** the **JavaScript** and **CSS** bundles built by Webpack as well as any scaffolded application pages [http://localhost:3001](http://localhost:3001)
 
 #### content-build
-  - **Metalsmith** manages this build pipeline. At a high level, this process:
-    1. Retrieves and **builds** all of the **static pages** sourced from `vagov-content` or Drupal
-    2. **Serves** the **static content** built by Metalsmith at [http://localhost:3002](http://localhost:3002)
+
+- **Metalsmith** manages this build pipeline. At a high level, this process:
+  1. Retrieves and **builds** all of the **static pages** sourced from `vagov-content` or Drupal
+  2. **Serves** the **static content** built by Metalsmith at [http://localhost:3002](http://localhost:3002)
 
 ### Output
-  - **Metalsmith** in the `content-build` repository outputs **static pages** to`build/localhost`
-  - **Webpack** in the `vets-website` repository development server has **no output**. **JavaScript** and **CSS** are kept on disk.
+
+- **Metalsmith** in the `content-build` repository outputs **static pages** to`build/localhost`
+- **Webpack** in the `vets-website` repository development server has **no output**. **JavaScript** and **CSS** are kept on disk.
 
 ### Watch and rebuild
-  - **Metalsmith** in the `content-build` repository will rebuild **static pages** when changes are saved to **templates** or content in `vagov-content`
-  - **Webpack** in the `vets-website` repository will rebuild when changes are saved to **JavaScript** or **SCSS**
-  - Both updates require a browser refresh to see changes.
-  - Changes to build process or configuration files are typically not picked up, and require a restart of the watch task to become active.
+
+- **Metalsmith** in the `content-build` repository will rebuild **static pages** when changes are saved to **templates** or content in `vagov-content`
+- **Webpack** in the `vets-website` repository will rebuild when changes are saved to **JavaScript** or **SCSS**
+- Both updates require a browser refresh to see changes.
+- Changes to build process or configuration files are typically not picked up, and require a restart of the watch task to become active.
 
 ## Locally build and run for specific environment
 
 _Note: most of the time, it's better to use the `watch` task to build the site locally since it is the most developer-friendly experience._
 
-| Environment | Build Command | Output directory | Run Command |
-| --- | --- | --- | ---|
-| localhost | `yarn build` | `build/localhost` | `npx http-server -p 3001 build/localhost` |
-| dev.va.gov | `yarn build --buildtype=vagovdev` | `build/vagovdev` | `npx http-server -p 3001 build/vagovdev` |
+| Environment    | Build Command                                             | Output directory     | Run Command                                  |
+| -------------- | --------------------------------------------------------- | -------------------- | -------------------------------------------- |
+| localhost      | `yarn build`                                              | `build/localhost`    | `npx http-server -p 3001 build/localhost`    |
+| dev.va.gov     | `yarn build --buildtype=vagovdev`                         | `build/vagovdev`     | `npx http-server -p 3001 build/vagovdev`     |
 | staging.va.gov | `NODE_ENV=production yarn build --buildtype=vagovstaging` | `build/vagovstaging` | `npx http-server -p 3001 build/vagovstaging` |
-| www.va.gov | `NODE_ENV=production yarn build --buildtype=vagovprod` | `build/vagovprod` | `npx http-server -p 3001 build/vagovprod` |
+| www.va.gov     | `NODE_ENV=production yarn build --buildtype=vagovprod`    | `build/vagovprod`    | `npx http-server -p 3001 build/vagovprod`    |
 
 ### Build commands
+
 - **create** the **static pages** from the markdown content in the `vagov-content` repository and data queried from the Drupal API into their **output directory**
 - **create** the **JavaScript** and **CSS** files with Webpack into `/generated` folder in their **output directory** with Webpack
 
 _Production like builds are required for staging and production environments. **NODE_ENV=production** environment variable is required to be set when running these build commands_
 
 ### Run commands
+
 - **start** an `http-server` that **serves** the **static pages** from the **output directory** at [http://localhost:3001](https://localhost:3001)
 
 _Typically, the reason for building the site locally like this is to build it in production mode and check that it is behaving as you'd expect._
@@ -69,5 +89,6 @@ _Typically, the reason for building the site locally like this is to build it in
 _**Deep-linking** to urls that are rendered by **React** apps on VA.gov **will not work** when you run the site this way, as that relies on some server-side routing that is handled in nginx (or the Webpack dev server when running the `watch` task)_
 
 ## Related source
-- [Metalsmith build script](https://github.com/department-of-veterans-affairs/content-build/tree/master/src/site/stages/build)
+
+- [Metalsmith build script](https://github.com/department-of-veterans-affairs/content-build/tree/main/src/site/stages/build)
 - [Webpack development server config](https://github.com/department-of-veterans-affairs/vets-website/blob/master/config/webpack.dev.config.js)

--- a/packages/documentation/src/pages/getting-started/workflow/deploy.mdx
+++ b/packages/documentation/src/pages/getting-started/workflow/deploy.mdx
@@ -6,9 +6,21 @@ tags: build, rollback, manual deploy, automatic deploy, static page deploy, depl
 # Deploy
 
 <div class="deprecation-message">
-    <h2>We're moving our docs!</h2>
-    <h3>Find <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Deployments.1844641889.html">the latest version of this page</a> on the Platform website.</h3>
-    <h3>Still can't find what you're looking for? Reach out to <a href="https://dsva.slack.com/archives/CBU0KDSB1">#vfs-platform-support</a> on Slack.</h3>
+  <h2>We're moving our docs!</h2>
+  <h3>
+    Find{" "}
+    <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Deployments.1844641889.html">
+      the latest version of this page
+    </a>{" "}
+    on the Platform website.
+  </h3>
+  <h3>
+    Still can't find what you're looking for? Reach out to{" "}
+    <a href="https://dsva.slack.com/archives/CBU0KDSB1">
+      #vfs-platform-support
+    </a>{" "}
+    on Slack.
+  </h3>
 </div>
 
 Code goes through several steps to get to production. This document describes this process. It should also be noted that this is the same flow for both content and code changes.
@@ -35,12 +47,12 @@ Code goes through several steps to get to production. This document describes th
 
 All listed times are eastern timezone and are **scheduled Monday&ndash;Friday** (excluding holidays). All deployments are executed from the master branch in each repository.
 
-| Application | Changes in by | Deployment Start | Release Information | Jenkins Job |
-| --- | --- | --- | --- | --- |
-| vets-website | 2:00pm ET | 3:00pm ET | [vets-website release history](https://github.com/department-of-veterans-affairs/vets-website/releases) | [vets-gov-autodeploy-vets-website](http://jenkins.vetsgov-internal/job/deploys/job/vets-gov-autodeploy-vets-website/) |
-| content-build | 2:00pm ET | 3:00pm ET | [content-build release history](https://github.com/department-of-veterans-affairs/content-build/releases) | [vets-gov-autodeploy-content-build](http://jenkins.vetsgov-internal/job/deploys/job/vets-gov-autodeploy-content-build/) |
-| vets-api | 2:00pm ET | 3:00pm ET | [vets-api release history](https://github.com/department-of-veterans-affairs/vets-api/releases) | [vets-gov-autodeploy-vets-api](http://jenkins.vfs.va.gov/job/deploys/job/vets-gov-autodeploy-vets-api/) |
-| content-build (content only) | n/a | 9am&ndash;12pm Hourly, 1:45pm, 4pm, 5pm ET | [content-build latest release](https://github.com/department-of-veterans-affairs/content-build/releases/latest) | [vets-gov-autodeploy-content-build](http://jenkins.vetsgov-internal/job/deploys/job/vets-gov-autodeploy-content-build/) |
+| Application                  | Changes in by | Deployment Start                           | Release Information                                                                                             | Jenkins Job                                                                                                             |
+| ---------------------------- | ------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| vets-website                 | 2:00pm ET     | 3:00pm ET                                  | [vets-website release history](https://github.com/department-of-veterans-affairs/vets-website/releases)         | [vets-gov-autodeploy-vets-website](http://jenkins.vetsgov-internal/job/deploys/job/vets-gov-autodeploy-vets-website/)   |
+| content-build                | 2:00pm ET     | 3:00pm ET                                  | [content-build release history](https://github.com/department-of-veterans-affairs/content-build/releases)       | [vets-gov-autodeploy-content-build](http://jenkins.vetsgov-internal/job/deploys/job/vets-gov-autodeploy-content-build/) |
+| vets-api                     | 2:00pm ET     | 3:00pm ET                                  | [vets-api release history](https://github.com/department-of-veterans-affairs/vets-api/releases)                 | [vets-gov-autodeploy-vets-api](http://jenkins.vfs.va.gov/job/deploys/job/vets-gov-autodeploy-vets-api/)                 |
+| content-build (content only) | n/a           | 9am&ndash;12pm Hourly, 1:45pm, 4pm, 5pm ET | [content-build latest release](https://github.com/department-of-veterans-affairs/content-build/releases/latest) | [vets-gov-autodeploy-content-build](http://jenkins.vetsgov-internal/job/deploys/job/vets-gov-autodeploy-content-build/) |
 
 ## Overview
 
@@ -57,13 +69,13 @@ _A big assumption in this process is that the `master` should always be deployab
 
 - Every work day at the configured time the [vets-gov-autodeploy-vets-website](http://jenkins.vfs.va.gov/job/deploys/job/vets-gov-autodeploy-vets-website/) and [vets-gov-autodeploy-content-build](http://jenkins.vfs.va.gov/job/deploys/job/vets-gov-autodeploy-content-build/) jobs will run.
 - The autodeploy jobs will call the [vets-website release](http://jenkins.vfs.va.gov/job/releases/job/vets-website/) and [content-build release](http://jenkins.vfs.va.gov/job/releases/job/content-build/) jobs which create a [vets-website release](https://github.com/department-of-veterans-affairs/vets-website/releases) and [content-build release](https://github.com/department-of-veterans-affairs/content-build/releases).
-- Release artifacts are deployed to production by the [vets-website-vagovprod](http://jenkins.vfs.va.gov/job/deploys/job/vets-website-vagovprod/) and [content-build-vagovprod](http://jenkins.vfs.va.gov/job/deploys/job/content-build-vagovprod/) jobs. These jobs should *not* be triggered manually.
+- Release artifacts are deployed to production by the [vets-website-vagovprod](http://jenkins.vfs.va.gov/job/deploys/job/vets-website-vagovprod/) and [content-build-vagovprod](http://jenkins.vfs.va.gov/job/deploys/job/content-build-vagovprod/) jobs. These jobs should _not_ be triggered manually.
 
 ## Rollbacks
 
-If a production deployment introduces issues that affect Service Level Objectives (SLOs) 
-established for the project, you may restore service to users by rolling back 
-to a previous deployment. This is accomplished by triggering a new deploy job in Jenkins using a 
+If a production deployment introduces issues that affect Service Level Objectives (SLOs)
+established for the project, you may restore service to users by rolling back
+to a previous deployment. This is accomplished by triggering a new deploy job in Jenkins using a
 previous release tag. Typical deployment times are under 5mins.
 
 1. Identify the release you want to rollback to by visiting the [vets-website](https://github.com/department-of-veterans-affairs/vets-website/releases) or [content-build](https://github.com/department-of-veterans-affairs/content-build/releases) release log(s)
@@ -73,7 +85,7 @@ previous release tag. Typical deployment times are under 5mins.
 5. Enter the ref value into the ref field
 6. Click "Build"
 
-If SLOs are not affected and a fix is not critical, no rollback will be issued. Instead the fix should 
+If SLOs are not affected and a fix is not critical, no rollback will be issued. Instead the fix should
 be applied through the standard development workflow.
 
 ## Creating a vets-website Release
@@ -99,7 +111,7 @@ If the commit you are trying to release to does not have an official release tag
 2. Check out the commit you want
 3. Note the latest release from the [content-build release log](https://github.com/department-of-veterans-affairs/content-build/releases)
 4. Visit the [release job in Jenkins](http://jenkins.vfs.va.gov/job/releases/job/content-build/)
-5. Make sure the commit you want to use has [passed through the build pipeline in master](https://github.com/department-of-veterans-affairs/content-build/commits/master)
+5. Make sure the commit you want to use has [passed through the build pipeline in master](https://github.com/department-of-veterans-affairs/content-build/commits/main)
 6. Replace the "ref" value with the commit you want to use to create the release (it will be a long string like: `7c74702605561a33a5a6edbe46a95ac43dddb1df`)
 7. Click "Build"
 8. You should now see it in the [content-build release log](https://github.com/department-of-veterans-affairs/content-build/releases) and can follow the normal rollback steps.
@@ -108,13 +120,12 @@ This should create a new release, and deploy it to va.gov.
 
 **Note:** Verify that there are no [scheduled](#automated-deployment-schedule) [content releases](http://jenkins.vfs.va.gov/job/deploys/job/content-build-content-autodeploy/) around the time of creating a release. A following release can override your manual release if started before your release has finished.
 
-
 ## Hotfixes
 
-The **use of hotfixes is discouraged**, but may be useful in an emergency situation when `master` 
-has significantly deviated from the release and a fix to the failed production release is critical. 
-To create a hotfix, create a branch from the last stable release tag, make changes necessary (with review), 
-create a new release tag following the correct naming scheme, and trigger a deploy in Jenkins with the 
+The **use of hotfixes is discouraged**, but may be useful in an emergency situation when `master`
+has significantly deviated from the release and a fix to the failed production release is critical.
+To create a hotfix, create a branch from the last stable release tag, make changes necessary (with review),
+create a new release tag following the correct naming scheme, and trigger a deploy in Jenkins with the
 release name as a parameter. This documentation is above, in the "Creating a Release" section.
 
 ## vets-website Manual deployment
@@ -143,22 +154,22 @@ _You may need to contact the developers of those commits to verify._
    - Click **Build**
    - Verify commits in **deployment notification**
 
- _In the [#vfs-platform-builds](https://dsva.slack.com/archives/C0MQ281DJ) Slack channel, Jenkins will include a link that shows the exact commits being released in the **deploy notification**._
- 
+_In the [#vfs-platform-builds](https://dsva.slack.com/archives/C0MQ281DJ) Slack channel, Jenkins will include a link that shows the exact commits being released in the **deploy notification**._
+
 2. **Verify** changes in **production** once the build finishes
 
 ### Manual deployment of vets-website to staging or dev
 
-When staging deployments get clogged up or staging as a whole falls behind production 
-(for various reasons) you may need to execute a manual deployment for staging. To do this 
-use the following steps: 
+When staging deployments get clogged up or staging as a whole falls behind production
+(for various reasons) you may need to execute a manual deployment for staging. To do this
+use the following steps:
 
 1. Visit the [vets-website vagovstaging](http://jenkins.vfs.va.gov/job/deploys/job/vets-website-vagovstaging/) job in Jenkins (or [vets-website vagovdev](http://jenkins.vfs.va.gov/job/deploys/job/vets-website-vagovdev/) for dev)
 2. Click **Build with Parameters**
 3. Make sure the commit you want to use has [passed through the build pipeline in master](https://github.com/department-of-veterans-affairs/vets-website/commits/master)
 4. Replace the "ref" value with the commit you want to use to create the release (it will be a long string like: `7c74702605561a33a5a6edbe46a95ac43dddb1df`)
 5. Click **Build**
-6. You can watch the deployment process from the [vets-website vagovstaging](http://jenkins.vfs.va.gov/job/deploys/job/vets-website-vagovstaging/) (or [vets-website vagovdev](http://jenkins.vfs.va.gov/job/deploys/job/vets-website-vagovdev/) for dev) status page in Jenkins 
+6. You can watch the deployment process from the [vets-website vagovstaging](http://jenkins.vfs.va.gov/job/deploys/job/vets-website-vagovstaging/) (or [vets-website vagovdev](http://jenkins.vfs.va.gov/job/deploys/job/vets-website-vagovdev/) for dev) status page in Jenkins
 7. [Confirm that your deployed commit is on staging](https://frontend-support-dashboard.now.sh/)
 
 ## content-build Manual deployment
@@ -180,13 +191,13 @@ Multiple manual deploys are supported in Jenkins:
    - Click **Build**
    - Verify commits in **deployment notification**
 
- _In the [#vfs-platform-builds](https://dsva.slack.com/archives/C0MQ281DJ) Slack channel, Jenkins will include a link that shows the exact commits being released in the **deploy notification**._
+_In the [#vfs-platform-builds](https://dsva.slack.com/archives/C0MQ281DJ) Slack channel, Jenkins will include a link that shows the exact commits being released in the **deploy notification**._
 
 ### Full production deploy of content-build
 
 1. Verify that your changes are committed and that the changes since the last deploy are safe to deploy:
    - **Last deployment time**: You can check the build [history](http://jenkins.vetsgov-internal/job/deploys/job/vets-gov-autodeploy-content-build/) for the time of the last deploy (usually daily at 2pm EST)
-   - **Commit history**: [Look](https://github.com/department-of-veterans-affairs/content-build/commits/master) for commits after the last deploy and verify they're production ready.
+   - **Commit history**: [Look](https://github.com/department-of-veterans-affairs/content-build/commits/main) for commits after the last deploy and verify they're production ready.
 
 _You may need to contact the developers of those commits to verify._
 
@@ -200,20 +211,20 @@ _You may need to contact the developers of those commits to verify._
 
 ### Manual deployment of content-build to staging or dev
 
-When staging deployments get clogged up or staging as a whole falls behind production 
-(for various reasons) you may need to execute a manual deployment for staging. To do this 
-use the following steps: 
+When staging deployments get clogged up or staging as a whole falls behind production
+(for various reasons) you may need to execute a manual deployment for staging. To do this
+use the following steps:
 
 1. Visit the [content-build vagovstaging](http://jenkins.vfs.va.gov/job/deploys/job/content-build-vagovstaging/) job in Jenkins (or [content-build vagovdev](http://jenkins.vfs.va.gov/job/deploys/job/content-build-vagovdev/))
 2. Click **Build with Parameters**
-3. Make sure the commit you want to use has [passed through the build pipeline in master](https://github.com/department-of-veterans-affairs/content-build/commits/master)
+3. Make sure the commit you want to use has [passed through the build pipeline in master](https://github.com/department-of-veterans-affairs/content-build/commits/main)
 4. Replace the "ref" value with the commit you want to use to create the release (it will be a long string like: `7c74702605561a33a5a6edbe46a95ac43dddb1df`)
 5. Click **Build**
-6. You can watch the deployment process from the [content-build vagovstaging](http://jenkins.vfs.va.gov/job/deploys/job/content-build-vagovstaging/) (or [content-build vagovdev](http://jenkins.vfs.va.gov/job/deploys/job/content-build-vagovdev/)) status page in Jenkins 
+6. You can watch the deployment process from the [content-build vagovstaging](http://jenkins.vfs.va.gov/job/deploys/job/content-build-vagovstaging/) (or [content-build vagovdev](http://jenkins.vfs.va.gov/job/deploys/job/content-build-vagovdev/)) status page in Jenkins
 
 ## Dealing with Flaky Unit Tests
 
-A test fixture is a fixed state so the results should be repeatable. A flaky test is a test 
+A test fixture is a fixed state so the results should be repeatable. A flaky test is a test
 which could fail or pass for the same configuration. In monitoring the deploy of vets-website
 we often have to deal with flaky tests in a few specific situations:
 
@@ -225,30 +236,30 @@ To tell if an auto-deploy is nearing you can refer to the table at the top of th
 
 #### A flaky test inside of a pull request
 
-If a unit test fails in a pull request, no one is alerted so it’s more likely that it gets refreshed 
+If a unit test fails in a pull request, no one is alerted so it’s more likely that it gets refreshed
 to unblock the work or skipped in the PR, then reviewed by the code owner. This action is the
 responsibility of the pull request owner and has no effect on the daily deploy.
 
 #### A flaky test in `master` when an autodeploy is not nearing
 
-If a unit test fails in master and a deploy is not nearing (or has already happened for the day), 
-the failure can be ignored as inconsequential. However, the pipeline should still be refreshed 
-in order to tell if the test is flaky or legitamately failing. The relevant code owner should 
-then be alerted so they can either skip or fix the test before the next deploy (at the discretion 
+If a unit test fails in master and a deploy is not nearing (or has already happened for the day),
+the failure can be ignored as inconsequential. However, the pipeline should still be refreshed
+in order to tell if the test is flaky or legitamately failing. The relevant code owner should
+then be alerted so they can either skip or fix the test before the next deploy (at the discretion
 of the test owner).
 
 #### A flaky test in `master` when an auto-deploy is nearing
 
-If a unit test fails in `master` and a scheduled deploy is nearing, the [Front-end Tools support 
-team member](https://github.com/orgs/department-of-veterans-affairs/teams/frontend-review-group) should 
-refresh the pipeline immediately, open up a pull request to skip the test, and alert the code owner 
-for a fix and/or pull request approval to skip the test. Ideally the test gets fixed, but in reality, 
-the process to merge can often take longer than is allowed for by the timing of the deploy. This is 
-why it is important to have a pull request opened immediately to skip the test if needed - no need 
-to wait for the code owner, delays can fail the deploy. This is the most common reason for a failed 
+If a unit test fails in `master` and a scheduled deploy is nearing, the [Front-end Tools support
+team member](https://github.com/orgs/department-of-veterans-affairs/teams/frontend-review-group) should
+refresh the pipeline immediately, open up a pull request to skip the test, and alert the code owner
+for a fix and/or pull request approval to skip the test. Ideally the test gets fixed, but in reality,
+the process to merge can often take longer than is allowed for by the timing of the deploy. This is
+why it is important to have a pull request opened immediately to skip the test if needed - no need
+to wait for the code owner, delays can fail the deploy. This is the most common reason for a failed
 deploy so we should all be on high alert for it while on a support rotation.
 
-As the pull request is running through the pipeline, the support engineer should keep 
-refreshing the master pipeline just in case it catches and is successful to prevent a failed deploy. 
-Even if the deploy is successful, the test should be either fixed or skipped as to not block future 
+As the pull request is running through the pipeline, the support engineer should keep
+refreshing the master pipeline just in case it catches and is successful to prevent a failed deploy.
+Even if the deploy is successful, the test should be either fixed or skipped as to not block future
 deploys.


### PR DESCRIPTION
## Description
This PR updates references to the `master` branch of the `content-build` repo to `main` in preparation for the setting the default branch name of `content-build` to `main`.


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
