### PR TITLE
Fix eslint-plugin tests

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,7 @@
 {
   "packages": [
     "packages/documentation",
+    "packages/eslint-plugin",
     "packages/formation",
     "packages/vagov-eslint"
   ],

--- a/lerna.json
+++ b/lerna.json
@@ -2,8 +2,7 @@
   "packages": [
     "packages/documentation",
     "packages/eslint-plugin",
-    "packages/formation",
-    "packages/vagov-eslint"
+    "packages/formation"
   ],
   "version": "independent",
   "npmClient": "yarn",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/eslint-plugin",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "ESLint plugin for va.gov projects",
   "homepage": "https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/tree/master/packages/eslint-plugin#readme",
   "bugs": {

--- a/packages/eslint-plugin/tests/lib/rules/axe-e2e-tests.js
+++ b/packages/eslint-plugin/tests/lib/rules/axe-e2e-tests.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const rule = require('../../../rules/axe-e2e-tests');
+const rule = require('../../../lib/rules/axe-e2e-tests');
 const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester();

--- a/packages/eslint-plugin/tests/lib/rules/prefer-web-component-library.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-web-component-library.js
@@ -21,7 +21,7 @@ const mockFile = (componentName, snippet) => {
 };
 
 const mockFileBindingsImport = (componentName, snippet) => {
-  return `import { ${componentName} } from 'web-components/react-bindings';
+  return `import { ${componentName} } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
   ${snippet}
   `;
 };


### PR DESCRIPTION
## Description
This PR fixes broken tests for the `eslint-plugin` package by updating the rule path in `axe-e2e-tests.js` and using the new `react-bindings` location in the test for `prefer-web-component-library.js`. Additionally, this PR adds `eslint-plugin` to the lerna config, so tests for the plugin will run in CI. 

## Testing done
Tested locally and in CI.

## Acceptance criteria
- [x] `eslint-plugin` tests pass
- [x] `eslint-plugin` tests run in CI

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
