### PR TITLE
Update focus styles

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "7.0.1",
+  "version": "8.0.0",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/base/_b-mixins.scss
+++ b/packages/formation/sass/base/_b-mixins.scss
@@ -92,12 +92,6 @@
   outline-offset: #{$offset}px;
 }
 
-@mixin focus-gold-lighter-highlight {
-  background: $color-gold-lighter;
-  outline: 2px solid $color-gold-lighter;
-  outline-offset: 0;
-}
-
 @mixin focus {
   @include focus-gold-vivid-outline;
 }

--- a/packages/formation/sass/base/_b-mixins.scss
+++ b/packages/formation/sass/base/_b-mixins.scss
@@ -87,7 +87,7 @@
   }
 }
 
-@mixin focus-gold-vivid-outline($offset: 2) {
+@mixin focus-gold-vivid-outline {
   box-shadow: 0 0 0 3px $color-white, 0 0 4px 6px $color-gold-50v;
   outline: none;
 }
@@ -148,7 +148,6 @@
   }
   &:focus {
     @include focus-gold-vivid-outline;
-    outline-offset: 0;
   }
   &:disabled {
     text-decoration: none;

--- a/packages/formation/sass/base/_b-mixins.scss
+++ b/packages/formation/sass/base/_b-mixins.scss
@@ -87,7 +87,7 @@
   }
 }
 
-@mixin focus-gold-light-outline($offset: 2) {
+@mixin focus-gold-vivid-outline($offset: 2) {
   outline: $focus-outline;
   outline-offset: #{$offset}px;
 }
@@ -99,7 +99,7 @@
 }
 
 @mixin focus {
-  @include focus-gold-light-outline;
+  @include focus-gold-vivid-outline;
 }
 
 @mixin color-transition {
@@ -153,7 +153,7 @@
     background: $color-link-default-hover;
   }
   &:focus {
-    @include focus-gold-light-outline;
+    @include focus-gold-vivid-outline;
     outline-offset: 0;
   }
   &:disabled {

--- a/packages/formation/sass/base/_b-mixins.scss
+++ b/packages/formation/sass/base/_b-mixins.scss
@@ -88,8 +88,8 @@
 }
 
 @mixin focus-gold-vivid-outline($offset: 2) {
-  outline: $focus-outline;
-  outline-offset: #{$offset}px;
+  box-shadow: 0 0 0 3px $color-white, 0 0 4px 6px $color-gold-50v;
+  outline: none;
 }
 
 @mixin focus {

--- a/packages/formation/sass/base/_b-variables.scss
+++ b/packages/formation/sass/base/_b-variables.scss
@@ -88,8 +88,6 @@ $color-gold-50v:             #936F38; // This is something that's not in USWDS 1
 $color-visited:              $color-purple;
 $color-focus:                #3e94cf;
 
-$focus-outline:              2px solid $color-gold-50v;
-
 $color-cool-blue:           #205493;
 $color-cool-blue-light:     #4773aa;
 $color-cool-blue-lighter:   #8ba6ca;

--- a/packages/formation/sass/base/_b-variables.scss
+++ b/packages/formation/sass/base/_b-variables.scss
@@ -88,6 +88,13 @@ $color-gold-50v:             #936F38; // This is something that's not in USWDS 1
 $color-visited:              $color-purple;
 $color-focus:                #3e94cf;
 
+// The focus outline is only used for anchor links in the main body
+// See this article for details:
+//  https://adhoc.team/2022/02/08/creating-focus-style-for-themable-design-system/
+// A double `box-shadow` is used for other focus styling, including
+// links in the header & footer since they are unlikely to wrap
+$focus-outline:              2px solid $color-gold-50v;
+
 $color-cool-blue:           #205493;
 $color-cool-blue-light:     #4773aa;
 $color-cool-blue-lighter:   #8ba6ca;

--- a/packages/formation/sass/base/_b-variables.scss
+++ b/packages/formation/sass/base/_b-variables.scss
@@ -83,11 +83,12 @@ $color-green-light:          #4aa564;
 $color-gold-lightest:        #fff1d2;
 $color-gold-lighter:         #fad980;
 $color-gold-light:           #f9c642;
+$color-gold-50v:             #936F38; // This is something that's not in USWDS 1.6
 
 $color-visited:              $color-purple;
 $color-focus:                #3e94cf;
 
-$focus-outline:              2px solid $color-gold-light;
+$focus-outline:              2px solid $color-gold-50v;
 
 $color-cool-blue:           #205493;
 $color-cool-blue-light:     #4773aa;

--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -35,7 +35,7 @@ body {
   &:focus {
     position: inherit;
     top: auto;
-    @include focus-gold-vivid-outline()
+    @include focus-gold-vivid-outline;
   }
 }
 

--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -35,7 +35,7 @@ body {
   &:focus {
     position: inherit;
     top: auto;
-    outline: 2px solid $color-gold;
+    outline: $focus-outline;
   }
 }
 

--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -97,6 +97,18 @@ a {
   }
 }
 
