### PR TITLE
add deprecation message

### DIFF
--- a/packages/documentation/src/pages/forms/index.mdx
+++ b/packages/documentation/src/pages/forms/index.mdx
@@ -5,6 +5,8 @@ tags: overview
 
 # VA.gov Forms Library
 
+**NOTE: THIS DOCUMENTATION IS NO LONGER ACTIVELY MAINTAINED AND WILL BE REMOVED ON 6/17/2022. FOR UP TO DATE DOCUMENTATION ON THE FORMS LIBRARY, PLEASE REFER TO THE [OFFICIAL PLATFORM WEBSITE](https://depo-platform-documentation.scrollhelp.site/developer-docs/VA-Forms-Library-Overview.2085355587.html)**
+
 The VA.gov Forms Library provides a simple way to create a consistent experience for complex forms for Veterans. Applications created with this framework generally follow this flow:
 
 ```mermaid


### PR DESCRIPTION
## Description
With all documentation around the current forms library fully migrated to [the platform documentation site](https://depo-platform-documentation.scrollhelp.site/developer-docs/VA-Forms-Library-Overview.2085355587.html), documentation here should be sunsetted and eventually removed to avoid conflicting sources of information. 

This pull request adds a deprecation message to the top of the forms index page stating as much. Target date for removal of this content is 6/17 (not a hard deadline, but far away enough to give folks enough time to see the message.

Part of an ongoing effort to consolidate documentation to the platform site as captured in [this forms library ticket](https://app.zenhub.com/workspaces/forms-library---platform-spike-team-61b0ae1f2cd3c30014e8a5b0/issues/department-of-veterans-affairs/va-forms-system-core/157)

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
