### PR TITLE
Fix deprecated-classes rule condition checks

### DIFF
--- a/packages/eslint-plugin/lib/rules/deprecated-classes.js
+++ b/packages/eslint-plugin/lib/rules/deprecated-classes.js
@@ -1,5 +1,5 @@
 const getPropNode = (node, propName) =>
-  node.openingElement.attributes.find(n => n.name.name === propName);
+  node.openingElement.attributes.find(n => n.name?.name === propName);
 
 module.exports = {
   meta: {
@@ -18,7 +18,10 @@ module.exports = {
          * Deprecate green button
          */
         const className = getPropNode(node, 'className');
-        if (className?.value.value.includes('va-button-primary')) {
+        if (
+          className?.value?.value?.includes('va-button-primary') ||
+          className?.value?.expression?.value?.includes('va-button-primary')
+        ) {
           context.report({
             node,
             message:

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/eslint-plugin",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "ESLint plugin for va.gov projects",
   "homepage": "https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/tree/master/packages/eslint-plugin#readme",
   "bugs": {

--- a/packages/eslint-plugin/tests/lib/rules/deprecated-classes.js
+++ b/packages/eslint-plugin/tests/lib/rules/deprecated-classes.js
@@ -18,10 +18,19 @@ ruleTester.run('deprecated-classes', rule, {
     {
       code: `<button onClick={verify} type="button" className="usa-button-primary">Verify your identity</button>`,
     },
+    {
+      code: '<button>Edit</button>',
+    },
   ],
   invalid: [
     {
       code: `<button onClick={verify} type="button" className="usa-button-primary va-button-primary">Verify your identity</button>`,
+      errors: [
+        'The va-button-primary utility class is deprecated. Please visit https://design.va.gov/components/button/ for our guidance on buttons.',
+      ],
+    },
+    {
+      code: `<button onClick={verify} type="button" className={"usa-button-primary va-button-primary"}>Verify your identity</button>`,
       errors: [
         'The va-button-primary utility class is deprecated. Please visit https://design.va.gov/components/button/ for our guidance on buttons.',
       ],


### PR DESCRIPTION
## Description
Fixes crash in deprecated-classes rule conditions

## Testing done
![Screen Shot 2022-06-15 at 20 15 09](https://user-images.githubusercontent.com/36863582/173962829-8f76d2ee-ca1a-441b-bb02-2b22ebecccb7.png)


## Acceptance criteria
- [x] `deprecated-classes` rule does not crash when prop is an expression or if prop is missing