+// Use outline focus styling for links in the main content area
+// since box-shadow styling doesn't look good on wrapped links
+main [href],
+va-banner [href] {
+  &:focus {
+    outline: $focus-outline;
+    background: $color-white;
+    color: $color-link-default;
+    box-shadow: unset;
+  }
+}
+
 // ====== Headings
 
 // H1 should only be used once at the top-level, so we can safely remove the margin-top.

--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -35,7 +35,7 @@ body {
   &:focus {
     position: inherit;
     top: auto;
-    outline: $focus-outline;
+    @include focus-gold-vivid-outline()
   }
 }
 

--- a/packages/formation/sass/modules/_m-form-process.scss
+++ b/packages/formation/sass/modules/_m-form-process.scss
@@ -214,7 +214,7 @@
 }
 
 .schemaform-array-row-title:focus {
-  @include focus-gold-light-outline;
+  @include focus-gold-vivid-outline;
   display: inline-block;
 }
 

--- a/packages/formation/sass/modules/_m-nav-sidebar.scss
+++ b/packages/formation/sass/modules/_m-nav-sidebar.scss
@@ -206,7 +206,7 @@ $level-3-hover-padding: 8px 12px 8px 30px;
       }
 
       &:focus {
-        outline: 2px solid $color-gold;
+        outline: $focus-outline;
         outline-offset: 3px;
       }
     }

--- a/packages/formation/sass/modules/_m-nav-sidebar.scss
+++ b/packages/formation/sass/modules/_m-nav-sidebar.scss
@@ -286,7 +286,7 @@ $level-3-hover-padding: 8px 12px 8px 30px;
       font-size: 15px;
 
       &:focus {
-        @include focus-gold-light-outline(0);
+        @include focus-gold-vivid-outline(0);
       }
 
       &:hover, &:focus {

--- a/packages/formation/sass/modules/_m-nav-sidebar.scss
+++ b/packages/formation/sass/modules/_m-nav-sidebar.scss
@@ -285,7 +285,7 @@ $level-3-hover-padding: 8px 12px 8px 30px;
       font-size: 15px;
 
       &:focus {
-        @include focus-gold-vivid-outline(0);
+        @include focus-gold-vivid-outline;
       }
 
       &:hover, &:focus {

--- a/packages/formation/sass/modules/_m-nav-sidebar.scss
+++ b/packages/formation/sass/modules/_m-nav-sidebar.scss
@@ -206,8 +206,7 @@ $level-3-hover-padding: 8px 12px 8px 30px;
       }
 
       &:focus {
-        outline: $focus-outline;
-        outline-offset: 3px;
+        @include focus-gold-vivid-outline;
       }
     }
 


### PR DESCRIPTION
## Description

Part of https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/654

Companion PR: https://github.com/department-of-veterans-affairs/component-library/pull/433

I left review comments, but links that aren't in the header/footer aren't getting the box-shadow styles because they could wrap, and box-shadow focus styling would look bad. Keeping the outline like we currently have (but with a different color) and setting the color to be dark and the background to be light should ensure that a focused link will have good contrast no matter where it appears.

## Testing done

`yarn link` and tested builds in `vets-website` and `content-build`


## Screenshots

<details>

<summary>Example of focus styling for buttons, links, and wrapped links where the ends are far apart</summary>

![Tabbing around on homepage with new box-shadow styling](https://user-images.githubusercontent.com/2008881/169415596-a8c42105-6179-4737-8c3f-e9e7431ee2ee.gif)

</details>

<details>

<summary>Example where wrapped links are stacked underneath</summary>

![Tabbing around in a narrow screen](https://user-images.githubusercontent.com/2008881/169415871-80943921-aa0a-4c96-a366-2ef5f2964db8.gif)

</details>

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
