### PR TITLE
update branch references master -> main for vets-website and content-build

### DIFF
--- a/packages/documentation/src/pages/forms/available-features-and-usage-guidelines.mdx
+++ b/packages/documentation/src/pages/forms/available-features-and-usage-guidelines.mdx
@@ -66,7 +66,7 @@ const formConfig = {
 };
 ```
 
-For the code implementation, see [FormApp.jsx](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/js/containers/FormApp.jsx).
+For the code implementation, see [FormApp.jsx](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/js/containers/FormApp.jsx).
 
 ## Progress bar
 
@@ -86,7 +86,7 @@ VAFS includes the progress bar by default, and will display automatically when t
 
 For the code implementation, see:
 
-- [FormNav.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/components/FormNav.jsx)
+- [FormNav.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/platform/forms-system/src/js/components/FormNav.jsx)
 - [va-segmented-progress-bar.tsx](https://github.com/department-of-veterans-affairs/component-library/blob/master/packages/web-components/src/components/va-segmented-progress-bar/va-segmented-progress-bar.tsx)
 
 ## Title and Subtitle
@@ -108,7 +108,7 @@ const formConfig = {
 };
 ```
 
-For the code implementation, see [FormTitle.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/components/FormTitle.jsx).
+For the code implementation, see [FormTitle.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/platform/forms-system/src/js/components/FormTitle.jsx).
 
 ## Date
 
@@ -120,11 +120,11 @@ Defines a date picker with validations.
 
 Define these fields in the `schema` and then reference them in the `uiSchema`. These date field definitions are available:
 
-- [date.js](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/definitions/date.js)
-- [dateRange.js](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/definitions/dateRange.js)
-- [currentOrPastDate.js](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/definitions/currentOrPastDate.js)
-- [monthYear.js](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/definitions/monthYear.js)
-- [monthYearRange.js](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/definitions/monthYearRange.js)
+- [date.js](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/platform/forms-system/src/js/definitions/date.js)
+- [dateRange.js](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/platform/forms-system/src/js/definitions/dateRange.js)
+- [currentOrPastDate.js](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/platform/forms-system/src/js/definitions/currentOrPastDate.js)
+- [monthYear.js](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/platform/forms-system/src/js/definitions/monthYear.js)
+- [monthYearRange.js](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/platform/forms-system/src/js/definitions/monthYearRange.js)
 
 For example:
 
@@ -152,7 +152,7 @@ Alerts are included automatically in fields that include validation. Taken from 
 
 ### Usage guidelines
 
-For examples of how alerts are used, see https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/js/widgets.
+For examples of how alerts are used, see https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/js/widgets.
 
 ## Radio button group
 
@@ -206,7 +206,7 @@ uiSchema: {
 }
 ```
 
-For the code implementation, see [RadioWidget](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/widgets/RadioWidget.jsx).
+For the code implementation, see [RadioWidget](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/platform/forms-system/src/js/widgets/RadioWidget.jsx).
 
 ## Checkbox group
 
@@ -255,7 +255,7 @@ uiSchema: {
 }
 ```
 
-For the code implementation, see [CheckboxWidget](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/widgets/CheckboxWidget.jsx).
+For the code implementation, see [CheckboxWidget](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/platform/forms-system/src/js/widgets/CheckboxWidget.jsx).
 
 ## Required field
 
@@ -280,7 +280,7 @@ There are several ways that form fields can be invalid, such as a required field
 - **To show an error on a blank field that is required**, include the field in the array under the `required` property in the `schema`. An error on that field will automatically be rendered if the field is blank.
 - **To show an error on a field for any other reason** (e.g., it has not met certain data requirements), pass a validation function to the array for the `ui:validations` property under that field in `uiSchema`.
 
-The error message that is displayed can either be a default message or one that you specify. There are several [default error messages](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/validation.js) for different situations.
+The error message that is displayed can either be a default message or one that you specify. There are several [default error messages](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/platform/forms-system/src/js/validation.js) for different situations.
 
 To show a custom error message, add the message to the `ui:errorMessages` object in the `uiSchema` as a key value pair:
 
@@ -390,7 +390,7 @@ Your config file might look like this:
 }
 ```
 
-For the code implementation, see [helpers.js](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/state/helpers.js).
+For the code implementation, see [helpers.js](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/platform/forms-system/src/js/state/helpers.js).
 
 ## Sequential duplicate form groups
 
@@ -456,7 +456,7 @@ These properties are nested under `uiSchema: { 'ui:options': {} }`:
 - `keepInPageOnReview`: By default, array fields that are displayed on a single page in a form, such as information for multiple dependents, are displayed in a separate section on the review page. To keep the information in a single section on a review page, set this property.
 - `hideEmptyValueInReview`: Hides the review row (e.g. "Street address 3") if the form data is an empty string, `null` or `undefined`. This option does not work if a custom `'ui:reviewField'` is controlling the review output.
 
-For the code implementation, see the [review folder](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/review).
+For the code implementation, see the [review folder](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/platform/forms-system/src/js/review).
 
 ## Required checkbox before form submission
 
@@ -497,7 +497,7 @@ preSubmitInfo: {
 
 - If you don't specify a **preSubmitInfo**, no notice or checkbox appears above the submit button. Most applications will want to give some sort of notice to the user before they submit the form. Although this section is optional, we recommend you specify it.
 
-- For the **code implementation**, see [PreSubmitSection](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/components/PreSubmitSection.jsx) and [SubmitController](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/review/SubmitController.jsx).
+- For the **code implementation**, see [PreSubmitSection](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/platform/forms-system/src/js/components/PreSubmitSection.jsx) and [SubmitController](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/platform/forms-system/src/js/review/SubmitController.jsx).
 
 #### `CustomComponent` props
 

--- a/packages/documentation/src/pages/forms/available-widgets.mdx
+++ b/packages/documentation/src/pages/forms/available-widgets.mdx
@@ -11,7 +11,7 @@ Some widgets are associated with particular schema types or formats. There are a
 Widgets from the [react-jsonschema-form library](/forms/about-the-schema-and-uischema-objects#understanding-the-uischema-object) include string mappings. Widgets created specifically for VAFS do not have mappings, and therefore must be specified by passing the component for the widget directly to the config. To include such widgets, import the widget at the top of the file:
 
 ```js
-import CurrencyWidget from 'platform/forms-system/src/js/widgets/CurrencyWidget';
+import CurrencyWidget from "platform/forms-system/src/js/widgets/CurrencyWidget";
 ```
 
 Then, set the `ui:widget` field to the imported widget name:
@@ -42,76 +42,75 @@ Available widgets are:
 
 Renders a `<input type="number">` HTML element, and is used when determining how many times a group of questions should be rendered. For more information about grouping common questions, see "[Sequential duplicate form groups](/forms/available-features-and-usage-guidelines#sequential-duplicate-form-groups)."
 
-- **File:** [ArrayCountWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/widgets/ArrayCountWidget.jsx)
+- **File:** [ArrayCountWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/platform/forms-system/src/js/widgets/ArrayCountWidget.jsx)
 - **Usage:** In the `uiSchema`, specify `'ui:widget': ArrayCountWidget` for the given field.
 
 ## `CheckboxWidget`
 
 Renders a single `<input type="checkbox">` HTML element. For information about rendering multiple checkboxes together, see "[Checkbox Group](/forms/available-features-and-usage-guidelines#checkbox-group)."
 
-- **File:** [CheckboxWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/widgets/CheckboxWidget.jsx)
+- **File:** [CheckboxWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/platform/forms-system/src/js/widgets/CheckboxWidget.jsx)
 - **Usage:** Usually the `CheckboxWidget` is not specified directly in the `uiSchema` because it renders by default for a schema that specifies `type: 'boolean'`.
 
 ## `CurrencyWidget`
 
 Renders a `<input>` HTML element with some additional logic to handle parsing currency inputs.
 
-- **File:** [CurrencyWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/widgets/CurrencyWidget.jsx)
+- **File:** [CurrencyWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/platform/forms-system/src/js/widgets/CurrencyWidget.jsx)
 - **Usage:** In the `uiSchema`, specify `'ui:widget': CurrencyWidget` for the given field.
 
 ## `DateWidget`
 
 Renders three separate fields for dates, two `<select>` elements for month and day and one `<input>` element for the year.
 
-- **File:** [DateWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/widgets/DateWidget.jsx)
+- **File:** [DateWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/platform/forms-system/src/js/widgets/DateWidget.jsx)
 - **Usage:** In the `uiSchema`, specify `'ui:widget': 'date'` for the given field.
 
 ## `EmailWidget`
 
 Renders a `TextWidget` with the `type: "email"` and `autocomplete: 'email'` passed to the `<input>` element.
 
-- **File:** [EmailWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/widgets/EmailWidget.jsx)
+- **File:** [EmailWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/platform/forms-system/src/js/widgets/EmailWidget.jsx)
 - **Usage:** In the `uiSchema`, specify `'ui:widget': 'email'` for the given field.
 
 ## `PhoneNumberWidget`
 
 Renders a `TextWidget` with additional logic to strip non-numeric characters from the input before saving the input. The phone number input includes an `autocomplete: 'tel'` setting.
 
-- **File:** [PhoneNumberWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/widgets/PhoneNumberWidget.jsx)
+- **File:** [PhoneNumberWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/platform/forms-system/src/js/widgets/PhoneNumberWidget.jsx)
 - **Usage:** In the `uiSchema`, specify `'ui:widget': PhoneNumberWidget` for the given field.
 
 ## `RadioWidget`
 
 Renders a single radio button for each `enum` value. This overrides the default `SelectWidget` that is normally rendered where `enum` exists.
 
-- **File:** [RadioWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/widgets/RadioWidget.jsx)
+- **File:** [RadioWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/platform/forms-system/src/js/widgets/RadioWidget.jsx)
 - **Usage:** In the `uiSchema`, specify `'ui:widget': 'radio'` for the given field. Usually used with `'ui:options': { labels: {}}` so you can specify the label for each radio button. To see a code example, refer to [radio button group in form features](/forms/available-features-and-usage-guidelines#radio-button-group). Include additional properties on the radio input by including `widgetProps` and `selectedProps` within the `ui:options`; the key for each input will match the custom option values.
 
 ## `SelectWidget`
 
 Renders a `<select>` HTML element. This is the default widget for data of `type: 'string'` with an `enum` property.
 
-- **File:** [SelectWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/widgets/SelectWidget.jsx)
+- **File:** [SelectWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/platform/forms-system/src/js/widgets/SelectWidget.jsx)
 - **Usage:** Usually the `SelectWidget` is not specified directly in the `uiSchema` because it renders by default for a schema that specifies `type: 'string'` with an `enum` property.
 
 ## `SSNWidget`
 
 Renders a `TextWidget` with additional logic to strip the dashes before saving the input.
 
-- **File:** [SSNWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/widgets/SSNWidget.jsx)
+- **File:** [SSNWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/platform/forms-system/src/js/widgets/SSNWidget.jsx)
 - **Usage:** In the `uiSchema`, specify `'ui:widget': SSNWidget` for the given field.
 
 ## `TextWidget`
 
 Renders a `<input>` HTML element, and is the default widget for data of `type: 'string'`.
 
-- **File:** [TextWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/widgets/TextWidget.jsx)
+- **File:** [TextWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/platform/forms-system/src/js/widgets/TextWidget.jsx)
 - **Usage:** Usually the `TextWidget` is not specified directly in the `uiSchema` because it renders by default for a schema that specifies `type: 'string'`.
 
 ## `YesNoWidget`
 
 Renders two radio buttons, one with a value of "Yes" and one with a value of "No".
 
-- **File:** [YesNoWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/forms-system/src/js/widgets/YesNoWidget.jsx)
+- **File:** [YesNoWidget.jsx](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/platform/forms-system/src/js/widgets/YesNoWidget.jsx)
 - **Usage:** In the `uiSchema`, specify `'ui:widget': 'yesNo'` for the given field. Include additional properties on the radio input by including `widgetProps` and `selectedProps` within the `ui:options`; the key for each input will match the option values of `Y` and `N`.
-

--- a/packages/documentation/src/pages/forms/save-in-progress-menu.mdx
+++ b/packages/documentation/src/pages/forms/save-in-progress-menu.mdx
@@ -13,6 +13,7 @@ Sadly, not every application includes a form, e.g. claim status tool. You won't
 see this save-in-progress menu or link show up on those pages.
 
 This save-in-progress menu will allow you to:
+
 - [Using the Save in Progress menu](#using-the-save-in-progress-menu)
   - [Activating & Deactivating](#activating--deactivating)
     - [Activate](#activate)
@@ -28,9 +29,14 @@ This save-in-progress menu will allow you to:
   - [Return url](#return-url)
     - [Jump to a specific page within the form](#jump-to-a-specific-page-within-the-form)
 
-<img width="506" alt="save-in-progress menu" src="../../images/forms/sips-menu.png" />
+<img
+  width="506"
+  alt="save-in-progress menu"
+  src="../../images/forms/sips-menu.png"
+/>
 
 Scenarios:
+
 - You have a user that doesn't have specific mock data available. Open this
   menu and add the new data; For example, for form 526, some mock users don't
   include pre-existing rated disabilities. This menu will allow you to enter
@@ -62,7 +68,11 @@ If you don't see the "Open save-in-progress menu" link:
   required hash will look like this - `#dev-on` - add it to the end of the url
 - Press <kbd>Enter</kbd> on the keyboard. The link will immediately show up.
 
-<img width="513" alt="Add `#dev-on` hash shows link" src="../../images/forms/sips-menu-link.png" />
+<img
+  width="513"
+  alt="Add `#dev-on` hash shows link"
+  src="../../images/forms/sips-menu-link.png"
+/>
 
 ### Deactivate
 
@@ -75,7 +85,11 @@ To hide the link:
   If the menu is open, it will also disappear, but may automatically reappear
   if immediately re-activated.
 
-<img width="528" alt="Add `#dev-off` hash hides link" src="../../images/forms/sips-menu-no-link.png" />
+<img
+  width="528"
+  alt="Add `#dev-off` hash hides link"
+  src="../../images/forms/sips-menu-no-link.png"
+/>
 
 ## Buttons
 
@@ -92,7 +106,11 @@ progress menu _and_ close the menu.
 At the bottom of the save-in-progress menu are two buttons: "Replace" and
 "Merge".
 
-<img width="350" alt="save-in-progress buttons" src="../../images/forms/sips-menu-buttons.png" />
+<img
+  width="350"
+  alt="save-in-progress buttons"
+  src="../../images/forms/sips-menu-buttons.png"
+/>
 
 #### Replace
 
@@ -116,27 +134,27 @@ Most forms include a `maximal-test.json` file for testing. Copy the content of
 this file and paste it into the menu form data (as-is) to apply this data
 (current as of July 2020; some of these forms may not be in production):
 
-- [burials](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/burials/tests/schema/maximal-test.json)
-- [disability-benefits/686](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/disability-benefits/686/tests/schema/maximal-test.json)
-- [disability-benefits/996](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/disability-benefits/996/tests/fixtures/data/maximal-test.json)
-- [disability-benefits/all-claims](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-test.json)
-- [disability-benefits/bdd](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-bdd-test.json)
-- [edu-benefits/10203](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/edu-benefits/10203/tests/schema/maximal-test.json)
-- [edu-benefits/0993](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/edu-benefits/tests/0993/schema/maximal-test.json)
-- [edu-benefits/0994](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/edu-benefits/tests/0994/schema/maximal-test.json)
-- [edu-benefits/1990](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/edu-benefits/tests/1990/schema/maximal-test.json)
-- [edu-benefits/1990e](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/edu-benefits/tests/1990e/schema/maximal-test.json)
-- [edu-benefits/1990n](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/edu-benefits/tests/1990n/schema/maximal-test.json)
-- [edu-benefits/1995](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/edu-benefits/tests/1995/schema/maximal-test.json)
-- [edu-benefits/5490](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/edu-benefits/tests/5490/schema/maximal-test.json)
-- [edu-benefits/5495](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/edu-benefits/tests/5495/schema/maximal-test.json)
-- [edu-benefits/feedback](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/edu-benefits/tests/feedback-tool/schema/maximal-test.json)
-- [hca](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/hca/tests/schema/maximal-test.json)
-- [pensions](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/pensions/tests/schema/maximal-test.json)
-- [pre-need](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/pre-need/tests/schema/maximal-test.json)
-- [veteran-representative](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/veteran-representative/tests/schema/maximal-test.json)
-- [vre/chapter31](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/vre/tests/chapter31/schema/maximal-test.json)
-- [vre/chapter36](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/vre/tests/chapter36/schema/maximal-test.json)
+- [burials](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/burials/tests/schema/maximal-test.json)
+- [disability-benefits/686](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/disability-benefits/686/tests/schema/maximal-test.json)
+- [disability-benefits/996](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/disability-benefits/996/tests/fixtures/data/maximal-test.json)
+- [disability-benefits/all-claims](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-test.json)
+- [disability-benefits/bdd](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-bdd-test.json)
+- [edu-benefits/10203](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/edu-benefits/10203/tests/schema/maximal-test.json)
+- [edu-benefits/0993](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/edu-benefits/tests/0993/schema/maximal-test.json)
+- [edu-benefits/0994](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/edu-benefits/tests/0994/schema/maximal-test.json)
+- [edu-benefits/1990](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/edu-benefits/tests/1990/schema/maximal-test.json)
+- [edu-benefits/1990e](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/edu-benefits/tests/1990e/schema/maximal-test.json)
+- [edu-benefits/1990n](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/edu-benefits/tests/1990n/schema/maximal-test.json)
+- [edu-benefits/1995](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/edu-benefits/tests/1995/schema/maximal-test.json)
+- [edu-benefits/5490](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/edu-benefits/tests/5490/schema/maximal-test.json)
+- [edu-benefits/5495](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/edu-benefits/tests/5495/schema/maximal-test.json)
+- [edu-benefits/feedback](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/edu-benefits/tests/feedback-tool/schema/maximal-test.json)
+- [hca](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/hca/tests/schema/maximal-test.json)
+- [pensions](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/pensions/tests/schema/maximal-test.json)
+- [pre-need](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/pre-need/tests/schema/maximal-test.json)
+- [veteran-representative](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/veteran-representative/tests/schema/maximal-test.json)
+- [vre/chapter31](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/vre/tests/chapter31/schema/maximal-test.json)
+- [vre/chapter36](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/vre/tests/chapter36/schema/maximal-test.json)
 
 **Note**:
 
@@ -145,13 +163,17 @@ this file and paste it into the menu form data (as-is) to apply this data
   content; then use <kbd>Ctrl</kbd> or <kbd>&#x2318;</kbd> plus <kbd>c</kbd> to copy the selected text.
 - To paste in the clipboard contents, use <kbd>Ctrl</kbd> or <kbd>&#x2318;</kbd> plus <kbd>v</kbd>.
 - After pasting in the complete form data into the textarea, use the "Replace" button to completely replace the form data. Using "Merge" would also
-work, but may not remove unrelated data.
+  work, but may not remove unrelated data.
 
 ### Edit the data without being on a specific page
 
 Within the save-in-progress menu, the textarea containing the "Form data" is editable. This would allow you to edit data in-place
 
