### PR TITLE
Revert "Update focus styles"

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "8.0.0",
+  "version": "7.0.1",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/base/_b-mixins.scss
+++ b/packages/formation/sass/base/_b-mixins.scss
@@ -87,13 +87,19 @@
   }
 }
 
-@mixin focus-gold-vivid-outline {
-  box-shadow: 0 0 0 3px $color-white, 0 0 4px 6px $color-gold-50v;
-  outline: none;
+@mixin focus-gold-light-outline($offset: 2) {
+  outline: $focus-outline;
+  outline-offset: #{$offset}px;
+}
+
+@mixin focus-gold-lighter-highlight {
+  background: $color-gold-lighter;
+  outline: 2px solid $color-gold-lighter;
+  outline-offset: 0;
 }
 
 @mixin focus {
-  @include focus-gold-vivid-outline;
+  @include focus-gold-light-outline;
 }
 
 @mixin color-transition {
@@ -147,7 +153,8 @@
     background: $color-link-default-hover;
   }
   &:focus {
-    @include focus-gold-vivid-outline;
+    @include focus-gold-light-outline;
+    outline-offset: 0;
   }
   &:disabled {
     text-decoration: none;

--- a/packages/formation/sass/base/_b-variables.scss
+++ b/packages/formation/sass/base/_b-variables.scss
@@ -83,17 +83,11 @@ $color-green-light:          #4aa564;
 $color-gold-lightest:        #fff1d2;
 $color-gold-lighter:         #fad980;
 $color-gold-light:           #f9c642;
-$color-gold-50v:             #936F38; // This is something that's not in USWDS 1.6
 
 $color-visited:              $color-purple;
 $color-focus:                #3e94cf;
 
-// The focus outline is only used for anchor links in the main body
-// See this article for details:
-//  https://adhoc.team/2022/02/08/creating-focus-style-for-themable-design-system/
-// A double `box-shadow` is used for other focus styling, including
-// links in the header & footer since they are unlikely to wrap
-$focus-outline:              2px solid $color-gold-50v;
+$focus-outline:              2px solid $color-gold-light;
 
 $color-cool-blue:           #205493;
 $color-cool-blue-light:     #4773aa;

--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -35,7 +35,7 @@ body {
   &:focus {
     position: inherit;
     top: auto;
-    @include focus-gold-vivid-outline;
+    outline: 2px solid $color-gold;
   }
 }
 
@@ -94,18 +94,6 @@ a {
   &:visited,
   &:visited abbr {
     color: $color-visited;
-  }
-}
-
-// Use outline focus styling for links in the main content area
-// since box-shadow styling doesn't look good on wrapped links
-main [href],
-va-banner [href] {
-  &:focus {
-    outline: $focus-outline;
-    background: $color-white;
-    color: $color-link-default;
-    box-shadow: unset;
   }
 }
 

--- a/packages/formation/sass/modules/_m-form-process.scss
+++ b/packages/formation/sass/modules/_m-form-process.scss
@@ -214,7 +214,7 @@
 }
 
 .schemaform-array-row-title:focus {
-  @include focus-gold-vivid-outline;
+  @include focus-gold-light-outline;
   display: inline-block;
 }
 

--- a/packages/formation/sass/modules/_m-nav-sidebar.scss
+++ b/packages/formation/sass/modules/_m-nav-sidebar.scss
@@ -206,7 +206,8 @@ $level-3-hover-padding: 8px 12px 8px 30px;
       }
 
       &:focus {
-        @include focus-gold-vivid-outline;
+        outline: 2px solid $color-gold;
+        outline-offset: 3px;
       }
     }
 
@@ -285,7 +286,7 @@ $level-3-hover-padding: 8px 12px 8px 30px;
       font-size: 15px;
 
       &:focus {
-        @include focus-gold-vivid-outline;
+        @include focus-gold-light-outline(0);
       }
 
       &:hover, &:focus {


### PR DESCRIPTION
Reverts department-of-veterans-affairs/veteran-facing-services-tools#822

These changes are being reverted so that we can publish a utility class fix and update `formation` in `vets-website` without also introducing the new focus style. https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/838#pullrequestreview-1013892044