### PR TITLE
Add no-cross-app-imports custom rule (#41208)

### DIFF
--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -4,6 +4,7 @@ module.exports = {
     'enzyme-unmount': require('./lib/rules/enzyme-unmount.js'),
     'use-resolved-path': require('./lib/rules/use-resolved-path.js'),
     'resolved-path-on-required': require('./lib/rules/resolved-path-on-required.js'),
+    'no-cross-app-imports': require('./lib/rules/no-cross-app-imports'),
     'axe-check-required': require('./lib/rules/axe-e2e-tests.js'),
     'correct-apostrophe': require('./lib/rules/correct-apostrophe'),
     'cypress-viewport-deprecated': require('./lib/rules/cypress-viewport-deprecated.js'),

--- a/packages/eslint-plugin/lib/config/recommended.js
+++ b/packages/eslint-plugin/lib/config/recommended.js
@@ -178,6 +178,15 @@ module.exports = {
         aliases: ['applications', 'platform', 'site', '@@vap-svc', '@@profile'],
       },
     ],
+    '@department-of-veterans-affairs/no-cross-app-imports': [
+      1, // Warnings for now, but after cleanup of imports, change to errors
+      {
+        // Aliases copied from babel.config.json
+        '~': './src',
+        '@@vap-svc': './src/platform/user/profile/vap-svc',
+        '@@profile': './src/applications/personalization/profile',
+      },
+    ],
     '@department-of-veterans-affairs/axe-check-required': 1,
     '@department-of-veterans-affairs/correct-apostrophe': 1,
     '@department-of-veterans-affairs/cypress-viewport-deprecated': 1,

--- a/packages/eslint-plugin/lib/config/recommended.js
+++ b/packages/eslint-plugin/lib/config/recommended.js
@@ -178,15 +178,6 @@ module.exports = {
         aliases: ['applications', 'platform', 'site', '@@vap-svc', '@@profile'],
       },
     ],
-    '@department-of-veterans-affairs/no-cross-app-imports': [
-      1, // Warnings for now, but after cleanup of imports, change to errors
-      {
-        // Aliases copied from babel.config.json
-        '~': './src',
-        '@@vap-svc': './src/platform/user/profile/vap-svc',
-        '@@profile': './src/applications/personalization/profile',
-      },
-    ],
     '@department-of-veterans-affairs/axe-check-required': 1,
     '@department-of-veterans-affairs/correct-apostrophe': 1,
     '@department-of-veterans-affairs/cypress-viewport-deprecated': 1,

--- a/packages/eslint-plugin/lib/rules/no-cross-app-imports.js
+++ b/packages/eslint-plugin/lib/rules/no-cross-app-imports.js
@@ -1,0 +1,56 @@
+const path = require('path');
+
+const MESSAGE = 'No cross app imports allowed';
+
+module.exports = {
+  meta: {
+    docs: {
+      description: MESSAGE,
+      category: 'problem',
+    },
+  },
+  create(context) {
+    const aliases = context.options[0] || {};
+
+    return {
+      ImportDeclaration(node) {
+        const { value } = node.source;
+        const currentPath = context.getFilename();
+
+        let importPath;
+        if (value.startsWith('applications')) {
+          // Absolute import
+          importPath = path.join('vets-website', 'src', value);
+        } else if (value.startsWith('..')) {
+          // Relative import
+          const currentDir = path.join(currentPath, '..');
+          importPath = path.join(currentDir, value);
+        } else if (value.startsWith('@@') || value.startsWith('~')) {
+          // Babel alias
+          const alias = value.match(/^@@[^/]+|~/)[0];
+          importPath = value
+            .replace(alias, aliases[alias])
+            .replace(/^\./, 'vets-website');
+        } else {
+          // Other imports (modules, files in current dir, etc)
+          importPath = value;
+        }
+
+        const testLocation = new RegExp('vets-website/src/applications');
+        // Are the current file and the import in vets-website apps?
+        if (importPath.match(testLocation) && currentPath.match(testLocation)) {
+          const regex = new RegExp('applications/(?<app>[a-zA-Z0-9_-]+)/');
+          const importedApp = importPath.match(regex)?.groups?.app;
+          const currentApp = currentPath.match(regex)?.groups?.app;
+
+          if (importedApp !== currentApp) {
+            context.report({
+              node,
+              message: `${MESSAGE}: ${currentApp} importing from ${importedApp}`,
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/eslint-plugin",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "ESLint plugin for va.gov projects",
   "homepage": "https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/tree/master/packages/eslint-plugin#readme",
   "bugs": {


### PR DESCRIPTION
## Description
Adding a custom linter rule to warn about cross-app-imports. We can't yet fail the build with this rule because we have too many existing cross-app imports. But we can warn engineers when they add a cross-app import.

See [ticket](https://app.zenhub.com/workspaces/vsp---release-tools-fe-5fc9325744944e0015ed1861/issues/department-of-veterans-affairs/va.gov-team/41208) for more info.

## Testing done
Local CLI testing:
- Run `yarn link` in `veteran-facing-services-tools/packages/eslint-plugin`
- Run `yarn link @department-of-veterans-affairs/eslint-plugin` in vets-website
- Run `yarn lint` in vets-website

Editor testing:
- Cross-app imports produce linter warnings in VS Code

## Screenshots


## Acceptance criteria
- [x] Cross-app imports in vets-website produce linter warnings (not errors)

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