-<img width="350" alt="save-in-progress buttons" src="../../images/forms/sips-menu-form-data.png" />
+<img
+  width="350"
+  alt="save-in-progress buttons"
+  src="../../images/forms/sips-menu-form-data.png"
+/>
 
 Edit the value, then use the "Replace" button.
 
@@ -178,7 +200,11 @@ form, then continue the form and open the menu a second time. Set the target
 page and use the "Replace" button again. This isn't ideal, but it'll work until
 a more optimal solution is found.
 
-<img width="387" alt="Return url select" src="../../images/forms/sips-menu-return-url.png" />
+<img
+  width="387"
+  alt="Return url select"
+  src="../../images/forms/sips-menu-return-url.png"
+/>
 
 ### Jump to a specific page within the form
 
@@ -189,6 +215,10 @@ a more optimal solution is found.
   it may be that the target url may not be a valid destination. You may have to
   restart the form to fix this problem.
 
-<img width="485" alt="Return url select" src="../../images/forms/sips-menu-return-url-expanded.png" />
+<img
+  width="485"
+  alt="Return url select"
+  src="../../images/forms/sips-menu-return-url-expanded.png"
+/>
 
 Next: [Forms in production](/forms/forms-in-production)

--- a/packages/documentation/src/pages/forms/save-in-progress.mdx
+++ b/packages/documentation/src/pages/forms/save-in-progress.mdx
@@ -69,8 +69,16 @@ widgets:
 And somewhere in the file, where you want the widget to show up:
 
 ```html
-<div id="react-applicationStatus" class="static-page-widget" data-widget-type="health-care-app-status">
-  <a class="usa-button-primary va-button-primary" href="/health-care/apply/application/">Apply for Health Care Benefits</a>
+<div
+  id="react-applicationStatus"
+  class="static-page-widget"
+  data-widget-type="health-care-app-status"
+>
+  <a
+    class="usa-button-primary va-button-primary"
+    href="/health-care/apply/application/"
+    >Apply for Health Care Benefits</a
+  >
 </div>
 ```
 
@@ -82,23 +90,20 @@ Once that's done, you can open up the static pages entry file at `src/applicatio
 
 ```js
 createApplicationStatus(store, {
-  formId: '1010ez',
-  additionalText: 'You can start your online application right now.',
-  applyLink: '/health-care/apply/',
-  applyText: 'Apply for Health Care Benefits',
+  formId: "1010ez",
+  additionalText: "You can start your online application right now.",
+  applyLink: "/health-care/apply/",
+  applyText: "Apply for Health Care Benefits",
   widgetType: widgetTypes.HEALTH_CARE_APP_STATUS,
 });
 ```
 
 The main things to note are that the `widgetType` should match the one you added to the widget types list. The code block also has some configuration options for your form that should be easy to get from the form config object.
 
-**Note:** An analytics event is added to the form introduction page by default. To finish setting it up, add an analytics event name to `gaStartEventName` property of the [`SaveInProgressIntro`](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx) component, which is used on `IntroductionPage`:
+**Note:** An analytics event is added to the form introduction page by default. To finish setting it up, add an analytics event name to `gaStartEventName` property of the [`SaveInProgressIntro`](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx) component, which is used on `IntroductionPage`:
 
 ```html
-<SaveInProgressIntro
-  gaStartEventName="my-start-form-event-name"
-  ...
-/>
+<SaveInProgressIntro gaStartEventName="my-start-form-event-name" ... />
 ```
 
 Once you've got all that set up, your form should appear on the profile page:

--- a/packages/documentation/src/pages/getting-started/common-tasks/new-end-to-end-test.mdx
+++ b/packages/documentation/src/pages/getting-started/common-tasks/new-end-to-end-test.mdx
@@ -41,7 +41,7 @@ _These are recommendations, not requirements, except where labeled as 'REQUIRED'
 - Use `waitForElementVisible` before interacting with any element on the page
 - Use `Timeouts` constants for setting timeouts (`platform/testing/e2e/timeouts.js`)
 - Use helpers for filling data and performing actions on the page
-- (_REQUIRED_) Perform `axeCheck` on the main body of the application on each page - see [axeCheck](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/cypress/support/commands/axeCheck.js)
+- (_REQUIRED_) Perform `axeCheck` on the main body of the application on each page - see [axeCheck](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/testing/e2e/cypress/support/commands/axeCheck.js)
 - Assert that each navigation is successful
 
 ## Mocking API responses
