### PR TITLE
Add single-app build check to dashboard

### DIFF
--- a/packages/documentation/src/components/dashboard/CommitsTable.jsx
+++ b/packages/documentation/src/components/dashboard/CommitsTable.jsx
@@ -18,18 +18,12 @@ export default function CommitsTable({
   stagingBuildText,
   prodBuildText,
   commits,
+  deploys,
 }) {
   const [isPanelOpen, setPanelOpen] = useState(false)
   const devRows = devBuildText.split('\n').filter(x => x) || [];
   const stagingRows = stagingBuildText.split('\n').filter(x => x);
   const prodRows = prodBuildText.split('\n').filter(x => x);
-
-  const devRef = devRows[6]?.slice(4);
-  const stagingRef = stagingRows[6]?.slice(4);
-  const prodRef = prodRows[6]?.slice(4);
-  let isOnDev = false;
-  let isOnStaging = false;
-  let isOnProd = false;
 
   const openAccordion = repo.repo === 'vets-website' ? false : true;
 
@@ -98,10 +92,6 @@ export default function CommitsTable({
                 const { date } = committer;
                 const login = getGithubLoginId(x);
 
-                if (sha === devRef) isOnDev = true;
-                if (sha === stagingRef) isOnStaging = true;
-                if (sha === prodRef) isOnProd = true;
-
                 return (
                   <tr key={sha}>
                     <td className="dash-td-center">
@@ -129,9 +119,9 @@ export default function CommitsTable({
                         </span>
                       </div>
                     </td>
-                    <td className="dash-td-center">{isOnEnv(isOnDev)}</td>
-                    <td className="dash-td-center">{isOnEnv(isOnStaging)}</td>
-                    <td className="dash-td-center">{isOnEnv(isOnProd)}</td>
+                    <td className="dash-td-center">{isOnEnv(deploys[sha]?.['dev'])}</td>
+                    <td className="dash-td-center">{isOnEnv(deploys[sha]?.['staging'])}</td>
+                    <td className="dash-td-center">{isOnEnv(deploys[sha]?.['prod'])}</td>
                   </tr>
                 );
               })}

--- a/packages/documentation/src/components/dashboard/DashboardDataFetch.jsx
+++ b/packages/documentation/src/components/dashboard/DashboardDataFetch.jsx
@@ -29,12 +29,20 @@ export async function DeployStatusDataFetch(repo) {
   if (!commitsResponse.ok) {
     throw Error(commitsResponse.statusText);
   }
+  const deploys = await deploysFetch(
+    repo,
+    devBuildText,
+    stagingBuildText,
+    prodBuildText,
+    commits,
+  );
 
   const result = {
     devBuildText,
     stagingBuildText,
     prodBuildText,
     commits,
+    deploys,
   };
 
   return result;
@@ -50,7 +58,6 @@ export async function TestCoverageDataFetch(repo) {
 
 export async function statusDataFetch(repo) {
   const statusDataResponse = await fetch(repo.backendStatus);
-  console.log(statusDataResponse);
   if (!statusDataResponse.ok) {
     throw Error(statusDataResponse.statusText);
   }
@@ -63,4 +70,56 @@ export async function crossAppImportDataFetch(repo) {
     throw Error(crossAppImportDataResponse.statusText);
   }
   return crossAppImportDataResponse.json();
+}
+
+export async function deploysFetch(
+  repo,
+  devBuildText,
+  stagingBuildText,
+  prodBuildText,
+  commits,
+) {
+  // Store results as a hash with sha and env as the keys, and boolean as value
+  // representing whether the commit was deployed to the env
+  const results = {};
+
+  // Parse BUILD.txt files to get shas of most recent full builds
+  const devRows = devBuildText.split('\n').filter(x => x) || [];
+  const stagingRows = stagingBuildText.split('\n').filter(x => x);
+  const prodRows = prodBuildText.split('\n').filter(x => x);
+  const devRef = devRows[6]?.slice(4);
+  const stagingRef = stagingRows[6]?.slice(4);
+  const prodRef = prodRows[6]?.slice(4);
+
+  let isVetsWebsite = repo.repo === 'vets-website';
+  let isOnDev = false;
+  let isOnStaging = false;
+  let isOnProd = false;
+
+  // Add each commit to results
+  for (const { sha } of commits) {
+    if (sha === devRef) isOnDev = true;
+    if (sha === stagingRef) isOnStaging = true;
+    if (sha === prodRef) isOnProd = true;
+
+    // If commit wasn't deployed by a full build, check for single-app build
+    let isSingleAppBuild = false;
+    if (isVetsWebsite && (!isOnDev || !isOnStaging || !isOnProd)) {
+      const buildArtifactUrl = `${repo.buildArtifactBucket}/${sha}/BUILD_ARTIFACT.txt`;
+      const response = await fetch(buildArtifactUrl);
+      if (response.ok) {
+        const fileText = await response.text();
+        const matchText = fileText.match(/IS_SINGLE_APP_BUILD=(\w+)/)[1];
+        isSingleAppBuild = matchText === 'true';
+      }
+    }
+
+    results[sha] = {
+      dev: isOnDev || isSingleAppBuild,
+      staging: isOnStaging || isSingleAppBuild,
+      prod: isOnProd || isSingleAppBuild,
+    };
+  }
+
+  return results;
 }

--- a/packages/documentation/src/components/dashboard/Reducer.jsx
+++ b/packages/documentation/src/components/dashboard/Reducer.jsx
@@ -3,10 +3,12 @@ export const deployStatusInitialState = {
   appsStagingBuildText: '',
   appsProdBuildText: '',
   appsCommits: [],
+  appsDeploys: [],
   contentDevBuildText: '',
   contentStagingBuildText: '',
   contentProdBuildText: '',
   contentCommits: [],
+  contentDeploys: [],
 };
 
 export function DeployStatusReducer(state, action) {
@@ -18,6 +20,7 @@ export function DeployStatusReducer(state, action) {
         appsStagingBuildText: action.appsStagingBuildText,
         appsProdBuildText: action.appsProdBuildText,
         appsCommits: action.appsCommits,
+        appsDeploys: action.appsDeploys,
       };
     }
     case 'contentBuild': {
@@ -27,6 +30,7 @@ export function DeployStatusReducer(state, action) {
         contentStagingBuildText: action.contentStagingBuildText,
         contentProdBuildText: action.contentProdBuildText,
         contentCommits: action.contentCommits,
+        contentDeploys: action.contentDeploys,
       };
     }
     default:

--- a/packages/documentation/src/components/dashboard/definitions/constants.jsx
+++ b/packages/documentation/src/components/dashboard/definitions/constants.jsx
@@ -13,6 +13,8 @@ export const vetsWebsiteInfo = {
   backendStatus: 'https://api.va.gov/v0/backend_statuses',
   crossAppImports:
     'https://s3-us-gov-west-1.amazonaws.com/vetsgov-website-builds-s3-upload-test/cross-app-imports/cross-app-imports.json',
+  buildArtifactBucket:
+    'https://s3-us-gov-west-1.amazonaws.com/vetsgov-website-builds-s3-upload',
 };
 
 // https://github.com/department-of-veterans-affairs/content-build/blob/844d3170a92005dbee70a7ecf643362137ba68c3/jenkins/common.groovy#L280

--- a/packages/documentation/src/pages/frontend-support-dashboard/app.jsx
+++ b/packages/documentation/src/pages/frontend-support-dashboard/app.jsx
@@ -22,10 +22,12 @@ export default function App({ location }) {
     appsStagingBuildText,
     appsProdBuildText,
     appsCommits,
+    appsDeploys,
     contentDevBuildText,
     contentStagingBuildText,
     contentProdBuildText,
-    contentCommits
+    contentCommits,
+    contentDeploys,
   } = state;
 
 
@@ -38,6 +40,7 @@ export default function App({ location }) {
           stagingBuildText,
           prodBuildText,
           commits,
+          deploys,
         } = allData;
 
         dispatch({
@@ -46,6 +49,7 @@ export default function App({ location }) {
           appsStagingBuildText: stagingBuildText,
           appsProdBuildText: prodBuildText,
           appsCommits: commits,
+          appsDeploys: deploys,
         })
         return allData;
       })
@@ -63,6 +67,7 @@ export default function App({ location }) {
           stagingBuildText,
           prodBuildText,
           commits,
+          deploys,
         } = allData;
 
         dispatch({
@@ -71,6 +76,7 @@ export default function App({ location }) {
           contentStagingBuildText: stagingBuildText,
           contentProdBuildText: prodBuildText,
           contentCommits: commits,
+          contentDeploys: deploys,
         })
         return allData;
       })
@@ -93,6 +99,7 @@ export default function App({ location }) {
             stagingBuildText={appsStagingBuildText}
             prodBuildText={appsProdBuildText}
             commits={appsCommits}
+            deploys={appsDeploys}
           />
 
           <h2>Deploy Status content-build</h2>
@@ -102,6 +109,7 @@ export default function App({ location }) {
             stagingBuildText={contentStagingBuildText}
             prodBuildText={contentProdBuildText}
             commits={contentCommits}
+            deploys={contentDeploys}
           />
         </div>
       </div>


### PR DESCRIPTION
## Description
Currently the [Frontend Support Dashboard](https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/frontend-support-dashboard/) shows deployments from the daily deploy, but not from single-app builds. This PR extends the dashboard to reflect single-app builds (autonomous deployments) in vets-website.

## Testing done
Local dashboard testing

## Screenshots


## Acceptance criteria
- [ ] The Frontend Support Dashboard shows deployments from both the daily deploy (full build) and single-app builds

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