@@ -67,17 +67,17 @@ Below are some of the commonly used Cypress mocks (accessible from the link abov
 
 ## Custom Cypress commands
 
-Cypress supports extending its client api with [custom commands](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/cypress/support/commands).
+Cypress supports extending its client api with [custom commands](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/testing/e2e/cypress/support/commands).
 
 Below are some of the commonly used custom Cypress commands.
 
-- [axeCheck](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/cypress/support/commands/axeCheck.js) - Callback from a11y check that logs aXe violations to console output.
-- [expandAccordions](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/cypress/support/commands/expandAccordions.js) - Expands all accordions and AdditionalInfo components.
-- [injectAxeThenAxeCheck](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/cypress/support/commands/hasCount.js) - Combines two common, sequentially called functions.
-- [login](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/cypress/support/commands/login.js) - Simulates a logged in session.
-- [syncFixtures](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/cypress/support/commands/syncFixtures.js) - Runs task to sync fixtures under a temp path in the Cypress fixtures folder then overwrites `cy.fixture` and the fixture shorthand in `cy.route` to look for fixtures under that temp path.
-- [upload](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/cypress/support/commands/upload.js) - Workaround to support file upload functionality in tests, which is currently not officially implemented.
-- [viewportPreset](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/cypress/support/commands/viewportPreset.js) - Sets the viewport by preset name.
+- [axeCheck](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/testing/e2e/cypress/support/commands/axeCheck.js) - Callback from a11y check that logs aXe violations to console output.
+- [expandAccordions](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/testing/e2e/cypress/support/commands/expandAccordions.js) - Expands all accordions and AdditionalInfo components.
+- [injectAxeThenAxeCheck](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/testing/e2e/cypress/support/commands/hasCount.js) - Combines two common, sequentially called functions.
+- [login](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/testing/e2e/cypress/support/commands/login.js) - Simulates a logged in session.
+- [syncFixtures](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/testing/e2e/cypress/support/commands/syncFixtures.js) - Runs task to sync fixtures under a temp path in the Cypress fixtures folder then overwrites `cy.fixture` and the fixture shorthand in `cy.route` to look for fixtures under that temp path.
+- [upload](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/testing/e2e/cypress/support/commands/upload.js) - Workaround to support file upload functionality in tests, which is currently not officially implemented.
+- [viewportPreset](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/testing/e2e/cypress/support/commands/viewportPreset.js) - Sets the viewport by preset name.
 
 ## Helpers
 

--- a/packages/documentation/src/pages/getting-started/common-tasks/new-unit-test.mdx
+++ b/packages/documentation/src/pages/getting-started/common-tasks/new-unit-test.mdx
@@ -6,13 +6,26 @@ tags: Mocha, Chai, Enzyme, schemaform-utils
 # Writing a unit test
 
 <div class="deprecation-message">
-    <h2>We're moving our docs!</h2>
-    <h3>Find <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Unit-tests.1836187655.html">the latest version of this page</a> on the Platform website.</h3>
-    <h3>Still can't find what you're looking for? Reach out to <a href="https://dsva.slack.com/archives/CBU0KDSB1">#vfs-platform-support</a> on Slack.</h3>
+  <h2>We're moving our docs!</h2>
+  <h3>
+    Find{" "}
+    <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Unit-tests.1836187655.html">
+      the latest version of this page
+    </a>{" "}
+    on the Platform website.
+  </h3>
+  <h3>
+    Still can't find what you're looking for? Reach out to{" "}
+    <a href="https://dsva.slack.com/archives/CBU0KDSB1">
+      #vfs-platform-support
+    </a>{" "}
+    on Slack.
+  </h3>
 </div>
 
 All new code that is added to `vets-website` should be unit tested and unit tests should cover at least 75% of code paths. Write unit tests as you build to make sure your form (or other component) is behaving as you expect and to help guard against future bugs.
 For example, you might create a unit test file for each page in a form and then test the following scenarios:
+
 - The correct number of inputs show up when you render the page.
 - The correct number of fields display validation errors if you submit without entering any information.
 - Any conditional logic on the page displays under the correct conditions.
@@ -20,6 +33,7 @@ For example, you might create a unit test file for each page in a form and then 
 For more detailed information about unit test best practices and an in-depth discussion of how they apply to `vets-website`, please view this recording of [Front End Unit Tests on VA.gov - Best Practices/Q&A Brown Bag Training](https://youtu.be/8Y0cuMUoWAw).
 
 ## Unit test overview
+
 - The `vets-website` repo uses:
   - [Mocha](https://mochajs.org/) for running unit tests
   - [Chai](http://chaijs.com/) for test assertions
@@ -38,23 +52,26 @@ For more detailed information about unit test best practices and an in-depth dis
         - MyComponent.unit.spec.jsx
 ```
 
-Mocha runs any *file_name*.unit.spec.js file located in the `/src` folder. This file is usually located in a test directory close to the code being tested.
-[Run the test](/getting-started/common-tasks/test) locally through npm script commands, during the Jenkins build (Unit), and after merging to master.
-   
+Mocha runs any _file_name_.unit.spec.js file located in the `/src` folder. This file is usually located in a test directory close to the code being tested.
+[Run the test](/getting-started/common-tasks/test) locally through npm script commands, during the Jenkins build (Unit), and after merging to main.
+
 ## Unit test conventions
+
 Use the following conventions when writing a unit test.
 
 ```js
-import React from 'react';
-import { expect } from 'chai';
-import { render } from '@testing-library/react';
-import MyComponent from '../../components/MyComponent';
+import React from "react";
+import { expect } from "chai";
+import { render } from "@testing-library/react";
+import MyComponent from "../../components/MyComponent";
 
-describe('my-application', () => {
-  describe('MyComponent', () => {
+describe("my-application", () => {
+  describe("MyComponent", () => {
     it('renders privacy act disclosure when "show" is true', () => {
-        const screen = render(<MyComponent show />);
-        expect(screen.getByRole('heading')).to.have.text('Privacy Act Disclosure');
+      const screen = render(<MyComponent show />);
+      expect(screen.getByRole("heading")).to.have.text(
+        "Privacy Act Disclosure"
+      );
     });
   });
 });
@@ -73,7 +90,9 @@ describe('my-application', () => {
     - `it('shows an error when the user is not logged in')`
 
 ### Testing components
+
 - Use [React Testing Library's `render` function](https://testing-library.com/docs/react-testing-library/api/#render) when testing components.
+
   ```js
   import React from 'react';
   import { render } from '@testing-library/react';
@@ -87,13 +106,16 @@ describe('my-application', () => {
     });
   });
   ```
+
 - If you're using Enzyme, use [shallow](https://airbnb.io/enzyme/docs/api/shallow.html) instead of [mount](https://airbnb.io/enzyme/docs/api/mount.html) when possible to test components.
+
   - Always `unmount` components at the end of the test.
+
   ```js
   import React from 'react';
   import { mount } from 'enzyme';
   import MyComponent from '../../components/MyComponent';
-  
+
   describe('MyComponent', () => {
     it('renders', () => {
       ...
@@ -103,8 +125,9 @@ describe('my-application', () => {
     });
   });
   ```
-  
+
 ## Unit tests for forms pages
+
 Use the following guidelines when writing a unit test for forms pages.
 
 ```js
@@ -143,6 +166,7 @@ describe('MyForm FormID', () => {
   - All field level validation errors
 
 When working with Enzyme, you can use the other `schemaform-utils` for filling out form data:
+
 - `fillData()` - Enzyme helper that fires a change event with a value for an element at the given selector
 
 ```
@@ -166,14 +190,15 @@ fillDate(
 - `selectCheckbox()` - Enzyme helper that fires a change event with a value for a checkbox at the given name
 
 ## Example unit tests - React Testing Library
+
 We recommend using [React Testing Library](https://testing-library.com/docs/react-testing-library/intro) for all your unit/integration testing needs.
 
 ```js
 // SimpleLoginForm.js
-import React from 'react';
+import React from "react";
 
 const SimpleLoginForm = ({ onSubmit }) => {
-  const [error, setError] = React.useState('');
+  const [error, setError] = React.useState("");
   function handleSubmit(event) {
     event.preventDefault();
     const {
@@ -181,11 +206,11 @@ const SimpleLoginForm = ({ onSubmit }) => {
       passwordInput: { value: password },
     } = event.target.elements;
     if (!username) {
-      setError('username is required');
+      setError("username is required");
     } else if (!password) {
-      setError('password is required');
+      setError("password is required");
     } else {
-      setError('');
+      setError("");
       onSubmit({ username, password });
     }
   }
@@ -212,26 +237,26 @@ export default SimpleLoginForm;
 
 ```js
 // SimpleLoginForm.unit.spec.jsx
-import React from 'react';
-import { expect } from 'chai';
-import sinon from 'sinon';
-import { render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import SimpleLoginForm from '../../components/SimpleLoginForm';
+import React from "react";
+import { expect } from "chai";
+import sinon from "sinon";
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SimpleLoginForm from "../../components/SimpleLoginForm";
 
-describe('my-application', () => {
-  describe('SimpleLoginForm', () => {
-    it('calls onSubmit with the username and password when submit is clicked', () => {
-        const handleSubmit = sinon.spy();
-        const screen = render(<SimpleLoginForm onSubmit={handleSubmit} />); // alternatively `const { getByLabelText, getByText } = render(<SimpleLoginForm onSubmit={handleSubmit} />);`
-        const user = { username: 'user123', password: 'password123' };
+describe("my-application", () => {
+  describe("SimpleLoginForm", () => {
+    it("calls onSubmit with the username and password when submit is clicked", () => {
+      const handleSubmit = sinon.spy();
+      const screen = render(<SimpleLoginForm onSubmit={handleSubmit} />); // alternatively `const { getByLabelText, getByText } = render(<SimpleLoginForm onSubmit={handleSubmit} />);`
+      const user = { username: "user123", password: "password123" };
 
-        userEvent.type(screen.getByLabelText(/username/i), user.username);
-        userEvent.type(screen.getByLabelText(/password/i), user.password);
-        userEvent.click(getByText(/submit/i));
+      userEvent.type(screen.getByLabelText(/username/i), user.username);
+      userEvent.type(screen.getByLabelText(/password/i), user.password);
+      userEvent.click(getByText(/submit/i));
 
-        expect(handleSubmit.callCount).to.equal(1); // alternatively `expect(handleSubmit.calledOnce).to.be.true()` works as well
-        expect(handleSubmit.calledWith(user)).to.be.true(); // for more explicit testing we can use `calledWithExactly` in place of `calledWith`
+      expect(handleSubmit.callCount).to.equal(1); // alternatively `expect(handleSubmit.calledOnce).to.be.true()` works as well
+      expect(handleSubmit.calledWith(user)).to.be.true(); // for more explicit testing we can use `calledWithExactly` in place of `calledWith`
     });
   });
 });
@@ -284,7 +309,9 @@ expect(handleSubmit.calledWith(user)).to.be.true(); // for more explicit testing
 To conclude this test we need to check that our `onSubmit` function fired and received the correct data.
 
 ## Example unit tests - Enzyme
-VSP provides helper utilities to make writing tests easier. The following example unit tests illustrate some of these helpers. You can find these unit tests in the `vets-website` repo in the [veteranInformation.unit.spec.jsx](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/vic-v2/tests/config/veteranInformation.unit.spec.jsx) file.
+
+VSP provides helper utilities to make writing tests easier. The following example unit tests illustrate some of these helpers. You can find these unit tests in the `vets-website` repo in the [veteranInformation.unit.spec.jsx](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/vic-v2/tests/config/veteranInformation.unit.spec.jsx) file.
+
 ```js
 import React from 'react';
 import { expect } from 'chai';
@@ -311,73 +338,88 @@ describe('VIC veteran information', () => {
   ...
 });
 ```
-Helpers are imported from [`schemaform-utils.jsx`](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/unit/schemaform-utils.jsx). The `DefinitionTester` is a component you can use to simulate a page being rendered without having to set up a whole form application with all the dependencies.
+
+Helpers are imported from [`schemaform-utils.jsx`](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/testing/unit/schemaform-utils.jsx). The `DefinitionTester` is a component you can use to simulate a page being rendered without having to set up a whole form application with all the dependencies.
 This example uses [Enzyme](http://airbnb.io/enzyme/) and mounts a `DefinitionTester` component that is passed in the schema information from the `veteranInformation` page as props. The test checks to make sure there are 7 `input` and 4 `select` entries on the page. When there are errors with definitions on the form pages, you will often see inputs not being rendered, so this helps check for that scenario.
 The next test in the file checks to see that the right fields are marked as required:
+
 ```js
-  it('should not submit without required info', () => {
-    const onSubmit = sinon.spy();
-    const form = mount(
-      <DefinitionTester
-        onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
-        schema={schema}
-        data={{}}
-        uiSchema={uiSchema}
-        />
-    );
-    form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error').length).to.equal(6);
-    expect(onSubmit.called).to.be.false;
-    form.unmount();
-  });
+it("should not submit without required info", () => {
+  const onSubmit = sinon.spy();
+  const form = mount(
+    <DefinitionTester
+      onSubmit={onSubmit}
+      definitions={formConfig.defaultDefinitions}
+      schema={schema}
+      data={{}}
+      uiSchema={uiSchema}
+    />
+  );
+  form.find("form").simulate("submit");
+  expect(form.find(".usa-input-error").length).to.equal(6);
+  expect(onSubmit.called).to.be.false;
+  form.unmount();
+});
 ```
+
 This test simulates a form submission and then counts the number of error elements on the page, which is expected to be 6. The test checks that the existing validation rules are still generally in place and that additional rules haven't been added.
 Finally, this example test fills in all the data and submits the form:
+
 ```js
-  it('should submit with all info filled in', () => {
-    const onSubmit = sinon.spy();
-    const form = mount(
-      <DefinitionTester
-        onSubmit={onSubmit}
-        definitions={formConfig.defaultDefinitions}
-        schema={schema}
-        data={{}}
-        uiSchema={uiSchema}
-        />
-    );
-    fillData(form, 'input#root_veteranFullName_first', 'test');
-    fillData(form, 'input#root_veteranFullName_last', 'test2');
-    fillData(form, 'input#root_veteranSocialSecurityNumber', '233224343');
-    selectRadio(form, 'root_gender', 'F');
-    fillDate(form, 'root_veteranDateOfBirth', '1920-01-04');
-    fillData(form, 'select#root_serviceBranch', 'F');
-    form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error').length).to.equal(0);
-    expect(onSubmit.called).to.be.true;
-    form.unmount();
-  });
+it("should submit with all info filled in", () => {
+  const onSubmit = sinon.spy();
+  const form = mount(
+    <DefinitionTester
+      onSubmit={onSubmit}
+      definitions={formConfig.defaultDefinitions}
+      schema={schema}
+      data={{}}
+      uiSchema={uiSchema}
+    />
+  );
+  fillData(form, "input#root_veteranFullName_first", "test");
+  fillData(form, "input#root_veteranFullName_last", "test2");
+  fillData(form, "input#root_veteranSocialSecurityNumber", "233224343");
+  selectRadio(form, "root_gender", "F");
+  fillDate(form, "root_veteranDateOfBirth", "1920-01-04");
+  fillData(form, "select#root_serviceBranch", "F");
+  form.find("form").simulate("submit");
+  expect(form.find(".usa-input-error").length).to.equal(0);
+  expect(onSubmit.called).to.be.true;
+  form.unmount();
+});
 ```
-Helper functions make the correct Enzyme calls to fill in data, so there isn't a lot of repeated code. The helpers are documented in the `schemaform-utils.jsx` file. The helpers fill in data and then check that the right number of inputs appear on the page after that change. Some of the tests also directly test logic in `depends` functions on the page configuration. 
+
+Helper functions make the correct Enzyme calls to fill in data, so there isn't a lot of repeated code. The helpers are documented in the `schemaform-utils.jsx` file. The helpers fill in data and then check that the right number of inputs appear on the page after that change. Some of the tests also directly test logic in `depends` functions on the page configuration.
+
 ## Other utilities
+
 These utilities can be found in `platform/testing/unit/helpers.js`:
-- `mockFetch()` -  A function to mock the global fetch function and return the value provided in returnVal
+
+- `mockFetch()` - A function to mock the global fetch function and return the value provided in returnVal
   - `resetFetch()` - Resets the mocked fetch set with `mockFetch()`
   - `mockApiRequest()` - Decorated `mockFetch()` that adds typical API headers to `returnVal`
   - `mockMultipleApiRequests()` - Decorated `mockFetch()` that mocks a fetch call for each response object in an array
+
 ```
 mockFetch(
   new Error('fake error'), // returnVal
   false, // shouldResolve: false returns rejected promise. default is true
 );
 ```
+
 **Note:** This utility can be found in `platform/utilities/storage/localstorage.js`.
+
 - `getLocalStorage()` - convenience accessor for local storage and implements a fallback. Useful for stubbing localstorage.
 
 ## Legacy tools
+
 While ReactTestUtils, SkinDeep, and Enzyme are used in many of our tests, use React Testing Library for any updated or new tests.
+
 ## Libraries
+
 Unit tests use the following libraries:
+
 - [mocha.js](https://mochajs.org/): Test framework.
 - [chai.js](https://www.chaijs.com/): BDD / TDD assertion library.
 - [chai-as-promised](https://github.com/domenic/chai-as-promised): Extends Chai with assertions about promises.

--- a/packages/documentation/src/pages/getting-started/common-tasks/run-build.mdx
+++ b/packages/documentation/src/pages/getting-started/common-tasks/run-build.mdx
@@ -6,62 +6,82 @@ tags: watch
 # Run and build VA.gov
 
 <div class="deprecation-message">
-    <h2>We're moving our docs!</h2>
-    <h3>Find <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Running-VA.gov-locally.1844248620.html">the latest version of this page</a> on the Platform website.</h3>
-    <h3>Still can't find what you're looking for? Reach out to <a href="https://dsva.slack.com/archives/CBU0KDSB1">#vfs-platform-support</a> on Slack.</h3>
+  <h2>We're moving our docs!</h2>
+  <h3>
+    Find{" "}
+    <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Running-VA.gov-locally.1844248620.html">
+      the latest version of this page
+    </a>{" "}
+    on the Platform website.
+  </h3>
+  <h3>
+    Still can't find what you're looking for? Reach out to{" "}
+    <a href="https://dsva.slack.com/archives/CBU0KDSB1">
+      #vfs-platform-support
+    </a>{" "}
+    on Slack.
+  </h3>
 </div>
 
 ## Prerequisite
 
-- Complete the [first](/getting-started) step in *Start up guide*.
+- Complete the [first](/getting-started) step in _Start up guide_.
 
 ## Locally run VA.gov
 
 Start the watch task:
+
 ```bash
 yarn watch
 ```
+
 ### Build
 
 #### vets-website
-  - **Webpack** manages this build pipeline. At a high level, this process:
-    1. Starts **Webpack**'s devevelopment server which
-       - **Builds** the **JavaScript** and **CSS** bundles
-       - **Serves** the **JavaScript** and **CSS** bundles built by Webpack as well as any scaffolded application pages [http://localhost:3001](http://localhost:3001)
+
+- **Webpack** manages this build pipeline. At a high level, this process:
+  1. Starts **Webpack**'s devevelopment server which
+     - **Builds** the **JavaScript** and **CSS** bundles
+     - **Serves** the **JavaScript** and **CSS** bundles built by Webpack as well as any scaffolded application pages [http://localhost:3001](http://localhost:3001)
 
 #### content-build
-  - **Metalsmith** manages this build pipeline. At a high level, this process:
-    1. Retrieves and **builds** all of the **static pages** sourced from `vagov-content` or Drupal
-    2. **Serves** the **static content** built by Metalsmith at [http://localhost:3002](http://localhost:3002)
+
+- **Metalsmith** manages this build pipeline. At a high level, this process:
+  1. Retrieves and **builds** all of the **static pages** sourced from `vagov-content` or Drupal
+  2. **Serves** the **static content** built by Metalsmith at [http://localhost:3002](http://localhost:3002)
 
 ### Output
-  - **Metalsmith** in the `content-build` repository outputs **static pages** to`build/localhost`
-  - **Webpack** in the `vets-website` repository development server has **no output**. **JavaScript** and **CSS** are kept on disk.
+
+- **Metalsmith** in the `content-build` repository outputs **static pages** to`build/localhost`
+- **Webpack** in the `vets-website` repository development server has **no output**. **JavaScript** and **CSS** are kept on disk.
 
 ### Watch and rebuild
-  - **Metalsmith** in the `content-build` repository will rebuild **static pages** when changes are saved to **templates** or content in `vagov-content`
-  - **Webpack** in the `vets-website` repository will rebuild when changes are saved to **JavaScript** or **SCSS**
-  - Both updates require a browser refresh to see changes.
-  - Changes to build process or configuration files are typically not picked up, and require a restart of the watch task to become active.
+
+- **Metalsmith** in the `content-build` repository will rebuild **static pages** when changes are saved to **templates** or content in `vagov-content`
+- **Webpack** in the `vets-website` repository will rebuild when changes are saved to **JavaScript** or **SCSS**
+- Both updates require a browser refresh to see changes.
+- Changes to build process or configuration files are typically not picked up, and require a restart of the watch task to become active.
 
 ## Locally build and run for specific environment
 
 _Note: most of the time, it's better to use the `watch` task to build the site locally since it is the most developer-friendly experience._
 
-| Environment | Build Command | Output directory | Run Command |
-| --- | --- | --- | ---|
-| localhost | `yarn build` | `build/localhost` | `npx http-server -p 3001 build/localhost` |
-| dev.va.gov | `yarn build --buildtype=vagovdev` | `build/vagovdev` | `npx http-server -p 3001 build/vagovdev` |
+| Environment    | Build Command                                             | Output directory     | Run Command                                  |
+| -------------- | --------------------------------------------------------- | -------------------- | -------------------------------------------- |
+| localhost      | `yarn build`                                              | `build/localhost`    | `npx http-server -p 3001 build/localhost`    |
+| dev.va.gov     | `yarn build --buildtype=vagovdev`                         | `build/vagovdev`     | `npx http-server -p 3001 build/vagovdev`     |
 | staging.va.gov | `NODE_ENV=production yarn build --buildtype=vagovstaging` | `build/vagovstaging` | `npx http-server -p 3001 build/vagovstaging` |
-| www.va.gov | `NODE_ENV=production yarn build --buildtype=vagovprod` | `build/vagovprod` | `npx http-server -p 3001 build/vagovprod` |
+| www.va.gov     | `NODE_ENV=production yarn build --buildtype=vagovprod`    | `build/vagovprod`    | `npx http-server -p 3001 build/vagovprod`    |
 
 ### Build commands
+
 - **create** the **static pages** from the markdown content in the `vagov-content` repository and data queried from the Drupal API into their **output directory**
 - **create** the **JavaScript** and **CSS** files with Webpack into `/generated` folder in their **output directory** with Webpack
 
 _Production like builds are required for staging and production environments. **NODE_ENV=production** environment variable is required to be set when running these build commands_
 
 ### Run commands
+
 - **start** an `http-server` that **serves** the **static pages** from the **output directory** at [http://localhost:3001](https://localhost:3001)
 
 _Typically, the reason for building the site locally like this is to build it in production mode and check that it is behaving as you'd expect._
@@ -69,5 +89,6 @@ _Typically, the reason for building the site locally like this is to build it in
 _**Deep-linking** to urls that are rendered by **React** apps on VA.gov **will not work** when you run the site this way, as that relies on some server-side routing that is handled in nginx (or the Webpack dev server when running the `watch` task)_
 
 ## Related source
+
 - [Metalsmith build script](https://github.com/department-of-veterans-affairs/content-build/tree/master/src/site/stages/build)
-- [Webpack development server config](https://github.com/department-of-veterans-affairs/vets-website/blob/master/config/webpack.dev.config.js)
+- [Webpack development server config](https://github.com/department-of-veterans-affairs/vets-website/blob/main/config/webpack.dev.config.js)

--- a/packages/documentation/src/pages/getting-started/index.mdx
+++ b/packages/documentation/src/pages/getting-started/index.mdx
@@ -6,9 +6,21 @@ tags: local, watch, node, nvm, yarn, install
 # Set up VA.gov locally
 
 <div class="deprecation-message">
-    <h2>We're moving our docs!</h2>
-    <h3>Find <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Setting-up-your-local-frontend-environment.1844215878.html">the latest version of this page</a> on the Platform website.</h3>
-    <h3>Still can't find what you're looking for? Reach out to <a href="https://dsva.slack.com/archives/CBU0KDSB1">#vfs-platform-support</a> on Slack.</h3>
+  <h2>We're moving our docs!</h2>
+  <h3>
+    Find{" "}
+    <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Setting-up-your-local-frontend-environment.1844215878.html">
+      the latest version of this page
+    </a>{" "}
+    on the Platform website.
+  </h3>
+  <h3>
+    Still can't find what you're looking for? Reach out to{" "}
+    <a href="https://dsva.slack.com/archives/CBU0KDSB1">
+      #vfs-platform-support
+    </a>{" "}
+    on Slack.
+  </h3>
 </div>
 
 These instructions cover building and running VA.gov locally, including configuring any required dependencies.
@@ -75,87 +87,97 @@ These instructions cover building and running VA.gov locally, including configur
    ```
 
    **Front end repos**
+
    - `vets-website`: Core front end platform and application code
    - `vagov-content`: Markdown content used to generate static pages
    - `content-build`: Liquid templates and content build for static pages
    - `veteran-facing-services-tools`: Shared front end components (including non VA.gov users) and front end documentation site
 
    **Back end repos**
+
    - `vets-api`: Core Rails API server application code
    - `vets-api-mockdata`: Mock data used when running locally and on dev for the backend
 
    **Shared repos**
+
    - `vets-json-schema`: Shared JSON Schema definitions used by form applications and the APIs that they consume
 
 ## Start up the front end
 
 ### vets-website
 
-7a. Navigate to the `vets-website` repository, then install `vets-website` dependencies. See these [common commands](https://github.com/department-of-veterans-affairs/vets-website/blob/master/README.md) for more information.
-   ```bash
-   $ cd vets-website
-   $ yarn install
-   ```
+7a. Navigate to the `vets-website` repository, then install `vets-website` dependencies. See these [common commands](https://github.com/department-of-veterans-affairs/vets-website/blob/main/README.md) for more information.
+
+```bash
+$ cd vets-website
+$ yarn install
+```
 
 8a. Build `vets-website`. If you're only doing application work inside `vets-website` you can run the build command which contains the scaffolding option by default:
-   ```bash
-   $ yarn build
-   ```
 
-   If you need the CSS and JS generated for work in `content-build` you can run a normal build:
+```bash
+$ yarn build
+```
 
-   ```bash
-   $ yarn build
-   ```
+If you need the CSS and JS generated for work in `content-build` you can run a normal build:
 
-9a. Start the local development server. If you are applying CSS and/or JS changes to a static page/template that renders 
+```bash
+$ yarn build
+```
+
+9a. Start the local development server. If you are applying CSS and/or JS changes to a static page/template that renders
 in `content-build`, we recommend leaving this command running so you will be able to see the changes in `content-build`.
-   ```bash
-   $ yarn watch
-   ```
 
-   The watch is complete when the CLI says `Compiled successfully`.
+```bash
+$ yarn watch
+```
 
-   If you would like webpack to open a browser window for you, please run `yarn watch --open`. We use [Webpack DevServer](https://webpack.js.org/configuration/dev-server/) to watch and serve the files locally; all the same options and documentation should apply.
+The watch is complete when the CLI says `Compiled successfully`.
 
-10a. Open [http://localhost:3001](http://localhost:3001) in a browser if you are working on an app; 
+If you would like webpack to open a browser window for you, please run `yarn watch --open`. We use [Webpack DevServer](https://webpack.js.org/configuration/dev-server/) to watch and serve the files locally; all the same options and documentation should apply.
+
+10a. Open [http://localhost:3001](http://localhost:3001) in a browser if you are working on an app;
 otherwise, continue on to the [content-build](#content-build) section for viewing changes in the browser.
 
 ### content-build
 
-**NOTE:** In order to run `content-build`, you must first generate the CSS and JS files within `vets-website` 
+**NOTE:** In order to run `content-build`, you must first generate the CSS and JS files within `vets-website`
 (follow steps above). If you don't, you will see a build error in the console instructing you to first
-generate files in `vets-website`. If you are applying CSS and/or JS changes to a static page/template that renders 
-in `content-build` (like the homepage) you will need to run a watch in `vet-website` to view 
-the updates. The CSS and JS files within `vets-website` are locally connected through a symlink 
+generate files in `vets-website`. If you are applying CSS and/or JS changes to a static page/template that renders
+in `content-build` (like the homepage) you will need to run a watch in `vet-website` to view
+the updates. The CSS and JS files within `vets-website` are locally connected through a symlink
 in the build process.
 
 If you don't need to locally view static pages and are just working on applications, you don't need to set this part up.
 
 7b. Navigate to the `content-build` repository, then install dependencies via `yarn`
-   ```bash
-   $ cd content-build
-   $ yarn install
-   ```
+
+```bash
+$ cd content-build
+$ yarn install
+```
 
 8b. Build `content-build`. Make sure you [configured the SOCKS proxy](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/internal-tools.md#configure-the-socks-proxy) to fetch content from Drupal.
-   ```bash
-   $ yarn build
-   ```
 
-   If you do not have access to the SOCKS proxy, you can alternately fetch the latest cached version of the content.
-   ```bash
-   $ yarn fetch-drupal-cache
-   ```
+```bash
+$ yarn build
+```
+
+If you do not have access to the SOCKS proxy, you can alternately fetch the latest cached version of the content.
+
+```bash
+$ yarn fetch-drupal-cache
+```
 
 9a. Start the local development server.
-   ```bash
-   $ yarn watch
-   ```
 
-   The watch is complete when the CLI says `Compiled successfully`. If you just need a server running without 
-   watching the metalsmith files you can run `npx http-server . -p 3002` inside `/build/localhost` to 
-   save some CPU.
+```bash
+$ yarn watch
+```
+
+The watch is complete when the CLI says `Compiled successfully`. If you just need a server running without
+watching the metalsmith files you can run `npx http-server . -p 3002` inside `/build/localhost` to
+save some CPU.
 
 10a. Open [http://localhost:3002](http://localhost:3002) in a browser
 

--- a/packages/documentation/src/pages/getting-started/workflow/deploy.mdx
+++ b/packages/documentation/src/pages/getting-started/workflow/deploy.mdx
@@ -6,9 +6,21 @@ tags: build, rollback, manual deploy, automatic deploy, static page deploy, depl
 # Deploy
 
 <div class="deprecation-message">
-    <h2>We're moving our docs!</h2>
-    <h3>Find <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Deployments.1844641889.html">the latest version of this page</a> on the Platform website.</h3>
-    <h3>Still can't find what you're looking for? Reach out to <a href="https://dsva.slack.com/archives/CBU0KDSB1">#vfs-platform-support</a> on Slack.</h3>
+  <h2>We're moving our docs!</h2>
+  <h3>
+    Find{" "}
+    <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Deployments.1844641889.html">
+      the latest version of this page
+    </a>{" "}
+    on the Platform website.
+  </h3>
+  <h3>
+    Still can't find what you're looking for? Reach out to{" "}
+    <a href="https://dsva.slack.com/archives/CBU0KDSB1">
+      #vfs-platform-support
+    </a>{" "}
+    on Slack.
+  </h3>
 </div>
 
 Code goes through several steps to get to production. This document describes this process. It should also be noted that this is the same flow for both content and code changes.
@@ -33,37 +45,37 @@ Code goes through several steps to get to production. This document describes th
 
 ## Automated deployment schedule
 
-All listed times are eastern timezone and are **scheduled Monday&ndash;Friday** (excluding holidays). All deployments are executed from the master branch in each repository.
+All listed times are eastern timezone and are **scheduled Monday&ndash;Friday** (excluding holidays). All deployments are executed from the main/master branch in each repository.
 
-| Application | Changes in by | Deployment Start | Release Information | Jenkins Job |
-| --- | --- | --- | --- | --- |
-| vets-website | 2:00pm ET | 3:00pm ET | [vets-website release history](https://github.com/department-of-veterans-affairs/vets-website/releases) | [vets-gov-autodeploy-vets-website](http://jenkins.vetsgov-internal/job/deploys/job/vets-gov-autodeploy-vets-website/) |
-| content-build | 2:00pm ET | 3:00pm ET | [content-build release history](https://github.com/department-of-veterans-affairs/content-build/releases) | [vets-gov-autodeploy-content-build](http://jenkins.vetsgov-internal/job/deploys/job/vets-gov-autodeploy-content-build/) |
-| vets-api | 2:00pm ET | 3:00pm ET | [vets-api release history](https://github.com/department-of-veterans-affairs/vets-api/releases) | [vets-gov-autodeploy-vets-api](http://jenkins.vfs.va.gov/job/deploys/job/vets-gov-autodeploy-vets-api/) |
-| content-build (content only) | n/a | 9am&ndash;12pm Hourly, 1:45pm, 4pm, 5pm ET | [content-build latest release](https://github.com/department-of-veterans-affairs/content-build/releases/latest) | [vets-gov-autodeploy-content-build](http://jenkins.vetsgov-internal/job/deploys/job/vets-gov-autodeploy-content-build/) |
+| Application                  | Changes in by | Deployment Start                           | Release Information                                                                                             | Jenkins Job                                                                                                             |
+| ---------------------------- | ------------- | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| vets-website                 | 2:00pm ET     | 3:00pm ET                                  | [vets-website release history](https://github.com/department-of-veterans-affairs/vets-website/releases)         | [vets-gov-autodeploy-vets-website](http://jenkins.vetsgov-internal/job/deploys/job/vets-gov-autodeploy-vets-website/)   |
+| content-build                | 2:00pm ET     | 3:00pm ET                                  | [content-build release history](https://github.com/department-of-veterans-affairs/content-build/releases)       | [vets-gov-autodeploy-content-build](http://jenkins.vetsgov-internal/job/deploys/job/vets-gov-autodeploy-content-build/) |
+| vets-api                     | 2:00pm ET     | 3:00pm ET                                  | [vets-api release history](https://github.com/department-of-veterans-affairs/vets-api/releases)                 | [vets-gov-autodeploy-vets-api](http://jenkins.vfs.va.gov/job/deploys/job/vets-gov-autodeploy-vets-api/)                 |
+| content-build (content only) | n/a           | 9am&ndash;12pm Hourly, 1:45pm, 4pm, 5pm ET | [content-build latest release](https://github.com/department-of-veterans-affairs/content-build/releases/latest) | [vets-gov-autodeploy-content-build](http://jenkins.vetsgov-internal/job/deploys/job/vets-gov-autodeploy-content-build/) |
 
 ## Overview
 
-Jenkins performs the following tasks after a pull request is merged into `master`
+Jenkins performs the following tasks after a pull request is merged into `main/master`
 
-1. **Build** `master` branch to create an deployment artifact (.tar file)
+1. **Build** `main/master` branch to create an deployment artifact (.tar file)
 1. **Deploy** to development and staging using deployment artifact
-1. [Create a release](https://help.github.com/en/articles/creating-releases) in GitHub from master, tag artifacts of that commit SHA hash with release name
+1. [Create a release](https://help.github.com/en/articles/creating-releases) in GitHub from main/master, tag artifacts of that commit SHA hash with release name
 1. **Deploy** to production using deployment artifact according to automated deployment schedule
 
-_A big assumption in this process is that the `master` should always be deployable. As such, the deployment to the staging environment is configured to happen automatically and can be used to see what something would look like in a production-like environment for any kind of manual testing/verification._
+_A big assumption in this process is that the `main/master` should always be deployable. As such, the deployment to the staging environment is configured to happen automatically and can be used to see what something would look like in a production-like environment for any kind of manual testing/verification._
 
 ## Automated process details
 
 - Every work day at the configured time the [vets-gov-autodeploy-vets-website](http://jenkins.vfs.va.gov/job/deploys/job/vets-gov-autodeploy-vets-website/) and [vets-gov-autodeploy-content-build](http://jenkins.vfs.va.gov/job/deploys/job/vets-gov-autodeploy-content-build/) jobs will run.
 - The autodeploy jobs will call the [vets-website release](http://jenkins.vfs.va.gov/job/releases/job/vets-website/) and [content-build release](http://jenkins.vfs.va.gov/job/releases/job/content-build/) jobs which create a [vets-website release](https://github.com/department-of-veterans-affairs/vets-website/releases) and [content-build release](https://github.com/department-of-veterans-affairs/content-build/releases).
-- Release artifacts are deployed to production by the [vets-website-vagovprod](http://jenkins.vfs.va.gov/job/deploys/job/vets-website-vagovprod/) and [content-build-vagovprod](http://jenkins.vfs.va.gov/job/deploys/job/content-build-vagovprod/) jobs. These jobs should *not* be triggered manually.
+- Release artifacts are deployed to production by the [vets-website-vagovprod](http://jenkins.vfs.va.gov/job/deploys/job/vets-website-vagovprod/) and [content-build-vagovprod](http://jenkins.vfs.va.gov/job/deploys/job/content-build-vagovprod/) jobs. These jobs should _not_ be triggered manually.
 
 ## Rollbacks
 
-If a production deployment introduces issues that affect Service Level Objectives (SLOs) 
-established for the project, you may restore service to users by rolling back 
-to a previous deployment. This is accomplished by triggering a new deploy job in Jenkins using a 
+If a production deployment introduces issues that affect Service Level Objectives (SLOs)
+established for the project, you may restore service to users by rolling back
+to a previous deployment. This is accomplished by triggering a new deploy job in Jenkins using a
 previous release tag. Typical deployment times are under 5mins.
 
 1. Identify the release you want to rollback to by visiting the [vets-website](https://github.com/department-of-veterans-affairs/vets-website/releases) or [content-build](https://github.com/department-of-veterans-affairs/content-build/releases) release log(s)
@@ -73,18 +85,18 @@ previous release tag. Typical deployment times are under 5mins.
 5. Enter the ref value into the ref field
 6. Click "Build"
 
-If SLOs are not affected and a fix is not critical, no rollback will be issued. Instead the fix should 
+If SLOs are not affected and a fix is not critical, no rollback will be issued. Instead the fix should
 be applied through the standard development workflow.
 
 ## Creating a vets-website Release
 
 If the commit you are trying to release to does not have an official release tag, you have to create one:
 
-1. Update your local master branch
+1. Update your local main branch
 2. Check out the commit you want
 3. Note the latest release from the [vets-website release log](https://github.com/department-of-veterans-affairs/vets-website/releases)
 4. Visit the [release job in Jenkins](http://jenkins.vfs.va.gov/job/releases/job/vets-website/build?delay=0sec)
-5. Make sure the commit you want to use has [passed through the build pipeline in master](https://github.com/department-of-veterans-affairs/vets-website/commits/master)
+5. Make sure the commit you want to use has [passed through the build pipeline in main](https://github.com/department-of-veterans-affairs/vets-website/commits/main)
 6. Replace the "ref" value with the commit you want to use to create the release (it will be a long string like: `7c74702605561a33a5a6edbe46a95ac43dddb1df`)
 7. Click "Build"
 8. You should now see it in the [vets-website release log](https://github.com/department-of-veterans-affairs/vets-website/releases) and can follow the normal rollback steps.
@@ -95,11 +107,11 @@ This should create a new release, and deploy it to va.gov.
 
 If the commit you are trying to release to does not have an official release tag, you have to create one:
 
-1. Update your local master branch
+1. Update your local main branch
 2. Check out the commit you want
 3. Note the latest release from the [content-build release log](https://github.com/department-of-veterans-affairs/content-build/releases)
 4. Visit the [release job in Jenkins](http://jenkins.vfs.va.gov/job/releases/job/content-build/)
-5. Make sure the commit you want to use has [passed through the build pipeline in master](https://github.com/department-of-veterans-affairs/content-build/commits/master)
+5. Make sure the commit you want to use has [passed through the build pipeline in main](https://github.com/department-of-veterans-affairs/content-build/commits/main)
 6. Replace the "ref" value with the commit you want to use to create the release (it will be a long string like: `7c74702605561a33a5a6edbe46a95ac43dddb1df`)
 7. Click "Build"
 8. You should now see it in the [content-build release log](https://github.com/department-of-veterans-affairs/content-build/releases) and can follow the normal rollback steps.
@@ -108,13 +120,12 @@ This should create a new release, and deploy it to va.gov.
 
 **Note:** Verify that there are no [scheduled](#automated-deployment-schedule) [content releases](http://jenkins.vfs.va.gov/job/deploys/job/content-build-content-autodeploy/) around the time of creating a release. A following release can override your manual release if started before your release has finished.
 
-
 ## Hotfixes
 
-The **use of hotfixes is discouraged**, but may be useful in an emergency situation when `master` 
-has significantly deviated from the release and a fix to the failed production release is critical. 
-To create a hotfix, create a branch from the last stable release tag, make changes necessary (with review), 
-create a new release tag following the correct naming scheme, and trigger a deploy in Jenkins with the 
+The **use of hotfixes is discouraged**, but may be useful in an emergency situation when `master`
+has significantly deviated from the release and a fix to the failed production release is critical.
+To create a hotfix, create a branch from the last stable release tag, make changes necessary (with review),
+create a new release tag following the correct naming scheme, and trigger a deploy in Jenkins with the
 release name as a parameter. This documentation is above, in the "Creating a Release" section.
 
 ## vets-website Manual deployment
@@ -143,22 +154,22 @@ _You may need to contact the developers of those commits to verify._
    - Click **Build**
    - Verify commits in **deployment notification**
 
- _In the [#vfs-platform-builds](https://dsva.slack.com/archives/C0MQ281DJ) Slack channel, Jenkins will include a link that shows the exact commits being released in the **deploy notification**._
- 
+_In the [#vfs-platform-builds](https://dsva.slack.com/archives/C0MQ281DJ) Slack channel, Jenkins will include a link that shows the exact commits being released in the **deploy notification**._
+
 2. **Verify** changes in **production** once the build finishes
 
 ### Manual deployment of vets-website to staging or dev
 
-When staging deployments get clogged up or staging as a whole falls behind production 
-(for various reasons) you may need to execute a manual deployment for staging. To do this 
-use the following steps: 
+When staging deployments get clogged up or staging as a whole falls behind production
+(for various reasons) you may need to execute a manual deployment for staging. To do this
+use the following steps:
 
 1. Visit the [vets-website vagovstaging](http://jenkins.vfs.va.gov/job/deploys/job/vets-website-vagovstaging/) job in Jenkins (or [vets-website vagovdev](http://jenkins.vfs.va.gov/job/deploys/job/vets-website-vagovdev/) for dev)
 2. Click **Build with Parameters**
-3. Make sure the commit you want to use has [passed through the build pipeline in master](https://github.com/department-of-veterans-affairs/vets-website/commits/master)
+3. Make sure the commit you want to use has [passed through the build pipeline in main](https://github.com/department-of-veterans-affairs/vets-website/commits/main)
 4. Replace the "ref" value with the commit you want to use to create the release (it will be a long string like: `7c74702605561a33a5a6edbe46a95ac43dddb1df`)
 5. Click **Build**
-6. You can watch the deployment process from the [vets-website vagovstaging](http://jenkins.vfs.va.gov/job/deploys/job/vets-website-vagovstaging/) (or [vets-website vagovdev](http://jenkins.vfs.va.gov/job/deploys/job/vets-website-vagovdev/) for dev) status page in Jenkins 
+6. You can watch the deployment process from the [vets-website vagovstaging](http://jenkins.vfs.va.gov/job/deploys/job/vets-website-vagovstaging/) (or [vets-website vagovdev](http://jenkins.vfs.va.gov/job/deploys/job/vets-website-vagovdev/) for dev) status page in Jenkins
 7. [Confirm that your deployed commit is on staging](https://frontend-support-dashboard.now.sh/)
 
 ## content-build Manual deployment
@@ -180,7 +191,7 @@ Multiple manual deploys are supported in Jenkins:
    - Click **Build**
    - Verify commits in **deployment notification**
 
- _In the [#vfs-platform-builds](https://dsva.slack.com/archives/C0MQ281DJ) Slack channel, Jenkins will include a link that shows the exact commits being released in the **deploy notification**._
+_In the [#vfs-platform-builds](https://dsva.slack.com/archives/C0MQ281DJ) Slack channel, Jenkins will include a link that shows the exact commits being released in the **deploy notification**._
 
 ### Full production deploy of content-build
 
@@ -200,20 +211,20 @@ _You may need to contact the developers of those commits to verify._
 
 ### Manual deployment of content-build to staging or dev
 
-When staging deployments get clogged up or staging as a whole falls behind production 
-(for various reasons) you may need to execute a manual deployment for staging. To do this 
-use the following steps: 
+When staging deployments get clogged up or staging as a whole falls behind production
+(for various reasons) you may need to execute a manual deployment for staging. To do this
+use the following steps:
 
 1. Visit the [content-build vagovstaging](http://jenkins.vfs.va.gov/job/deploys/job/content-build-vagovstaging/) job in Jenkins (or [content-build vagovdev](http://jenkins.vfs.va.gov/job/deploys/job/content-build-vagovdev/))
 2. Click **Build with Parameters**
-3. Make sure the commit you want to use has [passed through the build pipeline in master](https://github.com/department-of-veterans-affairs/content-build/commits/master)
+3. Make sure the commit you want to use has [passed through the build pipeline in main](https://github.com/department-of-veterans-affairs/content-build/commits/main)
 4. Replace the "ref" value with the commit you want to use to create the release (it will be a long string like: `7c74702605561a33a5a6edbe46a95ac43dddb1df`)
 5. Click **Build**
-6. You can watch the deployment process from the [content-build vagovstaging](http://jenkins.vfs.va.gov/job/deploys/job/content-build-vagovstaging/) (or [content-build vagovdev](http://jenkins.vfs.va.gov/job/deploys/job/content-build-vagovdev/)) status page in Jenkins 
+6. You can watch the deployment process from the [content-build vagovstaging](http://jenkins.vfs.va.gov/job/deploys/job/content-build-vagovstaging/) (or [content-build vagovdev](http://jenkins.vfs.va.gov/job/deploys/job/content-build-vagovdev/)) status page in Jenkins
 
 ## Dealing with Flaky Unit Tests
 
-A test fixture is a fixed state so the results should be repeatable. A flaky test is a test 
+A test fixture is a fixed state so the results should be repeatable. A flaky test is a test
 which could fail or pass for the same configuration. In monitoring the deploy of vets-website
 we often have to deal with flaky tests in a few specific situations:
 
@@ -225,30 +236,30 @@ To tell if an auto-deploy is nearing you can refer to the table at the top of th
 
 #### A flaky test inside of a pull request
 
-If a unit test fails in a pull request, no one is alerted so it’s more likely that it gets refreshed 
+If a unit test fails in a pull request, no one is alerted so it’s more likely that it gets refreshed
 to unblock the work or skipped in the PR, then reviewed by the code owner. This action is the
 responsibility of the pull request owner and has no effect on the daily deploy.
 
-#### A flaky test in `master` when an autodeploy is not nearing
+#### A flaky test in `main` when an autodeploy is not nearing
 
-If a unit test fails in master and a deploy is not nearing (or has already happened for the day), 
-the failure can be ignored as inconsequential. However, the pipeline should still be refreshed 
-in order to tell if the test is flaky or legitamately failing. The relevant code owner should 
-then be alerted so they can either skip or fix the test before the next deploy (at the discretion 
+If a unit test fails in main and a deploy is not nearing (or has already happened for the day),
+the failure can be ignored as inconsequential. However, the pipeline should still be refreshed
+in order to tell if the test is flaky or legitamately failing. The relevant code owner should
+then be alerted so they can either skip or fix the test before the next deploy (at the discretion
 of the test owner).
 
 #### A flaky test in `master` when an auto-deploy is nearing
 
-If a unit test fails in `master` and a scheduled deploy is nearing, [platform release tools support 
-team member](https://github.com/orgs/department-of-veterans-affairs/teams/platform-release-tools) should 
-refresh the pipeline immediately, open up a pull request to skip the test, and alert the code owner 
-for a fix and/or pull request approval to skip the test. Ideally the test gets fixed, but in reality, 
-the process to merge can often take longer than is allowed for by the timing of the deploy. This is 
-why it is important to have a pull request opened immediately to skip the test if needed - no need 
-to wait for the code owner, delays can fail the deploy. This is the most common reason for a failed 
+If a unit test fails in `main` and a scheduled deploy is nearing, [platform release tools support
+team member](https://github.com/orgs/department-of-veterans-affairs/teams/platform-release-tools) should
+refresh the pipeline immediately, open up a pull request to skip the test, and alert the code owner
+for a fix and/or pull request approval to skip the test. Ideally the test gets fixed, but in reality,
+the process to merge can often take longer than is allowed for by the timing of the deploy. This is
+why it is important to have a pull request opened immediately to skip the test if needed - no need
+to wait for the code owner, delays can fail the deploy. This is the most common reason for a failed
 deploy so we should all be on high alert for it while on a support rotation.
 
-As the pull request is running through the pipeline, the support engineer should keep 
-refreshing the master pipeline just in case it catches and is successful to prevent a failed deploy. 
-Even if the deploy is successful, the test should be either fixed or skipped as to not block future 
+As the pull request is running through the pipeline, the support engineer should keep
+refreshing the main pipeline just in case it catches and is successful to prevent a failed deploy.
+Even if the deploy is successful, the test should be either fixed or skipped as to not block future
 deploys.

--- a/packages/documentation/src/pages/getting-started/workflow/overview.mdx
+++ b/packages/documentation/src/pages/getting-started/workflow/overview.mdx
@@ -1,37 +1,50 @@
 ---
-title:  Workflow- Overview
+title: Workflow- Overview
 ---
 
 # VA.gov workflow
 
 <div class="deprecation-message">
-    <h2>We're moving our docs!</h2>
-    <h3>Find <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Frontend-workflow.1846083611.html">the latest version of this page</a> on the Platform website.</h3>
-    <h3>Still can't find what you're looking for? Reach out to <a href="https://dsva.slack.com/archives/CBU0KDSB1">#vfs-platform-support</a> on Slack.</h3>
+  <h2>We're moving our docs!</h2>
+  <h3>
+    Find{" "}
+    <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Frontend-workflow.1846083611.html">
+      the latest version of this page
+    </a>{" "}
+    on the Platform website.
+  </h3>
+  <h3>
+    Still can't find what you're looking for? Reach out to{" "}
+    <a href="https://dsva.slack.com/archives/CBU0KDSB1">
+      #vfs-platform-support
+    </a>{" "}
+    on Slack.
+  </h3>
 </div>
 
 VA.gov uses a [Continuous Integration](https://www.thoughtworks.com/continuous-integration) process, which consists of the following steps:
 
 1. [Write](/getting-started/workflow/write)
-    - Determine which issue to work on
-    - Create feature branch
-      - branch naming convention {issue-id}-{subject you are working on}
-    - Code new functionality
-    - Write tests for new functionality
-    - Test new functionality on supported [browsers](/platform/front-end-standards/documented-decisions/browser-support/) (Chrome, IE, Safari, Edge)
+   - Determine which issue to work on
+   - Create feature branch
+     - branch naming convention {issue-id}-{subject you are working on}
+   - Code new functionality
+   - Write tests for new functionality
+   - Test new functionality on supported [browsers](/platform/front-end-standards/documented-decisions/browser-support/) (Chrome, IE, Safari, Edge)
 2. [Review](/getting-started/workflow/review)
-    - Submit pull request
-    - Run unit tests and compliance scans (kicked off when a pull request is created)
-    - Test feature on review instance (page link is available on the PR page)
-    - Test and peer review code (read: code review)
+   - Submit pull request
+   - Run unit tests and compliance scans (kicked off when a pull request is created)
+   - Test feature on review instance (page link is available on the PR page)
+   - Test and peer review code (read: code review)
 3. [Deploy](/getting-started/workflow/deploy)
-    - Merge code to stable code base
-    - Jenkins automatically deploys changes merged into `master` to staging and dev
-    - Jenkins automatically deploys master to production every day
+   - Merge code to stable code base
+   - Jenkins automatically deploys changes merged into `main` to staging and dev
+   - Jenkins automatically deploys main to production every day
 
-_Each project's code base has a branch called `master` by default. Anything in `master` is deemed to be stable and deployable. This means that **anything you merge will need to be ready to immediately be live or hidden in some way behind a feature flag**._
+_Each project's code base has a branch called `main` by default. Anything in `main` is deemed to be stable and deployable. This means that **anything you merge will need to be ready to immediately be live or hidden in some way behind a feature flag**._
 
 Merge changes when support can be provided; Avoid merging significant changes at the end of the day or before the weekend.
 
 ## References
+
 [GitHub Flow](https://guides.github.com/introduction/flow/)

--- a/packages/documentation/src/pages/getting-started/workflow/review.mdx
+++ b/packages/documentation/src/pages/getting-started/workflow/review.mdx
@@ -1,26 +1,40 @@
 ---
-title:  Workflow- Review
+title: Workflow- Review
 tags: peer review, pull request, feature branch, git
 ---
 
 # Review
 
 <div class="deprecation-message">
-    <h2>We're moving our docs!</h2>
-    <h3>Find <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Frontend-workflow:-Review.1845919891.html">the latest version of this page</a> on the Platform website.</h3>
-    <h3>Still can't find what you're looking for? Reach out to <a href="https://dsva.slack.com/archives/CBU0KDSB1">#vfs-platform-support</a> on Slack.</h3>
+  <h2>We're moving our docs!</h2>
+  <h3>
+    Find{" "}
+    <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Frontend-workflow:-Review.1845919891.html">
+      the latest version of this page
+    </a>{" "}
+    on the Platform website.
+  </h3>
+  <h3>
+    Still can't find what you're looking for? Reach out to{" "}
+    <a href="https://dsva.slack.com/archives/CBU0KDSB1">
+      #vfs-platform-support
+    </a>{" "}
+    on Slack.
+  </h3>
 </div>
 
 ## Submit pull request
 
-- **Pull master** and **push feature branch** to `vets-website` and/or `content-build` repositories
+- **Pull main** and **push feature branch** to `vets-website` and/or `content-build` repositories
+
 ```bash
-git pull origin master
+git pull origin main
 git push origin feature/12345-issue-title
 ```
+
 **Note:** If you are making changes in both repositories that are dependent on each other, you should give both branches in each repository the same name.
 
-_Always **pull master** into your feature branch before creating a pull request._
+_Always **pull main** into your feature branch before creating a pull request._
 
 - **Create a pull request** indicating that your code is ready for review.
 - **Request peer review** on Github by tagging a fellow team member who you feel is qualified to review the code (this prevents the pull request from just sitting). You may also want to tag developers on other teams if the changes cover more than one application.
@@ -60,20 +74,21 @@ _**The person making the change is responsible** for ensuring the change is adeq
 ### Review instance automatic creation
 
 **Jenkins** automatically **deploys** two remote **review instances** of a **feature branch** when a pull request is created:
-  - an instance that just includes static pages content deployed by **va-bot**
-  - an instance that includes static pages and the VA.gov client application deployed by **va-vfs-bot**
 
-  _Example of deployment links:_
+- an instance that just includes static pages content deployed by **va-bot**
+- an instance that includes static pages and the VA.gov client application deployed by **va-vfs-bot**
 
-  ![PR deployment list](../../../images/reviewing-feature-branches/PR-deployment-list.png)
+_Example of deployment links:_
+
+![PR deployment list](../../../images/reviewing-feature-branches/PR-deployment-list.png)
 
 After a pull request is created, **Jenkins** will automatically **rebuild** these instances when feature branch **changes are pushed**
 
 To review dependent changes made in `vets-website` and `content-build` pull requests in the same review instance, verify both branches in each repository have the same name. The review instance deployment in both pull requests will share the same link. Changes made in either pull request will be deployed to that review instance.
 
-  _You will need your browser configured to access the vetsgov-internal domain via the SOCKS proxy. Please see the [2. Access internal tools](/getting-started/internal-tools) for detailed instructions._
+_You will need your browser configured to access the vetsgov-internal domain via the SOCKS proxy. Please see the [2. Access internal tools](/getting-started/internal-tools) for detailed instructions._
 
-  ### Review instance manual creation
+### Review instance manual creation
 
 **Jenkins** can be **manually triggered** to build a **review instance**.
 

--- a/packages/documentation/src/pages/getting-started/workflow/write.mdx
+++ b/packages/documentation/src/pages/getting-started/workflow/write.mdx
@@ -1,14 +1,26 @@
 ---
-title:  Workflow- Write
+title: Workflow- Write
 tags: feature branching, git, code
 ---
 
 # Write
 
 <div class="deprecation-message">
-    <h2>We're moving our docs!</h2>
-    <h3>Find <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Frontend-workflow:-Write.1846312961.html">the latest version of this page</a> on the Platform website.</h3>
-    <h3>Still can't find what you're looking for? Reach out to <a href="https://dsva.slack.com/archives/CBU0KDSB1">#vfs-platform-support</a> on Slack.</h3>
+  <h2>We're moving our docs!</h2>
+  <h3>
+    Find{" "}
+    <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Frontend-workflow:-Write.1846312961.html">
+      the latest version of this page
+    </a>{" "}
+    on the Platform website.
+  </h3>
+  <h3>
+    Still can't find what you're looking for? Reach out to{" "}
+    <a href="https://dsva.slack.com/archives/CBU0KDSB1">
+      #vfs-platform-support
+    </a>{" "}
+    on Slack.
+  </h3>
 </div>
 
 ## Choose an issue to work on
@@ -19,12 +31,14 @@ _The VA handbook has more information about the broader process for delivering s
 
 ## Create feature branch
 
-- Checkout `master` branch and pull the latest
+- Checkout `main` branch and pull the latest
+
 ```bash
-git checkout master && git pull origin master
+git checkout main && git pull origin main
 ```
 
-- Create a new feature branch from master
+- Create a new feature branch from main
+
 ```bash
 git checkout -b feature/12345-issue-title
 ```

--- a/packages/documentation/src/pages/platform/architecture/build-deploy-flows.mdx
+++ b/packages/documentation/src/pages/platform/architecture/build-deploy-flows.mdx
@@ -1,25 +1,37 @@
 ---
 title: Build and deploy Jenkins flows
-tags: Jenkins, drupal, metalsmith, cache, master
+tags: Jenkins, drupal, metalsmith, cache, main
 ---
 
 # Build and deploy process flows
 
 <div class="deprecation-message">
-    <h2>We're moving our docs!</h2>
-    <h3>Find <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Build-and-deploy-process-flows.1844346924.html">the latest version of this page</a> on the Platform website.</h3>
-    <h3>Still can't find what you're looking for? Reach out to <a href="https://dsva.slack.com/archives/CBU0KDSB1">#vfs-platform-support</a> on Slack.</h3>
+  <h2>We're moving our docs!</h2>
+  <h3>
+    Find{" "}
+    <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Build-and-deploy-process-flows.1844346924.html">
+      the latest version of this page
+    </a>{" "}
+    on the Platform website.
+  </h3>
+  <h3>
+    Still can't find what you're looking for? Reach out to{" "}
+    <a href="https://dsva.slack.com/archives/CBU0KDSB1">
+      #vfs-platform-support
+    </a>{" "}
+    on Slack.
+  </h3>
 </div>
 
 Here you'll find flow diagrames for the different types of build and deploy flows we have for VA.gov. Those different flows are:
 
-- [Standard master/PR build](#standard-masterpr-build)
+- [Standard main/PR build](#standard-masterpr-build)
 - [Content only build and deploy](#content-only-build-and-deploy)
 - [Daily deploy](#daily-deploy)
 
-## Standard master/PR build
+## Standard main/PR build
 
-This is the typical Jenkins build for any vets-website branch. There is some logic that is different between master and other branches:
+This is the typical Jenkins build for any vets-website branch. There is some logic that is different between main and other branches:
 
 ```mermaid
 graph TD
@@ -40,7 +52,7 @@ graph TD
 9 --> 11[End to end tests]
 11 --> 12[Create archives for each build and upload to S3]
 10 --> 12
-12 --> 13{On master branch?}
+12 --> 13{On main branch?}
 13 -->|Yes| 14[Cache Drupal content and files to S3]
 14 --> 15[Deploy builds to dev and staging]
 13 -->|No| 16(Done)
@@ -56,7 +68,7 @@ When content is changed in Drupal, sometimes we need to publish it immediately o
 ```mermaid
 graph TD
 1(Build started for dev or staging)
-1 --> 2[Fetch build for latest master commit from S3]
+1 --> 2[Fetch build for latest main commit from S3]
 2 --> 3[Build static pages with new content]
 3 --> 4[Skip Webpack build, use assets from most recent build for applications]
 4 --> 5[Create archive for build and upload to S3]
@@ -82,9 +94,9 @@ graph TD
 ```mermaid
 graph TD
 1(Deploy started)
-1 --> 2[Fetch build for latest master commit from S3]
+1 --> 2[Fetch build for latest main commit from S3]
 2 --> 3[Build static pages with new content]
-3 --> 4[Skip Webpack build, use assets from most recent master build for applications]
+3 --> 4[Skip Webpack build, use assets from most recent main build for applications]
 4 --> 5[Create archive for build and upload to S3]
 5 --> 6[Create GitHub release]
 6 --> 7[Wait for 60 minutes]

--- a/packages/documentation/src/pages/platform/architecture/cms.mdx
+++ b/packages/documentation/src/pages/platform/architecture/cms.mdx
@@ -6,9 +6,21 @@ tags: cms, drupal, headless, preview, graphql
 # VA.gov content management system overview
 
 <div class="deprecation-message">
-    <h2>We're moving our docs!</h2>
-    <h3>Find <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/VA.gov-content-management-system-overview.1854832733.html">the latest version of this page</a> on the Platform website.</h3>
-    <h3>Still can't find what you're looking for? Reach out to <a href="https://dsva.slack.com/archives/CBU0KDSB1">#vfs-platform-support</a> on Slack.</h3>
+  <h2>We're moving our docs!</h2>
+  <h3>
+    Find{" "}
+    <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/VA.gov-content-management-system-overview.1854832733.html">
+      the latest version of this page
+    </a>{" "}
+    on the Platform website.
+  </h3>
+  <h3>
+    Still can't find what you're looking for? Reach out to{" "}
+    <a href="https://dsva.slack.com/archives/CBU0KDSB1">
+      #vfs-platform-support
+    </a>{" "}
+    on Slack.
+  </h3>
 </div>
 
 The VA is currently in the process of moving content from several other systems into one primary content management system, powered by Drupal. VA.gov takes a decoupled approach, where content editors make change in a Drupal environment, then VA.gov build process queries that Drupal instance and transforms the resulting content into static html that is deployed on the site. Drupal does not control any Veteran-facing page rendering.
@@ -41,15 +53,15 @@ All Drupal environments require you to either be on the VA network or the SOCKS 
 VA.gov is a static html/js/css site, built with a static site generator tool called Metalsmith. During the Metalsmith build process we query the appropriate Drupal environment with a GraphQL query. The results of that query are transformed into pages through the Metalsmith build pipeline. There are [liquid](https://shopify.github.io/liquid/) templates specific to page content that came from Drupal, generally denoted with a `.drupal.liquid` suffix. Each `entity` from Drupal has a corresponding `entityType`, which is used to choose the entry template for each `entity` (i.e. page) from Drupal.
 
 - [Metalsmith build process diagram](/platform/architecture/static-site)
-- [Primary GraphQL query](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js)
-- [Entry templates](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/site/layouts)
+- [Primary GraphQL query](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js)
+- [Entry templates](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/site/layouts)
 
 ## Jenkins build process integration
 
-Drupal is queried in the Jenkins build process for any vets-website branch. On Jenkins, however, there is a caching mechanism to help deal with downtime and other failures in the live Drupal environments. After any successful master build, the results of the GraphQL query and any files downloaded from Drupal during the build process are put into a tarball and uploaded to S3. For builds on any branch, if the site build (the `npm run build` command) fails, Jenkins will download the appropriate cache and retry the build.
+Drupal is queried in the Jenkins build process for any vets-website branch. On Jenkins, however, there is a caching mechanism to help deal with downtime and other failures in the live Drupal environments. After any successful main build, the results of the GraphQL query and any files downloaded from Drupal during the build process are put into a tarball and uploaded to S3. For builds on any branch, if the site build (the `npm run build` command) fails, Jenkins will download the appropriate cache and retry the build.
 
 - [Jenkins build process flow](/platform/architecture/build-deploy-flows#standard-masterpr-build)
-- [Drupal/AWS cache script](https://github.com/department-of-veterans-affairs/vets-website/tree/master/script/drupal-aws-cache.js)
+- [Drupal/AWS cache script](https://github.com/department-of-veterans-affairs/vets-website/tree/main/script/drupal-aws-cache.js)
 
 ### Automated accessibility checking
 
@@ -101,7 +113,7 @@ A typical cms deploys content changes to users immediately, because the content 
 
 The scheduled deploy begins at 2pm ET, and fetches new content from Drupal before deploying. The off schedule deploy is a Jenkins job that can be triggered from a button in the production Drupal environment which will get the currently released code and update it with the latest content from Drupal.
 
-Off schedule deploys can be done for all environments, however there are separate Jenkins jobs for production vs staging/dev.The main difference is that dev/staging deploys update the latest builds from vets-website master with new content and the production deploy updates the latest released code on VA.gov with new content.
+Off schedule deploys can be done for all environments, however there are separate Jenkins jobs for production vs staging/dev.The main difference is that dev/staging deploys update the latest builds from vets-website main with new content and the production deploy updates the latest released code on VA.gov with new content.
 
 ## Preview server
 
@@ -113,7 +125,7 @@ A typical cms also provides an easy way to preview changes before making them li
 | staging     | http://preview-staging.vfs.va.gov | https://staging.va.gov |
 | production  | http://preview-prod.vfs.va.gov    | https://va.gov         |
 
-The preview server is written in Node and Express, [located in vets-website](https://github.com/department-of-veterans-affairs/vets-website/blob/master/script/preview.js).
+The preview server is written in Node and Express, [located in vets-website](https://github.com/department-of-veterans-affairs/vets-website/blob/main/script/preview.js).
 
 Requests that are made to the preview server that are not to the special `/preview` route are proxied to the associated live site. So, for example, a request for `/health-care` on the staging preview server will request the `/health-care` page from staging.va.gov. If you were trying to preview an unpublished version of the `/health-care` page you would go to `/preview?nodeId=<id of health care entity>`.
 

--- a/packages/documentation/src/pages/platform/architecture/teamsite.mdx
+++ b/packages/documentation/src/pages/platform/architecture/teamsite.mdx
@@ -6,9 +6,21 @@ tags: proxyRewrite, targetEnvironment
 # Teamsite Overview
 
 <div class="deprecation-message">
-    <h2>We're moving our docs!</h2>
-    <h3>Find <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/TeamSite-overview.1855127627.html">the latest version of this page</a> on the Platform website.</h3>
-    <h3>Still can't find what you're looking for? Reach out to <a href="https://dsva.slack.com/archives/CBU0KDSB1">#vfs-platform-support</a> on Slack.</h3>
+  <h2>We're moving our docs!</h2>
+  <h3>
+    Find{" "}
+    <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/TeamSite-overview.1855127627.html">
+      the latest version of this page
+    </a>{" "}
+    on the Platform website.
+  </h3>
+  <h3>
+    Still can't find what you're looking for? Reach out to{" "}
+    <a href="https://dsva.slack.com/archives/CBU0KDSB1">
+      #vfs-platform-support
+    </a>{" "}
+    on Slack.
+  </h3>
 </div>
 
 Updated from [TeamSite Technical Solution and Implementation](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/12779#issue-356005850)
@@ -21,7 +33,6 @@ Requests to subdomain hosts such as www.benefits.va.gov are not proxied through 
 
 There are no consistent staging/production environments for TeamSite properties, and there are multiple variants of header and footer functionality in `va_files` (attached to this issue). For properties that do have staging and production variants, they reference the same version of header and footer content. A change to the header or footer will affect both the staging and production versions of a property.
 
-
 ## Scripts and Teamsite Administration
 
 The header injection markup is added to Teamsite templates by their administrator. Current point of contact for this is:
@@ -31,18 +42,41 @@ The header injection markup is added to Teamsite templates by their administrato
 Current markup added to Teamsite templates:
 
 ```html
-<style type="text/css">.brand-consolidation-deprecated { display: none !important; } </style>
-<link rel="stylesheet" href="https://prod-va-gov-assets.s3-us-gov-west-1.amazonaws.com/generated/styleConsolidated.css" />
-<script type="text/javascript" src="https://prod-va-gov-assets.s3-us-gov-west-1.amazonaws.com/js/settings.js"></script>
-<script type="text/javascript" src="https://prod-va-gov-assets.s3-us-gov-west-1.amazonaws.com/generated/polyfills.entry.js"></script>
-<script type="text/javascript" src="https://prod-va-gov-assets.s3-us-gov-west-1.amazonaws.com/generated/vendor.entry.js"></script>
-<script type="text/javascript" src="https://prod-va-gov-assets.s3-us-gov-west-1.amazonaws.com/generated/proxy-rewrite.entry.js"></script>
-<script type="text/javascript" src="https://prod-va-gov-assets.s3-us-gov-west-1.amazonaws.com/js/vendor/uswds.min.js"></script>
+<style type="text/css">
+  .brand-consolidation-deprecated {
+    display: none !important;
+  }
+</style>
+<link
+  rel="stylesheet"
+  href="https://prod-va-gov-assets.s3-us-gov-west-1.amazonaws.com/generated/styleConsolidated.css"
+/>
+<script
+  type="text/javascript"
+  src="https://prod-va-gov-assets.s3-us-gov-west-1.amazonaws.com/js/settings.js"
+></script>
+<script
+  type="text/javascript"
+  src="https://prod-va-gov-assets.s3-us-gov-west-1.amazonaws.com/generated/polyfills.entry.js"
+></script>
+<script
+  type="text/javascript"
+  src="https://prod-va-gov-assets.s3-us-gov-west-1.amazonaws.com/generated/vendor.entry.js"
+></script>
+<script
+  type="text/javascript"
+  src="https://prod-va-gov-assets.s3-us-gov-west-1.amazonaws.com/generated/proxy-rewrite.entry.js"
+></script>
+<script
+  type="text/javascript"
+  src="https://prod-va-gov-assets.s3-us-gov-west-1.amazonaws.com/js/vendor/uswds.min.js"
+></script>
 ```
 
 ## Teamsite Behavior and Whitelisting Pages
 
 There are an unknown number of Teamsite templates that drive the `<head>` content on Teamsite pages and there are several pages that receive the above markup that **should not** show the va.gov header. The proxy rewrite application uses a [whitelist](https://github.com/department-of-veterans-affairs/vets-website/blob/b770f380270722228563e56629af440c64342157/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json) to drive the activation of the header content. Example whitelist entry:
+
 ```
 {
   "hostname": "www.benefits.va.gov",
@@ -50,7 +84,9 @@ There are an unknown number of Teamsite templates that drive the `<head>` conten
   "cookieOnly": false
 },
 ```
+
 Pages can be whitelisted in two ways:
+
 - `cookieOnly: false` - the header will always activate
 - `cookieOnly: true` - the header will activate when `proxyRewrite` cookie is set to true.
 
@@ -65,6 +101,7 @@ This cookie can be set in the console by running `document.cookie = "proxyRewrit
   - injected as part of a Teamsite sourced JavaScript.
 
 # Proxy Rewrite
+
 The `proxy-rewrite` application is used to inject site-wide VA.gov components into pages that are outside of the www.va.gov build and publish process. The affected sites are generally referred to as "TeamSite", because TeamSite is the name of the CMS use for those pages.
 
 This works by -
@@ -76,18 +113,21 @@ This works by -
 Because the Teamsite template containing the `proxy-rewrite` snippet is used both on sites that should and shouldn't show the VA.gov header, the script is governed by an allow list contained in `proxy-rewrite-whitelist.json`.
 
 ## Local Dev
+
 Since Teamsite content is not run through the `vets-website` build process, testing changes on Teamsite requires running local or staging changes against the production pages. The `proxy-rewrite` app supports targeting a specific environment for testing:
 
 For example: https://staging.va.gov/health/?targetEnvironment=vagovstaging
 
 The default behavior for https://staging.va.gov/health is to load the production assets. when the `targetEnvironment` is set, the loader well delete the production nodes from the DOM and add script and style nodes for the target environment.
 
-The injection script will support any of [these](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/site/constants/environments.js) environment names set as the `targetEnvironment`.
+The injection script will support any of [these](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/site/constants/environments.js) environment names set as the `targetEnvironment`.
 
 Caveats:
+
 - Style node deletions will prompt a rebuilding of the CSSOM but removing script nodes doesn't undo any JS that was run before the JS node was removed. For most cases this should not impact testing as the application specific code doesn't run but JS that is executed before the application (e.g. polyfills) will always run the production code first.
 
 ## Charles Proxy
+
 You can also use an application called Charles Proxy to map the `proxy-rewrite` bundles of TeamSite pages to your local machine. This way you can navigate directly to `https://www.va.gov/health/` and when the request for the production bundle of `proxy-rewrite` is sent, Charles will have overridden that file to instead be served locally. Instructions to set this up are located here, https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Work%20Practices/Engineering/Teamsite.md.
 
 ## Teamsite Visual Regression Testing
@@ -103,18 +143,20 @@ Both scripts compare production Teamsite header and footer against images in `ve
 - Diff images are removed automatically when their associated test succeeds.
 
 ### Details
+
 - compares snapsshots of `<header>` and `.footerNav` on current subdomain Teamsite pages
 - [jest-image-snapshot](https://github.com/americanexpress/jest-image-snapshot) uses [pixelmatch](https://github.com/mapbox/pixelmatch) to detect failure
 - Diff images show **left center right** the **baseline diff new** images
-![Example Diff Image](../../../images/platform/teamsite/diff-image-example.png)
+  ![Example Diff Image](../../../images/platform/teamsite/diff-image-example.png)
 
 ## What To Do When The Test Fails
+
 - If needed, run `npm run vrt` locally
 - The test log will show a
   - Summary of successes and failures
- ![Test Summary Example](../../../images/platform/teamsite/vrt-test-summary-example.png)
+    ![Test Summary Example](../../../images/platform/teamsite/vrt-test-summary-example.png)
   - Failure details for each test with path to diff image for failure
- ![Failure Detail Example](../../../images/platform/teamsite/cli-failure-example.png)
+    ![Failure Detail Example](../../../images/platform/teamsite/cli-failure-example.png)
 - **If failure is caused by production issue**
   - Repair issue and publish to production
   - Verify `npm run test:vrt` succeeds

--- a/packages/documentation/src/pages/platform/front-end-standards/manual-reviews.mdx
+++ b/packages/documentation/src/pages/platform/front-end-standards/manual-reviews.mdx
@@ -7,7 +7,7 @@ tags: vagovprod, vagovstaging, vagovdev
 
 Each pull request (PR) on `vets-website` runs through an automated process that looks for code additions and modifications that don't meet code quality standards. If no issues are found, the code does not need to be reviewed by a VSP engineer. If a potential issue is found, a bot will leave an automated comment and request a manual review from the **platform-release-tools**.
 
-   ![Screen Shot](https://images.zenhubusercontent.com/5e387fa505ac7e30c820a2da/a09c4c8c-ae32-4142-8fa5-0fc81b6a1892)
+![Screen Shot](https://images.zenhubusercontent.com/5e387fa505ac7e30c820a2da/a09c4c8c-ae32-4142-8fa5-0fc81b6a1892)
 
 ## Manual reviews
 
@@ -22,14 +22,15 @@ The following items trigger a manual review:
 VSP reviews logs to Sentry to ensure that any new logs are useful and do not contain personally identifiable information (PII).
 
 Examples:
+
 - Do not log an entire request response if all that's important is an error code.
 - Do not log PII such as names, emails, or user IDs.
 
 ### ESLint
 
-VSP enforces [ESLint rules](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/engineering/frontend/eslint) through CircleCI to enforce code quality. ESLint rules are included in the `.eslintrc` file, which is located in the root folder. Any rules that VSP is [testing for inclusion](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/frontend/eslint/adding-new-rules.md) are located in the [`circle.eslint.json`](https://github.com/department-of-veterans-affairs/vets-website/blob/master/circle.eslint.json) file.
+VSP enforces [ESLint rules](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/engineering/frontend/eslint) through CircleCI to enforce code quality. ESLint rules are included in the `.eslintrc` file, which is located in the root folder. Any rules that VSP is [testing for inclusion](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/frontend/eslint/adding-new-rules.md) are located in the [`circle.eslint.json`](https://github.com/department-of-veterans-affairs/vets-website/blob/main/circle.eslint.json) file.
 
-When ESLint rules are disabled, VSP will review each case individually. 
+When ESLint rules are disabled, VSP will review each case individually.
 
 ### Icons
 
@@ -37,4 +38,4 @@ VSP uses Font Awesome as a dependency, which uses the `<i>` tag for adding icons
 
 ## Actions to take
 
-If a manual review is triggered, you can use the error information provided in the comment to identify the problem and resolve any errors. A member of the VSP team will review the PR and confirm that all issues have been resolved or will follow up with more feedback. 
+If a manual review is triggered, you can use the error information provided in the comment to identify the problem and resolve any errors. A member of the VSP team will review the PR and confirm that all issues have been resolved or will follow up with more feedback.

--- a/packages/documentation/src/pages/platform/front-end-standards/react.mdx
+++ b/packages/documentation/src/pages/platform/front-end-standards/react.mdx
@@ -7,26 +7,42 @@ title: Frontend Best Practices
 **Last Updated:** April 28, 2017
 
 <div class="deprecation-message">
-    <h2>We're moving our docs!</h2>
-    <h3>Find <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Best-practices.1824489781.html">the latest version of this page</a> on the Platform website.</h3>
-    <h3>Still can't find what you're looking for? Reach out to <a href="https://dsva.slack.com/archives/CBU0KDSB1">#vfs-platform-support</a> on Slack.</h3>
+  <h2>We're moving our docs!</h2>
+  <h3>
+    Find{" "}
+    <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Best-practices.1824489781.html">
+      the latest version of this page
+    </a>{" "}
+    on the Platform website.
+  </h3>
+  <h3>
+    Still can't find what you're looking for? Reach out to{" "}
+    <a href="https://dsva.slack.com/archives/CBU0KDSB1">
+      #vfs-platform-support
+    </a>{" "}
+    on Slack.
+  </h3>
 </div>
 
 ## Overview
+
 This is an initial pass at the best practices followed in vets.gov front-end development.
 
 ### Objective
+
 To promote a consistent approach to vets.gov front-end development by outlining an evolving set of best practices.
 
 ### Background
+
 Over the last year, we have launched a number of different single-page React/Redux apps on vets.gov, in addition to building digital forms using a [form-builder library](https://github.com/mozilla-services/react-jsonschema-form) that reuses the same code to run multiple React apps for different forms. This document is an attempt to begin collecting best practices for React/Redux development that the team has and continues to lean toward when architecting and developing front-end applications.
 
 ### High Order Guidelines
 
 This is a placeholder for any high-level paradigms we settle on. For now, it's merely a laundry list of debatable topics:
-  - *PropTypes*: we try to define PropTypes to make it easier for newcomers to understand what can be passed to a component.
-  - What to put into a selector vs. reducer vs. action
-  - How we map backend data to the state?
+
+- _PropTypes_: we try to define PropTypes to make it easier for newcomers to understand what can be passed to a component.
+- What to put into a selector vs. reducer vs. action
+- How we map backend data to the state?
 
 ### React/Redux Guidelines
 
@@ -48,33 +64,33 @@ Keep in mind that these are general conventions, not iron-clad rules, and we sho
 
 ### Existing Guides and Tools
 
-We have a set of [ESLint rules](https://github.com/department-of-veterans-affairs/vets-website/blob/master/.eslintrc) that extend the [AirBnB style guide](https://github.com/airbnb/javascript) and also use the [Prettier](https://prettier.io) [ESLint rules](https://prettier.io/docs/en/eslint.html). There is a pre-commit hook that prevents committing code that fails the ESLint rules. Developers should all be using ESLint plugins in their dev environments to catch lint-able things. In lieu of using an ESLint editor plugin, developers can run the `lint:js:fix` or `lint:js:changed:fix` NPM scripts to fix all errors that ESLint can auto-fix.
+We have a set of [ESLint rules](https://github.com/department-of-veterans-affairs/vets-website/blob/main/.eslintrc) that extend the [AirBnB style guide](https://github.com/airbnb/javascript) and also use the [Prettier](https://prettier.io) [ESLint rules](https://prettier.io/docs/en/eslint.html). There is a pre-commit hook that prevents committing code that fails the ESLint rules. Developers should all be using ESLint plugins in their dev environments to catch lint-able things. In lieu of using an ESLint editor plugin, developers can run the `lint:js:fix` or `lint:js:changed:fix` NPM scripts to fix all errors that ESLint can auto-fix.
 
 _TODO: list any notable exceptions here._
 
 ### Project Structure and Code Location
 
-The structure of our React app's is described in [How to Start a New ReactJS Project](https://github.com/department-of-veterans-affairs/vets-website/blob/master/docs/StartANewReactApp.md)
+The structure of our React app's is described in [How to Start a New ReactJS Project](https://github.com/department-of-veterans-affairs/vets-website/blob/main/docs/StartANewReactApp.md)
 
-A number (and soon all) of our forms use the [`react-json-schemaform`](https://github.com/mozilla-services/react-jsonschema-form) (or rjsf) library. To learn more about those, see [schemaform walkthrough](https://github.com/department-of-veterans-affairs/vets-website/blob/master/docs/schemaform/walkthrough.md) and this [form config cookbook](https://github.com/department-of-veterans-affairs/vets-website/blob/master/docs/schemaform/form-config.md).
+A number (and soon all) of our forms use the [`react-json-schemaform`](https://github.com/mozilla-services/react-jsonschema-form) (or rjsf) library. To learn more about those, see [schemaform walkthrough](https://github.com/department-of-veterans-affairs/vets-website/blob/main/docs/schemaform/walkthrough.md) and this [form config cookbook](https://github.com/department-of-veterans-affairs/vets-website/blob/main/docs/schemaform/form-config.md).
 
 ### Related Documents
 
-  * [Using Redux](/Work%20Practices/Engineering/DocumentedDecisions/Redux.md)
-  * [How to Start a New ReactJS Project](https://github.com/department-of-veterans-affairs/vets-website/blob/master/docs/StartANewReactApp.md)
-  * [Schemaform walkthrough](https://github.com/department-of-veterans-affairs/vets-website/blob/master/docs/schemaform/walkthrough.md)
-  * [Form config cookbook](https://github.com/department-of-veterans-affairs/vets-website/blob/master/docs/schemaform/form-config.md)
+- [Using Redux](/Work%20Practices/Engineering/DocumentedDecisions/Redux.md)
+- [How to Start a New ReactJS Project](https://github.com/department-of-veterans-affairs/vets-website/blob/main/docs/StartANewReactApp.md)
+- [Schemaform walkthrough](https://github.com/department-of-veterans-affairs/vets-website/blob/main/docs/schemaform/walkthrough.md)
+- [Form config cookbook](https://github.com/department-of-veterans-affairs/vets-website/blob/main/docs/schemaform/form-config.md)
 
-  Existing posts/articles on best practices that we may or may not agree with but can pull topics from:
-    * [React best practices](https://medium.com/@nesbtesh/react-best-practices-a76fd0fbef21)
-    * [Redux best practices](https://medium.com/lexical-labs-engineering/redux-best-practices-64d59775802e)
-    * [Long list of links about react architecture and best practices](https://github.com/markerikson/react-redux-links/blob/master/react-architecture.md)
-    * [Redux isn't slow, you're just doing it wrong - An optimization guide](https://reactrocket.com/post/react-redux-optimization/)
+Existing posts/articles on best practices that we may or may not agree with but can pull topics from:
+_ [React best practices](https://medium.com/@nesbtesh/react-best-practices-a76fd0fbef21)
+_ [Redux best practices](https://medium.com/lexical-labs-engineering/redux-best-practices-64d59775802e)
+_ [Long list of links about react architecture and best practices](https://github.com/markerikson/react-redux-links/blob/master/react-architecture.md)
+_ [Redux isn't slow, you're just doing it wrong - An optimization guide](https://reactrocket.com/post/react-redux-optimization/)
 
 ### Revision History
 
-Date | Revisions Made | Author | Reviewed By
------|----------------|--------|--------------
-March 1, 2017 | Skeleton document based on outline of [Node.js Best Practices](Javascript/Node.js.md)
-April 28, 2017 | Pulled in content from discussion in [#659](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/659)
-May 17, 2017 | Added information about React component types and `setState` usage
+| Date           | Revisions Made                                                                                                          | Author | Reviewed By |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------- | ------ | ----------- |
+| March 1, 2017  | Skeleton document based on outline of [Node.js Best Practices](Javascript/Node.js.md)                                   |
+| April 28, 2017 | Pulled in content from discussion in [#659](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/659) |
+| May 17, 2017   | Added information about React component types and `setState` usage                                                      |

--- a/packages/documentation/src/pages/platform/site-structure/application-structure.mdx
+++ b/packages/documentation/src/pages/platform/site-structure/application-structure.mdx
@@ -6,9 +6,21 @@ tags: bundle, react, webpack, site-wide
 # Page and application Javascript structure
 
 <div class="deprecation-message">
-    <h2>We're moving our docs!</h2>
-    <h3>Find <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Page-and-application-JavaScript-structure.1855062047.html">the latest version of this page</a> on the Platform website.</h3>
-    <h3>Still can't find what you're looking for? Reach out to <a href="https://dsva.slack.com/archives/CBU0KDSB1">#vfs-platform-support</a> on Slack.</h3>
+  <h2>We're moving our docs!</h2>
+  <h3>
+    Find{" "}
+    <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Page-and-application-JavaScript-structure.1855062047.html">
+      the latest version of this page
+    </a>{" "}
+    on the Platform website.
+  </h3>
+  <h3>
+    Still can't find what you're looking for? Reach out to{" "}
+    <a href="https://dsva.slack.com/archives/CBU0KDSB1">
+      #vfs-platform-support
+    </a>{" "}
+    on Slack.
+  </h3>
 </div>
 
 In this doc we'll go over how a page on VA.gov is related to the application code located in vets-website.
@@ -35,7 +47,7 @@ entryname: dashboard
 
 When this page is built, the `entryname` property tells our build process how to construct the path for the third script tag in the above group. For pages that don't have an `entryname`, the `static-pages` bundle will be used.
 
-In `vets-website`, there will be a manifest.json (or manifest.js) file with a matching entry name. In this case we can search for `entryName: 'dashboard'` and find [src/applications/personalization/dashboard/manifest.js](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/personalization/dashboard/manifest.js). The `entryFile` property in the manifest will tell you the entry point for this application, the file that Webpack uses as its entry for creating the `dashboard` bundle.
+In `vets-website`, there will be a manifest.json (or manifest.js) file with a matching entry name. In this case we can search for `entryName: 'dashboard'` and find [src/applications/personalization/dashboard/manifest.js](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/personalization/dashboard/manifest.js). The `entryFile` property in the manifest will tell you the entry point for this application, the file that Webpack uses as its entry for creating the `dashboard` bundle.
 
 ## Structure of a page
 
@@ -57,35 +69,35 @@ F[Announcements]-->A
 
 Static content pages work similarly, except the main content area is not a React component (though it may have one or more React widgets mounted within it).
 
-As we covered in the last section, `/my-va` uses the `dashboard` bundle, the entry file for which is located [here](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/personalization/dashboard/dashboard-entry.jsx). There's not a lot of code in that file; most of the functionality is abstracted in `startApp`. The dashboard passes in a reducer and routes, which is the primary application. In the [startApp](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/startup/index.js#L31) function, we create the [common Redux store](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/startup/index.js#L44), [start the site-wide components](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/startup/index.js#L64), and [mount the primary React application](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/startup/index.js#L73):
+As we covered in the last section, `/my-va` uses the `dashboard` bundle, the entry file for which is located [here](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/personalization/dashboard/dashboard-entry.jsx). There's not a lot of code in that file; most of the functionality is abstracted in `startApp`. The dashboard passes in a reducer and routes, which is the primary application. In the [startApp](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/startup/index.js#L31) function, we create the [common Redux store](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/startup/index.js#L44), [start the site-wide components](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/startup/index.js#L64), and [mount the primary React application](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/startup/index.js#L73):
 
 ![Abbreviated dashboard with yellow boxes drawn around site wide components](../../../images/platform/sitewide_primary.png)
 
-The components in the yellow boxes are the common site-wide components started by [startSitewideComponents](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/site-wide/index.js#L26) and the blue box is the primary React application.
+The components in the yellow boxes are the common site-wide components started by [startSitewideComponents](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/site-wide/index.js#L26) and the blue box is the primary React application.
 
 ## Structure of a React application
 
-Our React applications can vary in structure depending on what their purpose is, but typically they have a reducer and actions for Redux related logic and routes and components for the rest of the application. Routes are typically the best place to start looking at an application. Again using `/my-va` as an example, you can see the React components to start looking at in the [routes.jsx](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/personalization/dashboard/routes.jsx) file:
+Our React applications can vary in structure depending on what their purpose is, but typically they have a reducer and actions for Redux related logic and routes and components for the rest of the application. Routes are typically the best place to start looking at an application. Again using `/my-va` as an example, you can see the React components to start looking at in the [routes.jsx](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/personalization/dashboard/routes.jsx) file:
 
 ```jsx
-import DashboardApp from './containers/DashboardApp';
-import DashboardAppNew from './containers/DashboardAppNew';
-import DashboardAppWrapper from './containers/DashboardAppWrapper';
-import SetPreferences from '../preferences/containers/SetPreferences';
+import DashboardApp from "./containers/DashboardApp";
+import DashboardAppNew from "./containers/DashboardAppNew";
+import DashboardAppWrapper from "./containers/DashboardAppWrapper";
+import SetPreferences from "../preferences/containers/SetPreferences";
 
-import environment from 'platform/utilities/environment';
+import environment from "platform/utilities/environment";
 
 const component = environment.isProduction() ? DashboardApp : DashboardAppNew;
 
 export const findBenefitsRoute = {
-  path: 'find-benefits',
+  path: "find-benefits",
   component: SetPreferences,
-  key: 'find-benefits',
-  name: 'Find VA benefits',
+  key: "find-benefits",
+  name: "Find VA benefits",
 };
 
 const routes = {
-  path: '/',
+  path: "/",
   component: DashboardAppWrapper,
   indexRoute: { component },
   childRoutes: [findBenefitsRoute],
@@ -96,7 +108,7 @@ export default routes;
 
 There are only two routes in here, but you can see that there's a main `DashboardAppWrapper` component and then a `DashboardApp` component for the main index route.
 
-[DashboardAppWrapper](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/personalization/dashboard/containers/DashboardAppWrapper.jsx) has some important functionality that's common to a lot of our applications. Here's the render method from that component:
+[DashboardAppWrapper](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/personalization/dashboard/containers/DashboardAppWrapper.jsx) has some important functionality that's common to a lot of our applications. Here's the render method from that component:
 
 ```jsx
 render() {

--- a/packages/documentation/src/pages/platform/site-structure/client-overview.mdx
+++ b/packages/documentation/src/pages/platform/site-structure/client-overview.mdx
@@ -6,9 +6,21 @@ tags: build process, Javascript applications, design system, routing for react a
 # VA.gov client overview
 
 <div class="deprecation-message">
-    <h2>We're moving our docs!</h2>
-    <h3>Find <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Frontend-architecture.1855324196.html">the latest version of this page</a> on the Platform website.</h3>
-    <h3>Still can't find what you're looking for? Reach out to <a href="https://dsva.slack.com/archives/CBU0KDSB1">#vfs-platform-support</a> on Slack.</h3>
+  <h2>We're moving our docs!</h2>
+  <h3>
+    Find{" "}
+    <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Frontend-architecture.1855324196.html">
+      the latest version of this page
+    </a>{" "}
+    on the Platform website.
+  </h3>
+  <h3>
+    Still can't find what you're looking for? Reach out to{" "}
+    <a href="https://dsva.slack.com/archives/CBU0KDSB1">
+      #vfs-platform-support
+    </a>{" "}
+    on Slack.
+  </h3>
 </div>
 
 Welcome to the VA digital services platform front-end overview. The goal of this article is to provide a high level overview of our front end architecture to get you oriented with the [vets-website](https://github.com/department-of-veterans-affairs/vets-website) repository.
@@ -23,11 +35,11 @@ The content build process for this is controlled by a tool called [Metalsmith](h
 
 ## Javascript applications
 
-Javascript applications are the other type of functionality in vets-website. These applications are written in [React](https://reactjs.org/) and [Redux](https://redux.js.org/), and live in `src/applications/` in `vets-website`. For each app, you'll find a `manifest.json` file that contains application information as well as an entry in the `src/applications/registry.json`.  The `manifest.json` is used by Webpack in the application build, while the `registry.json` is used by the content build. See [Creating a new application](/veteran-facing-services-tools/getting-started/common-tasks/new-application/#manual-set-up) for more information on the difference between the `manifest.json` files and the `registry.json` file.
+Javascript applications are the other type of functionality in vets-website. These applications are written in [React](https://reactjs.org/) and [Redux](https://redux.js.org/), and live in `src/applications/` in `vets-website`. For each app, you'll find a `manifest.json` file that contains application information as well as an entry in the `src/applications/registry.json`. The `manifest.json` is used by Webpack in the application build, while the `registry.json` is used by the content build. See [Creating a new application](/veteran-facing-services-tools/getting-started/common-tasks/new-application/#manual-set-up) for more information on the difference between the `manifest.json` files and the `registry.json` file.
 
 You'll find the root url of the application, which you can use to navigate to that application on the site. These applications also usually have client-side routes, so opening that root url may allow you to click to other pages that are fully client-side.
 
-If you're a developer, most of your time will likely be spent working on a React application. We use React because it's widely used by front end developers and provides a good balance of performance and approachability. We also use Redux to manage application state, also because it's commonly used with React and fits most of the applications on VA.gov well. We use [React Router](https://reacttraining.com/react-router/) for client-side routing and [Webpack](https://webpack.js.org/) as a build tool, both of which are the *de facto* standards in the Javascript world. For styles we use [Sass](https://sass-lang.com/), and for dependency management we use [Yarn](https://yarnpkg.com/en/).
+If you're a developer, most of your time will likely be spent working on a React application. We use React because it's widely used by front end developers and provides a good balance of performance and approachability. We also use Redux to manage application state, also because it's commonly used with React and fits most of the applications on VA.gov well. We use [React Router](https://reacttraining.com/react-router/) for client-side routing and [Webpack](https://webpack.js.org/) as a build tool, both of which are the _de facto_ standards in the Javascript world. For styles we use [Sass](https://sass-lang.com/), and for dependency management we use [Yarn](https://yarnpkg.com/en/).
 
 ## Design system
 
@@ -36,6 +48,7 @@ You will also find that our visual components and site-wide styles live in an ex
 ## Routing for React apps
 
 ### Production
+
 The production deployment of the vet-website front end consists of static HTML, CSS, and JS assets deployed to an Amazon S3 bucket. We have an nginx server that serves those static assets and does some extra route handling for our single page React apps.
 
 React applications have a single entry page created by the content build and a special nginx [config entry](https://github.com/department-of-veterans-affairs/devops/blob/master/ansible/deployment/config/revproxy-vetsgov/vars/react_routes.yml). Each of the React applications listed in that config are standalone single page apps, and for each of the urls listed in that section of the config, the nginx server routes anything that starts with that url to the static page at that url, instead of trying to find a content page for a client-side route with the app. See the example below for a step by step view of that process.
@@ -59,8 +72,7 @@ One other thing to note is that links that use the `Link` component or the `rout
 
 Locally, we've configured the webpack dev server to do the same redirects as nginx, however they are duplicated in a couple places:
 
-- [script/build.js](https://github.com/department-of-veterans-affairs/vets-website/blob/master/script/build.js)
-- [src/platform/testing/e2e/test-server.js](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/test-server.js) (for e2e tests)
+- [script/build.js](https://github.com/department-of-veterans-affairs/vets-website/blob/main/script/build.js)
+- [src/platform/testing/e2e/test-server.js](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/testing/e2e/test-server.js) (for e2e tests)
 
 You will need to update these locations as well as the nginx config when creating a new React application.
-

--- a/packages/documentation/src/pages/platform/site-structure/environments.mdx
+++ b/packages/documentation/src/pages/platform/site-structure/environments.mdx
@@ -6,19 +6,32 @@ tags: localhost, development, staging, production, automated deployment
 # Environments
 
 <div class="deprecation-message">
-    <h2>We're moving our docs!</h2>
-    <h3>Find <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Environment-URLs.1851392210.html">the latest version of this page</a> on the Platform website.</h3>
-    <h3>Still can't find what you're looking for? Reach out to <a href="https://dsva.slack.com/archives/CBU0KDSB1">#vfs-platform-support</a> on Slack.</h3>
+  <h2>We're moving our docs!</h2>
+  <h3>
+    Find{" "}
+    <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Environment-URLs.1851392210.html">
+      the latest version of this page
+    </a>{" "}
+    on the Platform website.
+  </h3>
+  <h3>
+    Still can't find what you're looking for? Reach out to{" "}
+    <a href="https://dsva.slack.com/archives/CBU0KDSB1">
+      #vfs-platform-support
+    </a>{" "}
+    on Slack.
+  </h3>
 </div>
 
-| Environment | site url | api url | buildtype | NODE_ENV | Deployments |
-| ----------- | -------- | ------------ | --------- | -------- | ----------- |
-| localhost | http://localhost:3001 | http://localhost:3000 | localhost | | |
-| development | https://dev.va.gov | https://dev-api.va.gov | vagovdev | | After a merge to master |
-| staging | https://staging.va.gov | https://staging-api.va.gov | vagovstaging | production | After a merge to master |
-| production | https://www.va.gov | https://api.va.gov | vagovprod | production | Daily, Monday - Friday |
+| Environment | site url               | api url                    | buildtype    | NODE_ENV   | Deployments            |
+| ----------- | ---------------------- | -------------------------- | ------------ | ---------- | ---------------------- |
+| localhost   | http://localhost:3001  | http://localhost:3000      | localhost    |            |                        |
+| development | https://dev.va.gov     | https://dev-api.va.gov     | vagovdev     |            | After a merge to main  |
+| staging     | https://staging.va.gov | https://staging-api.va.gov | vagovstaging | production | After a merge to main  |
+| production  | https://www.va.gov     | https://api.va.gov         | vagovprod    | production | Daily, Monday - Friday |
 
 There are four environments for va.gov:
+
 - **localhost** runs on a local developer's machine
 - **development, staging,** and **production** are shared environments that are accessible publicly.
 
@@ -26,7 +39,7 @@ There are four environments for va.gov:
 
 ## Deployment
 
-- **development, staging,** and **production** have changes to them deployed automatically after pull requests are merged into master.
+- **development, staging,** and **production** have changes to them deployed automatically after pull requests are merged into main.
 - Review instances have changes deployed to them automatically when pull requests are created. Review instances are custom environments based on the shared dev environment.
 
 ## Access and test users

--- a/packages/documentation/src/pages/platform/site-structure/styling-overview.mdx
+++ b/packages/documentation/src/pages/platform/site-structure/styling-overview.mdx
@@ -6,15 +6,28 @@ tags: styling overview, sass, SCSS, US Web Design System, USWDS, Foundation, Fon
 # CSS General Info
 
 <div class="deprecation-message">
-    <h2>We're moving our docs!</h2>
-    <h3>Find <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Styling.1851392375.html">the latest version of this page</a> on the Platform website.</h3>
-    <h3>Still can't find what you're looking for? Reach out to <a href="https://dsva.slack.com/archives/CBU0KDSB1">#vfs-platform-support</a> on Slack.</h3>
+  <h2>We're moving our docs!</h2>
+  <h3>
+    Find{" "}
+    <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Styling.1851392375.html">
+      the latest version of this page
+    </a>{" "}
+    on the Platform website.
+  </h3>
+  <h3>
+    Still can't find what you're looking for? Reach out to{" "}
+    <a href="https://dsva.slack.com/archives/CBU0KDSB1">
+      #vfs-platform-support
+    </a>{" "}
+    on Slack.
+  </h3>
 </div>
 
 ## Background
+
 - Written in [Sass](http://sass-lang.com/) using the [SCSS](http://sass-lang.com/documentation/file.SASS_REFERENCE.html) syntax
-    > There are two syntaxes available for Sass. The first, known as SCSS (Sassy CSS) and used throughout this reference, is an extension of the syntax of CSS. This means that every valid CSS stylesheet is a valid SCSS file with the same meaning. In addition, SCSS understands most CSS hacks and vendor-specific syntax, such as IE's old filter syntax. This syntax is enhanced with the Sass features described below. Files using this syntax have the .scss extension.
-- Files resides in [src/platform/site-wide/sass](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/platform/site-wide/sass)
+  > There are two syntaxes available for Sass. The first, known as SCSS (Sassy CSS) and used throughout this reference, is an extension of the syntax of CSS. This means that every valid CSS stylesheet is a valid SCSS file with the same meaning. In addition, SCSS understands most CSS hacks and vendor-specific syntax, such as IE's old filter syntax. This syntax is enhanced with the Sass features described below. Files using this syntax have the .scss extension.
+- Files resides in [src/platform/site-wide/sass](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/platform/site-wide/sass)
 - Frameworks and libraries include:
   - [U.S. Web Design System (USWDS)](https://designsystem.digital.gov/)
     - [GitHub Repo](https://github.com/uswds/uswds)
@@ -24,8 +37,8 @@ tags: styling overview, sass, SCSS, US Web Design System, USWDS, Foundation, Fon
   - [Font Awesome](http://fontawesome.io/)
 - Compiled to CSS using Webpack
 
-
 ## Directory structure
+
 - `root/`
   - Site-wide style is defined in `style.scss`
     - Includes global imports, such as our frameworks and libraries
@@ -42,6 +55,7 @@ tags: styling overview, sass, SCSS, US Web Design System, USWDS, Foundation, Fon
     - Generally used only for specific applications/pages of the website that are organized in a directory rather than a single file.
 
 # Webpack/Compilation
+
 - Sass is configured and compiled into CSS via Webpack
   - Configuration at `config/webpack.config.js`
 - Website is broken into a series of entry files, one of which is the site-wide file, `style.scss`, while the rest are entry points for applications defined as `JSX` files.
@@ -51,6 +65,7 @@ tags: styling overview, sass, SCSS, US Web Design System, USWDS, Foundation, Fon
 ## Example Application
 
 ##### config/webpack.config.js
+
 ```js
 const entryFiles = {
   // ...
@@ -59,26 +74,31 @@ const entryFiles = {
 ```
 
 ##### content/somewhere/some-application.md
+
 ```html
 ---
 title: My Application
 layout: page-react.html
 entryname: my-application
 ---
-<p> Some content</p>
+
+<p>Some content</p>
 <div id="react-entry"></div>
 ```
 
 ##### src/applications/my-application/entry.jsx
+
 ```js
 // Our Webpack configuration will use the file extension to determine how to handle that import, which in our case is to compile it into a CSS file.
-import '../../sass/my-application.scss';
+import "../../sass/my-application.scss";
 ```
 
 ## Static Assets
+
 The `root/assets/` directory is used for storing images, fonts, and other files you may want to have reside outside of the Webpack build system. During build time, the contents of that directory will be moved as-is to the build output, so `root/assets/js/something.js` will be moved to `root/build/development/js/something.js`, which means it can be linked to in the website with `/js/something.js`.
 
 # Roadmap Ahead
+
 - Keep up-to-date with USWDS
   - [What's New](https://designsystem.digital.gov/whats-new/)
 - Foundation needs to go entirely. We should opt for the USWDS grid system or Flexbox instead.

--- a/packages/documentation/src/pages/platform/tools/downtime-notifications.mdx
+++ b/packages/documentation/src/pages/platform/tools/downtime-notifications.mdx
@@ -9,7 +9,7 @@ Downtime Notications are a mechanism for handling outages of external services i
 
 ## Overview
 
-- Available as a React component in [vets-website](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/monitoring/DowntimeNotification/index.jsx).
+- Available as a React component in [vets-website](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/monitoring/DowntimeNotification/index.jsx).
 - Consumers of the React component register required-services as dependencies via React props
 - Driven by [PagerDuty maintenance windows](https://dsva.pagerduty.com/maintenance_windows) so that downtime for a certain service can be scheduled without requiring a deployment. [More info on PagerDuty maintenance windows](https://support.pagerduty.com/docs/maintenance-windows).
 - After a maintenance window is added in Pager Duty, an application wrapped in the Downtime Notification React component typically responds in one of three ways:
@@ -76,17 +76,17 @@ Note that `MyAppDataGrid` would issue the API request to _Fancy Service_ during 
 **src/applications/my-app/containers/MyApp.jsx**
 
 ```jsx
-import React from 'react';
-import { connect } from 'react-redux';
+import React from "react";
+import { connect } from "react-redux";
 
 import {
   DowntimeNotification,
   externalServices,
-} from 'platform/monitoring/DowntimeNotifications';
+} from "platform/monitoring/DowntimeNotifications";
 
-import { fetchFromFancyService } from '../actions';
+import { fetchFromFancyService } from "../actions";
 
-import MyAppDataGrid from '../components/MyAppDataGrid';
+import MyAppDataGrid from "../components/MyAppDataGrid";
 
 class MyApp extends React.component {
   render() {
@@ -106,7 +106,7 @@ class MyApp extends React.component {
   }
 }
 
-const mapStateToProps = state => store.myApp;
+const mapStateToProps = (state) => store.myApp;
 
 const mapDispatchToProps = {
   fetchFromFancyService,

--- a/packages/documentation/src/pages/platform/tools/feature-toggles.mdx
+++ b/packages/documentation/src/pages/platform/tools/feature-toggles.mdx
@@ -8,21 +8,24 @@ tags: vagovprod, vagovstaging, vagovdev
 Feature toggles can be used in both vets-api and vets-website to manage unreleased features in a continuous integration environment. Feature toggles enable VFS teams to test out new functionality (applications, features, VA.gov content pages, Metalsmith) in the VSP development, staging, or production environments for a set of users. Teams can enable or disable a feature for all users, a percentage of all users, a percentage of all logged-in users, a list of users, or users defined in a method.
 
 Feature toggles:
+
 - Allow for production toggle switching without redeploying vets-website
 - Provide a user interface for managing feature toggle behavior
 - Provide code helpers for handling common user experience scenarios
 - Are powered by an open-source gem called [Flipper gem](https://github.com/jnunemaker/flipper)
 
 See the following sections for information about creating feature toggles:
+
 - [Writing good feature toggles](#writing-good-feature-toggles)
 - Adding a new feature toggle
-   - [Frontend](#add-feature)
-   - [Backend](#backend)
+  - [Frontend](#add-feature)
+  - [Backend](#backend)
 - [Enabling and disabling features](#flipper-ui)
 
 ## <a id="writing-good-feature-toggles">Writing good feature toggles</a>
 
 Keep the following items in mind as you add feature toggles:
+
 - Remember that each environment has its own set of feature toggle values.
 - Test your feature toggle in staging before using it in production.
 - Remove feature toggles as soon as they are not needed.
@@ -40,31 +43,32 @@ Follow these steps to add and use a new feature toggle in vets-website:
 
 2. Add the feature name to vets-api (in snake case) by updating [config/features.yml](https://github.com/department-of-veterans-affairs/vets-api/blob/master/config/features.yml):
 
-  ```yml
- features:
-   app_name_then_your_feature_name:
-     actor_type: user
-     description: >
-       This describes what the feature does and
-       which team is responsible for the toggle.
-  ```
-3. Determine how you want the feature toggle to be "sticky".
-  For the behavior to be consistent across all devices for a logged in user choose "user" as the  actor_type.
-  For the behavior to be consistent for a user for the duration of a cookie within a single browser, regardless of their logged in status choose "cookie_id" as the actor_type.
+```yml
+features:
+  app_name_then_your_feature_name:
+    actor_type: user
+    description: >
+      This describes what the feature does and
+      which team is responsible for the toggle.
+```
 
-4. Run vets-api locally. This can be done on master after your pull request (PR) is merged or off of your feature branch.
+3. Determine how you want the feature toggle to be "sticky".
+   For the behavior to be consistent across all devices for a logged in user choose "user" as the actor_type.
+   For the behavior to be consistent for a user for the duration of a cookie within a single browser, regardless of their logged in status choose "cookie_id" as the actor_type.
+
+4. Run vets-api locally. This can be done on main after your pull request (PR) is merged or off of your feature branch.
 
 5. Navigate to [http://localhost:3000/flipper/features](http://localhost:3000/flipper/features) and verify that you see your new feature name. If not, restart your rails server.
 
-6. Add the feature toggle name to vets-website by updating [featureFlagNames.js](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/utilities/feature-toggles/featureFlagNames.js).
+6. Add the feature toggle name to vets-website by updating [featureFlagNames.js](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/utilities/feature-toggles/featureFlagNames.js).
 
-    ```js
-    const FEATURE_FLAG_NAMES = Object.freeze({
-     showYourFeatureName: 'app_name_then_your_feature_name',
-    })
-    ```
+   ```js
+   const FEATURE_FLAG_NAMES = Object.freeze({
+     showYourFeatureName: "app_name_then_your_feature_name",
+   });
+   ```
 
-    **Note:** The key should be camelCase for use in JavaScript, but the value should exactly match the toggle name in `features.yml`.
+   **Note:** The key should be camelCase for use in JavaScript, but the value should exactly match the toggle name in `features.yml`.
 
 7. Submit a PR for each feature. Crosslinking the PRs in a comment will make it easier for the reviewers to check.
 
@@ -74,10 +78,10 @@ Follow these steps to add and use a new feature toggle in vets-website:
 
 ```js
 // import the toggleValues helper
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import { toggleValues } from "platform/site-wide/feature-toggles/selectors";
 
 // use the toggleValues helper to select the toggle values list
-export const appNameThenYourFeatureName = state =>
+export const appNameThenYourFeatureName = (state) =>
   toggleValues(state).appNameThenYourFeatureName;
 ```
 
@@ -117,17 +121,18 @@ Follow these steps to add and use a new feature toggle in vets-api:
 
 2. Add the feature name to vets-api (in snake case) by updating [config/features.yml](https://github.com/department-of-veterans-affairs/vets-api/blob/master/config/features.yml):
 
-  ```yml
-  features:
-     app_name_then_your_feature_name:
-     actor_type: user
-     description: >
-       This describes what the feature does and
-       which team is responsible for the toggle.
-  ```
+```yml
+features:
+  app_name_then_your_feature_name:
+  actor_type: user
+  description: >
+    This describes what the feature does and
+    which team is responsible for the toggle.
+```
+
 3. Determine how you want the feature toggle to be "sticky".
-  For the behavior to be consistent across all devices for a logged in user choose "user" as the  actor_type.
-  For the behavior to be consistent for a user for the duration of a cookie within a single browser, regardless of their logged in status choose "cookie_id" as the actor_type.
+   For the behavior to be consistent across all devices for a logged in user choose "user" as the actor_type.
+   For the behavior to be consistent for a user for the duration of a cookie within a single browser, regardless of their logged in status choose "cookie_id" as the actor_type.
 
 4. Run vets-api locally. This can be done on master after your PR is merged or off of your feature branch.
 
@@ -175,11 +180,11 @@ You can enable or disable features in the Flipper UI:
 
 1. Navigate to the Flipper UI at the following URLs:
 
-|Environment|URL|
-|---|---|
-|Dev|http://localhost:3000/flipper/features|
-|Staging|https://staging-api.va.gov/flipper/features|
-|Production|https://api.va.gov/flipper/features|
+| Environment | URL                                         |
+| ----------- | ------------------------------------------- |
+| Dev         | http://localhost:3000/flipper/features      |
+| Staging     | https://staging-api.va.gov/flipper/features |
+| Production  | https://api.va.gov/flipper/features         |
 
 2. To access the Flipper UI, you must sign in using an [identity-verified id.me user](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/identity-personalization/va.gov-login-process.md) that is listed in [settings.yml](https://github.com/department-of-veterans-affairs/vets-api/blob/master/config/settings.yml):
 
@@ -190,16 +195,18 @@ flipper:
     - email1@email.us
 ```
 
-   **Notes:**
-   - In the **Dev** environment, to get around the incompleteness of user data in the sandbox environment, you should sign in with a specific test user - see [`dev-settings.local.yml`](https://github.com/department-of-veterans-affairs/devops/blob/master/ansible/deployment/config/vets-api/dev-settings.local.yml.j2#L593) for more information. Credentials for this user can be found [here](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/Administrative/vagov-users/mvi-staging-users.csv).
-   - If you are not on the list, you can add yourself or your teammates to the file.
-   - If you're not sure if your account is identity-verified, you can check by going to [this page](https://www.va.gov/profile/). If you need to verify your account you'll see a "Verify with ID.me" button.
+**Notes:**
+
+- In the **Dev** environment, to get around the incompleteness of user data in the sandbox environment, you should sign in with a specific test user - see [`dev-settings.local.yml`](https://github.com/department-of-veterans-affairs/devops/blob/master/ansible/deployment/config/vets-api/dev-settings.local.yml.j2#L593) for more information. Credentials for this user can be found [here](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/Administrative/vagov-users/mvi-staging-users.csv).
+- If you are not on the list, you can add yourself or your teammates to the file.
+- If you're not sure if your account is identity-verified, you can check by going to [this page](https://www.va.gov/profile/). If you need to verify your account you'll see a "Verify with ID.me" button.
 
 3. Once you have logged into the Flipper UI, you can perform the following actions:
+
    - Select "Enable for everyone" or "Disable for everyone" to enable or disable the feature for all users.
    - Use "Percentage of Logged in Users" for a [staged rollout](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/product-management/release-plan-template.md#phase-ii-staged-rollout-also-known-as-unmoderated-production-testing) (gradual rollout or an a/b test).
-       - "Percentage of Logged in Users" will enable the feature for only a percentage of logged in users. It will be applied to the same users each time they return to the site (even when they log out and back in) as long as you don't change the percentage.
-       - If the feature toggle's actor_type in [config/features.yml](https://github.com/department-of-veterans-affairs/vets-api/blob/master/config/features.yml) is set to "cookie_id" rather than "user" then the feature instead applies to only a percentage of users for the duration of a cookie within a single browser, *regardless of their logged in status*. This is useful when you need to apply a staged rollout that involves an unauthenticated user experience.
+     - "Percentage of Logged in Users" will enable the feature for only a percentage of logged in users. It will be applied to the same users each time they return to the site (even when they log out and back in) as long as you don't change the percentage.
+     - If the feature toggle's actor*type in [config/features.yml](https://github.com/department-of-veterans-affairs/vets-api/blob/master/config/features.yml) is set to "cookie_id" rather than "user" then the feature instead applies to only a percentage of users for the duration of a cookie within a single browser, \_regardless of their logged in status*. This is useful when you need to apply a staged rollout that involves an unauthenticated user experience.
    - Use "Percentage of Time" to enable a feature for all users for a percentage of time.
    - Register a "Group" of users to enable a feature for.
    - You can also roll out a feature for a select few users by adding their email address to the “Users” section. For performance reasons, the list of users is intended to be small — do not use this option for hundreds of users.
@@ -208,35 +215,39 @@ flipper:
 
    ![Screen Shot](https://user-images.githubusercontent.com/19188/74881655-b4d11a80-533b-11ea-8e97-fdea24c10830.png)
 
-*The following sections contain information that will be phased out.*
+_The following sections contain information that will be phased out._
 
 ## Testing new applications and updates to existing applications
-*Use the method described above to [add](#add-feature) and [enable/disable](#flipper-ui) feature toggles. The method described in this section will be phased out.*
 
-In the [staging environment](https://staging.va.gov), you can test unreleased features or applications using [!isProduction()](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/utilities/environment/index.js).
+_Use the method described above to [add](#add-feature) and [enable/disable](#flipper-ui) feature toggles. The method described in this section will be phased out._
 
-In the [production environment](https://www.va.gov), you can test unreleased features and applications by checking [localstorage](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/utilities/storage/localStorage.js) for a developer-defined name/value. You can do this by:
+In the [staging environment](https://staging.va.gov), you can test unreleased features or applications using [!isProduction()](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/utilities/environment/index.js).
+
+In the [production environment](https://www.va.gov), you can test unreleased features and applications by checking [localstorage](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/utilities/storage/localStorage.js) for a developer-defined name/value. You can do this by:
+
 - Adding the feature name/value to local storage with a console command in the browser
 - Using application specific code that automatically checks when a certain query parameter is present
 
 **Note:** Unreleased applications can be made available on production behind a password by setting `protected: yes` in [react_routes.yml](https://github.com/department-of-veterans-affairs/devops/blob/master/ansible/deployment/config/revproxy-vagov/vars/react_routes.yml). External teams should work with their DSVA contact to request support for enabling this.
 
 ## Testing content pages
-*Use the method described above to [add](#add-feature) and [enable/disable](#flipper-ui) feature toggles. The method described in this section will be phased out.*
+
+_Use the method described above to [add](#add-feature) and [enable/disable](#flipper-ui) feature toggles. The method described in this section will be phased out._
 
 ### App-landing pages generated by registry.json
+
 Applications can control the HTML landing page associated with the application via a `template` property in the application's entry in the `src/applications/registry.json`. Properties defined inside the `template` property will pass through the Metalsmith templating process the same way as a vagov-content `.md` file. This means that via the `template` property, your appliations entry in `registry.json` can implement a feature toggle the same way as a `.md` file to prevent its HTML page from rendering in production environments. For example:
 
 ```json
 {
-   "appName": "Fantastic application",
-   "entryName": "fantastic-application",
-   "rootUrl": "/path/to/fantastic-application",
-   "template": {
-       "layout": "page-react.html",
-       "title": "Fantastic application",
-       "vagovprod": false
-   }
+  "appName": "Fantastic application",
+  "entryName": "fantastic-application",
+  "rootUrl": "/path/to/fantastic-application",
+  "template": {
+    "layout": "page-react.html",
+    "title": "Fantastic application",
+    "vagovprod": false
+  }
 }
 ```
 
@@ -251,11 +262,13 @@ Unreleased content pages should always be made available on [staging.va.gov](htt
 title: Apply for disability benefits
 vagovprod: false
 ---
+
 <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"
 id="va-breadcrumbs">
 ```
 
 Content pages can be excluded from any or all of these environments:
+
 ```markdown
 vagovprod: false
 vagovstaging: false
@@ -264,7 +277,8 @@ localhost: false
 ```
 
 ## Testing CMS feature toggles
-*Use the method described above to [add](#add-feature) and [enable/disable](#flipper-ui) feature toggles. The method described in this section will be phased out.*
+
+_Use the method described above to [add](#add-feature) and [enable/disable](#flipper-ui) feature toggles. The method described in this section will be phased out._
 
 VA.gov creates some pages based on content from the VA's Drupal CMS. The CMS has its own content model, which can sometimes change. When those changes modify the existing structure of the content model, the queries and templates in vets-website that expect a different model may break. And because the CMS and vets-website are separate systems with different deployment processes, we can't push up changes in both systems simultaneously. In order to keep the two systems in sync, we need to be able to turn features on and off in vets-website depending on what environment we're in, and update that feature state whenever a cms deployment happens.
 
@@ -276,9 +290,10 @@ When running a new vets-website build, the script will fetch all CMS feature tog
 
 Before writing any code to use a new feature toggle, it must first be created from within Drupal for all three environments. The feature toggles can be found at https://dev.cms.va.gov/admin/config/system/feature_toggle for dev. Staging and production have similar pages.
 
-**Important:** The new feature toggle *must* be in *every* Drupal environment or vets-website builds will fail when we try to use it! This is intentional so we don't have "accidentally" false feature toggles when Drupal doesn't have a toggle that vets-website is trying to use.
+**Important:** The new feature toggle _must_ be in _every_ Drupal environment or vets-website builds will fail when we try to use it! This is intentional so we don't have "accidentally" false feature toggles when Drupal doesn't have a toggle that vets-website is trying to use.
 
 ### Using toggles in GraphQL queries
+
 Because the toggles are fetched dynamically, they aren't stored in a file that we can `require` from a GraphQL query file. The build script puts the current toggles are put into `global.cmsFeatureFlags` after it either fetches the most recent toggles or uses the cache.
 
 Keep in mind the advice in the [writing good feature toggles](#writing-good-feature-toggles) section. You should write the logic in a way that is easy to remove later. It's often easier to change some logic and then add a conditional that modifies something with the toggle is not enabled. That lets you simply remove the conditional later.

--- a/packages/documentation/src/pages/platform/tools/visual-regression-testing.mdx
+++ b/packages/documentation/src/pages/platform/tools/visual-regression-testing.mdx
@@ -10,34 +10,37 @@ This is the first iteration of visual regression testing. It is useful to detect
 It works by gathering the links for the site using the sitemap, then opening an chromium instance using Puppeteer to navigate throughout the site, capturing an image of each page. The developer must first create the baseline image set for comparisons (sometimes called the golden set), then after making their changes, run an additional task to make the comparison.
 
 # How to use
+
 1. **Start the local website instance**
 2. **Generate your baseline/golden image set for desktop with the following command**
-    - `npm run test:visual:baseline`
-    - Note - These images should be generated before your changes, so you may want to switch to the master branch before running this command. This will create the directory `site-root/logs/visual-regression/baseline/desktop` with all of the website images.
+   - `npm run test:visual:baseline`
+   - Note - These images should be generated before your changes, so you may want to switch to the main branch before running this command. This will create the directory `site-root/logs/visual-regression/baseline/desktop` with all of the website images.
 3. **Generate your baseline/golden image set for mobile with the following command**
-    - `npm run test:visual:baseline -- --mobile`
-    - Note - These images should be generated before your changes, so you may want to switch to the master branch before running this command. This will create the directory `site-root/logs/visual-regression/baseline/mobile` with all of the website images.
-3. **Make your changes**
-4. **Run the visual regression test for desktop**
-    - `npm run test:visual`
-    - Screenshots of the website (updated to have your changes) will be stored in memory and compared to the baseline images created in step 3. If the images are different, a "diff" image will be generated and stored in the `site-root/logs/visual-regression/diffs/desktop` directory
-    - All pages that have changed will be outputted as test case failures
-5. **Run the visual regression test for mobile**
-    - `npm run test:visual -- mobile`
-    - Screenshots of the website (updated to have your changes) will be stored in memory and compared to the baseline images created in step 3. If the images are different, a "diff" image will be generated and stored in the `site-root/logs/visual-regression/diffs/mobile` directory
-    - All pages that have changed will be outputted as test case failures
+   - `npm run test:visual:baseline -- --mobile`
+   - Note - These images should be generated before your changes, so you may want to switch to the main branch before running this command. This will create the directory `site-root/logs/visual-regression/baseline/mobile` with all of the website images.
+4. **Make your changes**
+5. **Run the visual regression test for desktop**
+   - `npm run test:visual`
+   - Screenshots of the website (updated to have your changes) will be stored in memory and compared to the baseline images created in step 3. If the images are different, a "diff" image will be generated and stored in the `site-root/logs/visual-regression/diffs/desktop` directory
+   - All pages that have changed will be outputted as test case failures
+6. **Run the visual regression test for mobile**
+   - `npm run test:visual -- mobile`
+   - Screenshots of the website (updated to have your changes) will be stored in memory and compared to the baseline images created in step 3. If the images are different, a "diff" image will be generated and stored in the `site-root/logs/visual-regression/diffs/mobile` directory
+   - All pages that have changed will be outputted as test case failures
 
 # Limitations/ideas going forward
+
 Right now this is really limited to being useful for the developer, which I think is a good foundation if we decide to expand on it. Some thoughts -
+
 1. All screenshots are stored in a git-ignored directory
-    - All images are stored in `logs/visual-regression`, with two subdirectories, one being for the baseline and the other for diffs. This was the minimal implementation and what I considered to be a good stopping point for the first iteration.
-    - Do we want to include them in version control? And if so, will we store images using the commit SHA?
+   - All images are stored in `logs/visual-regression`, with two subdirectories, one being for the baseline and the other for diffs. This was the minimal implementation and what I considered to be a good stopping point for the first iteration.
+   - Do we want to include them in version control? And if so, will we store images using the commit SHA?
 2. Tests fail on all pages that don't match the baseline
-    - This means that intentionally-changed pages are detected as test failures the same as pages that may have been changed visually as an unintended side affect.
-    - If we want to plug this into our build pipeline, this will have to be addressed, meaning that we'll need a way for developers to sign off on pages that were intentionally changed.
+   - This means that intentionally-changed pages are detected as test failures the same as pages that may have been changed visually as an unintended side affect.
+   - If we want to plug this into our build pipeline, this will have to be addressed, meaning that we'll need a way for developers to sign off on pages that were intentionally changed.
 3. Does not scroll or resize the browser window
-    - This means that with this current implementation, we're only testing it on the desktop viewport. It wouldn't be very difficult to change the window size and take new screenshots as part of the automated tests but I wanted to avoid overkill on the first iteration.
+   - This means that with this current implementation, we're only testing it on the desktop viewport. It wouldn't be very difficult to change the window size and take new screenshots as part of the automated tests but I wanted to avoid overkill on the first iteration.
 4. Uses the sitemap to navigate throughout the site
-    - Pages not included in the sitemap will not be evaluated by this tool.
+   - Pages not included in the sitemap will not be evaluated by this tool.
 5. Does not interact with the page at all
-    - This means that style for elements that are visible only after certain user interactions will not be evaluated.
+   - This means that style for elements that are visible only after certain user interactions will not be evaluated.

--- a/packages/documentation/src/pages/platform/unit-testing.mdx
+++ b/packages/documentation/src/pages/platform/unit-testing.mdx
@@ -1,18 +1,30 @@
 # Unit testing
 
 <div class="deprecation-message">
-    <h2>We're moving our docs!</h2>
-    <h3>Find <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Unit-tests.1836187655.html">the latest version of this page</a> on the Platform website.</h3>
-    <h3>Still can't find what you're looking for? Reach out to <a href="https://dsva.slack.com/archives/CBU0KDSB1">#vfs-platform-support</a> on Slack.</h3>
+  <h2>We're moving our docs!</h2>
+  <h3>
+    Find{" "}
+    <a href="https://depo-platform-documentation.scrollhelp.site/developer-docs/Unit-tests.1836187655.html">
+      the latest version of this page
+    </a>{" "}
+    on the Platform website.
+  </h3>
+  <h3>
+    Still can't find what you're looking for? Reach out to{" "}
+    <a href="https://dsva.slack.com/archives/CBU0KDSB1">
+      #vfs-platform-support
+    </a>{" "}
+    on Slack.
+  </h3>
 </div>
 
 All new code that is added to `vets-website` should be unit tested and unit tests should cover at least 75% of code paths. Write unit tests as you build to make sure your form (or other component) is behaving as you expect and to help guard against future bugs.
 
-**Unit test file format:** *file_name*.unit.spec.js
+**Unit test file format:** _file_name_.unit.spec.js
 
-**Where:** Any *file_name*.unit.spec.js file located in the `/src` folder. This file is usually located in a test directory close to the code being tested.
+**Where:** Any _file_name_.unit.spec.js file located in the `/src` folder. This file is usually located in a test directory close to the code being tested.
 
-**When:** [Run the test](/getting-started/common-tasks/test) locally through npm script commands, during the Jenkins build (Unit), and after merging to master.
+**When:** [Run the test](/getting-started/common-tasks/test) locally through npm script commands, during the Jenkins build (Unit), and after merging to main.
 
 **How:** [Write a unit test.](/getting-started/common-tasks/new-unit-test)
 


### PR DESCRIPTION
## Description
This PR updates references to the master branch of vets-website and content-build to main in preparation for switching the default branch name of these repos to main.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
