### PR TITLE
Add ESLint rules for telephone numbers

### DIFF
--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -10,6 +10,7 @@ module.exports = {
     'cypress-viewport-deprecated': require('./lib/rules/cypress-viewport-deprecated.js'),
     'prefer-web-component-library': require('./lib/rules/prefer-web-component-library'),
     'prefer-telephone-component': require('./lib/rules/prefer-telephone-component'),
+    'telephone-contact-3-or-10-digits': require('./lib/rules/telephone-contact-3-or-10-digits'),
     'deprecated-classes': require('./lib/rules/deprecated-classes'),
   },
   configs: {

--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -9,6 +9,7 @@ module.exports = {
     'correct-apostrophe': require('./lib/rules/correct-apostrophe'),
     'cypress-viewport-deprecated': require('./lib/rules/cypress-viewport-deprecated.js'),
     'prefer-web-component-library': require('./lib/rules/prefer-web-component-library'),
+    'prefer-telephone-component': require('./lib/rules/prefer-telephone-component'),
     'deprecated-classes': require('./lib/rules/deprecated-classes'),
   },
   configs: {

--- a/packages/eslint-plugin/lib/config/recommended.js
+++ b/packages/eslint-plugin/lib/config/recommended.js
@@ -182,6 +182,7 @@ module.exports = {
     '@department-of-veterans-affairs/correct-apostrophe': 1,
     '@department-of-veterans-affairs/cypress-viewport-deprecated': 1,
     '@department-of-veterans-affairs/prefer-web-component-library': 1,
+    '@department-of-veterans-affairs/prefer-telephone-component': 1,
     '@department-of-veterans-affairs/deprecated-classes': 1,
   },
 };

--- a/packages/eslint-plugin/lib/config/recommended.js
+++ b/packages/eslint-plugin/lib/config/recommended.js
@@ -183,6 +183,7 @@ module.exports = {
     '@department-of-veterans-affairs/cypress-viewport-deprecated': 1,
     '@department-of-veterans-affairs/prefer-web-component-library': 1,
     '@department-of-veterans-affairs/prefer-telephone-component': 1,
+    '@department-of-veterans-affairs/telephone-contact-3-or-10-digits': 1,
     '@department-of-veterans-affairs/deprecated-classes': 1,
   },
 };

--- a/packages/eslint-plugin/lib/rules/prefer-telephone-component.js
+++ b/packages/eslint-plugin/lib/rules/prefer-telephone-component.js
@@ -1,4 +1,3 @@
-// const { elementType, getProp, getPropValue } from 'jsx-ast-utils';
 const jsxAstUtils = require('jsx-ast-utils');
 
 const { elementType, getProp, getPropValue } = jsxAstUtils;
@@ -10,7 +9,7 @@ module.exports = {
   meta: {
     docs: {
       description:
-        'Web Components are preferred over deprecated React component library components',
+        'The telephone Web Component is preferred over anchor links with tel hrefs',
       category: 'Best Practices',
       recommended: false,
     },
@@ -50,7 +49,7 @@ module.exports = {
                 ),
                 // The component will be self-closing since it accepts no child content
                 fixer.remove(node.closingElement),
-              ].filter(i => !!i);
+              ];
             },
           });
         }

--- a/packages/eslint-plugin/lib/rules/prefer-telephone-component.js
+++ b/packages/eslint-plugin/lib/rules/prefer-telephone-component.js
@@ -29,17 +29,14 @@ module.exports = {
 
         if (hrefValue.startsWith('tel:')) {
           const contact = hrefValue.substring('tel:'.length);
-          console.log('CONTACT', contact);
 
           context.report({
             node,
             message: MESSAGE,
             fix: fixer => {
-              // Replace the node name
-              // and remove the `pattern` prop if it's there
               return [
                 fixer.replaceText(node.name, 'va-telephone'),
-                fixer.replaceText(hrefProp.name, 'contact'),
+                fixer.replaceText(hrefProp, `contact="${contact}"`),
               ].filter(i => !!i);
             },
           });

--- a/packages/eslint-plugin/lib/rules/prefer-telephone-component.js
+++ b/packages/eslint-plugin/lib/rules/prefer-telephone-component.js
@@ -30,7 +30,9 @@ module.exports = {
         const hrefValue = getPropValue(hrefProp);
 
         if (hrefValue.startsWith('tel:')) {
-          const contact = hrefValue.substring('tel:'.length);
+          const contact = hrefValue
+            .substring('tel:'.length)
+            .replace(/[^\d]/g, '');
 
           context.report({
             node,

--- a/packages/eslint-plugin/lib/rules/prefer-telephone-component.js
+++ b/packages/eslint-plugin/lib/rules/prefer-telephone-component.js
@@ -39,11 +39,14 @@ module.exports = {
               return [
                 fixer.replaceText(anchorNode.name, 'va-telephone'),
                 fixer.replaceText(hrefProp, `contact="${contact}"`),
+                // Remove the children
                 ...node.children.map(c => fixer.remove(c)),
+                // Add the self-closing slash
                 fixer.insertTextBeforeRange(
                   [anchorNode.range[1] - 1, anchorNode.range[1]],
                   '/',
                 ),
+                // The component will be self-closing since it accepts no child content
                 fixer.remove(node.closingElement),
               ].filter(i => !!i);
             },

--- a/packages/eslint-plugin/lib/rules/prefer-telephone-component.js
+++ b/packages/eslint-plugin/lib/rules/prefer-telephone-component.js
@@ -11,7 +11,7 @@ module.exports = {
       description:
         'The telephone Web Component is preferred over anchor links with tel hrefs',
       category: 'Best Practices',
-      recommended: false,
+      recommended: true,
     },
     type: 'suggestion',
     fixable: 'code',

--- a/packages/eslint-plugin/lib/rules/prefer-telephone-component.js
+++ b/packages/eslint-plugin/lib/rules/prefer-telephone-component.js
@@ -7,12 +7,6 @@ const MESSAGE =
 
 module.exports = {
   meta: {
-    docs: {
-      description:
-        'The telephone Web Component is preferred over anchor links with tel hrefs',
-      category: 'Best Practices',
-      recommended: true,
-    },
     type: 'suggestion',
     fixable: 'code',
   },

--- a/packages/eslint-plugin/lib/rules/prefer-telephone-component.js
+++ b/packages/eslint-plugin/lib/rules/prefer-telephone-component.js
@@ -1,0 +1,50 @@
+// const { elementType, getProp, getPropValue } from 'jsx-ast-utils';
+const jsxAstUtils = require('jsx-ast-utils');
+
+const { elementType, getProp, getPropValue } = jsxAstUtils;
+
+const MESSAGE =
+  'The <va-telephone> Web Component should be used to display phone numbers.';
+
+module.exports = {
+  meta: {
+    docs: {
+      description:
+        'Web Components are preferred over deprecated React component library components',
+      category: 'Best Practices',
+      recommended: false,
+    },
+    type: 'suggestion',
+    fixable: 'code',
+  },
+
+  create(context) {
+    return {
+      JSXOpeningElement(node) {
+        // Exit early if we aren't on an anchor link
+        if (elementType(node) !== 'a') return;
+
+        const hrefProp = getProp(node.attributes, 'href');
+        const hrefValue = getPropValue(hrefProp);
+
+        if (hrefValue.startsWith('tel:')) {
+          const contact = hrefValue.substring('tel:'.length);
+          console.log('CONTACT', contact);
+
+          context.report({
+            node,
+            message: MESSAGE,
+            fix: fixer => {
+              // Replace the node name
+              // and remove the `pattern` prop if it's there
+              return [
+                fixer.replaceText(node.name, 'va-telephone'),
+                fixer.replaceText(hrefProp.name, 'contact'),
+              ].filter(i => !!i);
+            },
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin/lib/rules/prefer-telephone-component.js
+++ b/packages/eslint-plugin/lib/rules/prefer-telephone-component.js
@@ -33,6 +33,8 @@ module.exports = {
             .substring('tel:'.length)
             .replace(/[^\d]/g, '');
 
+          const ariaLabelProp = getProp(anchorNode.attributes, 'aria-label');
+
           context.report({
             node,
             message: MESSAGE,
@@ -40,6 +42,7 @@ module.exports = {
               return [
                 fixer.replaceText(anchorNode.name, 'va-telephone'),
                 fixer.replaceText(hrefProp, `contact="${contact}"`),
+                ariaLabelProp && fixer.remove(ariaLabelProp),
                 // Remove the children
                 ...node.children.map(c => fixer.remove(c)),
                 // Add the self-closing slash
@@ -49,7 +52,7 @@ module.exports = {
                 ),
                 // The component will be self-closing since it accepts no child content
                 fixer.remove(node.closingElement),
-              ];
+              ].filter(i => !!i);
             },
           });
         }

--- a/packages/eslint-plugin/lib/rules/prefer-telephone-component.js
+++ b/packages/eslint-plugin/lib/rules/prefer-telephone-component.js
@@ -1,6 +1,6 @@
 const jsxAstUtils = require('jsx-ast-utils');
 
-const { elementType, getProp, getPropValue } = jsxAstUtils;
+const { elementType, getProp, getLiteralPropValue } = jsxAstUtils;
 
 const MESSAGE =
   'The <va-telephone> Web Component should be used to display phone numbers.';
@@ -26,9 +26,9 @@ module.exports = {
         const anchorNode = node.openingElement;
 
         const hrefProp = getProp(anchorNode.attributes, 'href');
-        const hrefValue = getPropValue(hrefProp);
+        const hrefValue = getLiteralPropValue(hrefProp);
 
-        if (hrefValue.startsWith('tel:')) {
+        if (hrefValue?.startsWith('tel:')) {
           const contact = hrefValue
             .substring('tel:'.length)
             .replace(/[^\d]/g, '');

--- a/packages/eslint-plugin/lib/rules/telephone-contact-3-or-10-digits.js
+++ b/packages/eslint-plugin/lib/rules/telephone-contact-3-or-10-digits.js
@@ -30,6 +30,11 @@ module.exports = {
           context.report({
             node,
             message: MESSAGE,
+            fix: fixer => {
+              // Strip hyphens if we can
+              const contact = contactValue?.replace(/[^\d]/g, '');
+              return [fixer.replaceText(contactProp, `contact="${contact}"`)];
+            },
           });
         }
       },

--- a/packages/eslint-plugin/lib/rules/telephone-contact-3-or-10-digits.js
+++ b/packages/eslint-plugin/lib/rules/telephone-contact-3-or-10-digits.js
@@ -3,7 +3,7 @@ const jsxAstUtils = require('jsx-ast-utils');
 const { elementType, getProp, getLiteralPropValue } = jsxAstUtils;
 
 const MESSAGE =
-  'The <va-telephone> contact prop should only contain digits and be 3 or 10 digits long.';
+  'The <va-telephone> contact prop should only contain digits and be 3 or 10 digits long. Consider the international prop if you want the number to begin with a 1.';
 
 module.exports = {
   meta: {

--- a/packages/eslint-plugin/lib/rules/telephone-contact-3-or-10-digits.js
+++ b/packages/eslint-plugin/lib/rules/telephone-contact-3-or-10-digits.js
@@ -1,0 +1,38 @@
+const jsxAstUtils = require('jsx-ast-utils');
+
+const { elementType, getProp, getLiteralPropValue } = jsxAstUtils;
+
+const MESSAGE =
+  'The <va-telephone> contact prop should only contain digits and be 3 or 10 digits long.';
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    fixable: 'code',
+  },
+
+  create(context) {
+    return {
+      JSXOpeningElement(node) {
+        // Exit early if we aren't on a telephone component
+        if (elementType(node) !== 'va-telephone') return;
+
+        const contactProp = getProp(node.attributes, 'contact');
+        const contactValue = getLiteralPropValue(contactProp);
+
+        // If contactValue is undefined then the first part of the expression will
+        // fail, since undefined doesn't equal 3 or 10
+        if (
+          contactValue &&
+          contactValue?.length !== 3 &&
+          contactValue?.length !== 10
+        ) {
+          context.report({
+            node,
+            message: MESSAGE,
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -75,5 +75,8 @@
     "testPathIgnorePatterns": [
       "<rootDir>/tests/helpers/"
     ]
+  },
+  "dependencies": {
+    "jsx-ast-utils": "^3.3.3"
   }
 }

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/eslint-plugin",
-  "version": "1.2.2",
+  "version": "1.3.2",
   "description": "ESLint plugin for va.gov projects",
   "homepage": "https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/tree/master/packages/eslint-plugin#readme",
   "bugs": {

--- a/packages/eslint-plugin/tests/lib/rules/prefer-telephone-component.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-telephone-component.js
@@ -95,5 +95,31 @@ ruleTester.run('prefer-telephone-component', rule, {
         const phone = () => (<va-telephone contact="8004569876"/>)
       `,
     },
+    {
+      code: `
+        const phone = () => (
+          <a
+            href="tel:8004569876"
+            aria-label="8 0 0. 4 5 6. 9 8 7 6."
+          >
+            Link text
+          </a>
+        )
+      `,
+      errors: [
+        {
+          message:
+            'The <va-telephone> Web Component should be used to display phone numbers.',
+        },
+      ],
+      output: `
+        const phone = () => (
+          <va-telephone
+            contact="8004569876"
+            
+          />
+        )
+      `,
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/lib/rules/prefer-telephone-component.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-telephone-component.js
@@ -69,5 +69,19 @@ ruleTester.run('prefer-telephone-component', rule, {
         )
       `,
     },
+    {
+      code: `
+        const phone = () => (<a href="tel:800-456-9876">Link text</a>)
+      `,
+      errors: [
+        {
+          message:
+            'The <va-telephone> Web Component should be used to display phone numbers.',
+        },
+      ],
+      output: `
+        const phone = () => (<va-telephone contact="8004569876"/>)
+      `,
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/lib/rules/prefer-telephone-component.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-telephone-component.js
@@ -29,7 +29,7 @@ ruleTester.run('prefer-telephone-component', rule, {
   invalid: [
     {
       code: `
-        const phone = () => (<a href="tel:8004569876" />)
+        const phone = () => (<a href="tel:8004569876">Link text</a>)
       `,
       errors: [
         {
@@ -38,7 +38,7 @@ ruleTester.run('prefer-telephone-component', rule, {
         },
       ],
       output: `
-        const phone = () => (<va-telephone contact="8004569876" />)
+        const phone = () => (<va-telephone contact="8004569876"/>)
       `,
     },
   ],

--- a/packages/eslint-plugin/tests/lib/rules/prefer-telephone-component.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-telephone-component.js
@@ -41,5 +41,33 @@ ruleTester.run('prefer-telephone-component', rule, {
         const phone = () => (<va-telephone contact="8004569876"/>)
       `,
     },
+    {
+      code: `
+        const phone = () => (
+          <a
+            href="tel:8004569876"
+            className="foo"
+            id="bar"
+          >
+            Link text
+          </a>
+        )
+      `,
+      errors: [
+        {
+          message:
+            'The <va-telephone> Web Component should be used to display phone numbers.',
+        },
+      ],
+      output: `
+        const phone = () => (
+          <va-telephone
+            contact="8004569876"
+            className="foo"
+            id="bar"
+          />
+        )
+      `,
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/lib/rules/prefer-telephone-component.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-telephone-component.js
@@ -25,6 +25,18 @@ ruleTester.run('prefer-telephone-component', rule, {
         const phone = () => (<va-telephone contact="711" tty />)
       `,
     },
+    {
+      code: `
+        const phone = () => (<a href="/foo/bar">Link text</a>)
+      `,
+    },
+    // The rule isn't fancy enough to evaluate variables, though ideally this would fail
+    {
+      code: `
+        const telLink = "tel:8004569999";
+        const phone = () => (<a href={telLink}>Link text</a>)
+      `,
+    },
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/lib/rules/prefer-telephone-component.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-telephone-component.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const rule = require('../../../lib/rules/prefer-telephone-component');
+const RuleTester = require('eslint').RuleTester;
+
+const parserOptions = {
+  ecmaVersion: 2018,
+  // sourceType: 'module',
+  ecmaFeatures: {
+    jsx: true,
+  },
+};
+
+const ruleTester = new RuleTester({ parserOptions });
+
+ruleTester.run('prefer-telephone-component', rule, {
+  valid: [
+    {
+      code: `
+        const phone = () => (<va-telephone contact={phoneContact} />)
+      `,
+    },
+    {
+      code: `
+        const phone = () => (<va-telephone contact="711" tty />)
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        const phone = () => (<a href="tel:8004569876" />)
+      `,
+      errors: [
+        {
+          message:
+            'The <va-telephone> Web Component should be used to display phone numbers.',
+        },
+      ],
+      output: `
+        const phone = () => (<va-telephone contact="8004569876" />)
+      `,
+    },
+  ],
+});

--- a/packages/eslint-plugin/tests/lib/rules/telephone-contact-3-or-10-digits.js
+++ b/packages/eslint-plugin/tests/lib/rules/telephone-contact-3-or-10-digits.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const rule = require('../../../lib/rules/telephone-contact-3-or-10-digits');
+const RuleTester = require('eslint').RuleTester;
+
+const parserOptions = {
+  ecmaVersion: 2018,
+  ecmaFeatures: {
+    jsx: true,
+  },
+};
+
+const ruleTester = new RuleTester({ parserOptions });
+
+ruleTester.run('telephone-contact-3-or-10-digits', rule, {
+  valid: [
+    {
+      code: `
+        const phoneContact = "1234567890";
+        const phone = () => (<va-telephone contact={phoneContact} />)
+      `,
+    },
+    {
+      code: `
+        const phone = () => (<va-telephone contact="911" />)
+      `,
+    },
+    {
+      code: `
+        const phone = () => (<va-telephone contact="1234567890" />)
+      `,
+    },
+    // The rule isn't fancy enough to evaluate variables, though ideally this would fail
+    {
+      code: `
+        const partialContact = "12345";
+        const phone = () => (<va-telephone contact={partialContact} />)
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        const phone = () => (<va-telephone contact="1" />)
+      `,
+      errors: [
+        {
+          message:
+            'The <va-telephone> contact prop should only contain digits and be 3 or 10 digits long.',
+        },
+      ],
+    },
+    {
+      code: `
+        const phone = () => (<va-telephone contact="123-456-7890" />)
+      `,
+      errors: [
+        {
+          message:
+            'The <va-telephone> contact prop should only contain digits and be 3 or 10 digits long.',
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin/tests/lib/rules/telephone-contact-3-or-10-digits.js
+++ b/packages/eslint-plugin/tests/lib/rules/telephone-contact-3-or-10-digits.js
@@ -49,6 +49,9 @@ ruleTester.run('telephone-contact-3-or-10-digits', rule, {
             'The <va-telephone> contact prop should only contain digits and be 3 or 10 digits long.',
         },
       ],
+      output: `
+        const phone = () => (<va-telephone contact="1" />)
+      `,
     },
     {
       code: `
@@ -60,6 +63,8 @@ ruleTester.run('telephone-contact-3-or-10-digits', rule, {
             'The <va-telephone> contact prop should only contain digits and be 3 or 10 digits long.',
         },
       ],
+      // This is the only case where the output is any different
+      // due to the hyphens being stripped. The number isn't changed otherwise
       output: `
         const phone = () => (<va-telephone contact="1234567890" />)
       `,
@@ -74,6 +79,9 @@ ruleTester.run('telephone-contact-3-or-10-digits', rule, {
             'The <va-telephone> contact prop should only contain digits and be 3 or 10 digits long.',
         },
       ],
+      output: `
+        const phone = () => (<va-telephone contact="0011234567890" />)
+      `,
     },
   ],
 });

--- a/packages/eslint-plugin/tests/lib/rules/telephone-contact-3-or-10-digits.js
+++ b/packages/eslint-plugin/tests/lib/rules/telephone-contact-3-or-10-digits.js
@@ -60,6 +60,9 @@ ruleTester.run('telephone-contact-3-or-10-digits', rule, {
             'The <va-telephone> contact prop should only contain digits and be 3 or 10 digits long.',
         },
       ],
+      output: `
+        const phone = () => (<va-telephone contact="1234567890" />)
+      `,
     },
     {
       code: `

--- a/packages/eslint-plugin/tests/lib/rules/telephone-contact-3-or-10-digits.js
+++ b/packages/eslint-plugin/tests/lib/rules/telephone-contact-3-or-10-digits.js
@@ -46,7 +46,7 @@ ruleTester.run('telephone-contact-3-or-10-digits', rule, {
       errors: [
         {
           message:
-            'The <va-telephone> contact prop should only contain digits and be 3 or 10 digits long.',
+            'The <va-telephone> contact prop should only contain digits and be 3 or 10 digits long. Consider the international prop if you want the number to begin with a 1.',
         },
       ],
       output: `
@@ -60,7 +60,7 @@ ruleTester.run('telephone-contact-3-or-10-digits', rule, {
       errors: [
         {
           message:
-            'The <va-telephone> contact prop should only contain digits and be 3 or 10 digits long.',
+            'The <va-telephone> contact prop should only contain digits and be 3 or 10 digits long. Consider the international prop if you want the number to begin with a 1.',
         },
       ],
       // This is the only case where the output is any different
@@ -76,7 +76,7 @@ ruleTester.run('telephone-contact-3-or-10-digits', rule, {
       errors: [
         {
           message:
-            'The <va-telephone> contact prop should only contain digits and be 3 or 10 digits long.',
+            'The <va-telephone> contact prop should only contain digits and be 3 or 10 digits long. Consider the international prop if you want the number to begin with a 1.',
         },
       ],
       output: `

--- a/packages/eslint-plugin/tests/lib/rules/telephone-contact-3-or-10-digits.js
+++ b/packages/eslint-plugin/tests/lib/rules/telephone-contact-3-or-10-digits.js
@@ -61,5 +61,16 @@ ruleTester.run('telephone-contact-3-or-10-digits', rule, {
         },
       ],
     },
+    {
+      code: `
+        const phone = () => (<va-telephone contact="0011234567890" />)
+      `,
+      errors: [
+        {
+          message:
+            'The <va-telephone> contact prop should only contain digits and be 3 or 10 digits long.',
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/yarn.lock
+++ b/packages/eslint-plugin/yarn.lock
@@ -2953,6 +2953,14 @@ json5@^2.2.1:
     array-includes "^3.1.4"
     object.assign "^4.1.2"
 
+jsx-ast-utils@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz#76b3e6e6cece5c69d49a5792c3d01bd1a0cdc7ea"
+  integrity sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==
+  dependencies:
+    array-includes "^3.1.5"
+    object.assign "^4.1.3"
+
 kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
@@ -3211,6 +3219,16 @@ object.assign@^4.1.2:
     call-bind "^1.0.0"
     define-properties "^1.1.3"
     has-symbols "^1.0.1"
+    object-keys "^1.1.1"
+
+object.assign@^4.1.3:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.4.tgz#9673c7c7c351ab8c4d0b516f4343ebf4dfb7799f"
+  integrity sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    has-symbols "^1.0.3"
     object-keys "^1.1.1"
 
 object.entries@^1.1.2, object.entries@^1.1.5:


### PR DESCRIPTION
## Description

Part of https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/864

This adds two new custom ESLint rules:

### prefer-telephone-component

This is an autofixable ESLint rule which will trigger on the pattern `<a href="tel:..."`. When run with `--fix`, it will replace that with `<va-telephone>`. It will also:

- replace the `href` attribute with `contact
- strip all non-digits out of the contact number
- remove child content since the component doesn't allow it
- remove the `aria-label` if present since the component will add its own to the link

### telephone-contact-3-or-10-digits

This is a rule added as part of this PR to try to prevent the first rule from applying a fix that results in the `<va-telephone>` component having a bad `contact` prop, i.e. one that doesn't have 3 or 10 digits. It might flag on code that results from the autofixable rule above, but also on [code like this](https://github.com/department-of-veterans-affairs/vets-website/blob/787b2486cf316ec1c5b4535866ee2d732e08bf26/src/applications/financial-status-report/components/AvailableDebts.jsx#L106).

This rule will try to remove any non-digit characters (i.e. hyphens) from the `contact` prop that it can, since they aren't digits and extend the length beyond 10.

This specific constraint is mentioned on [Storybook](https://design.va.gov/storybook/?path=/docs/components-va-telephone--default):

![Screenshot of the telephone component's storybook page with the contact prop's description highlighted. It reads "3 or 10 digit string representing the contact number"](https://user-images.githubusercontent.com/2008881/186280609-6e4630f4-7166-42f1-a21b-3edca1dcbb33.png)

As well as on the [component's guidance page](https://design.va.gov/components/telephone#code-usage):

![Screenshot of the component's page on design.va.gov. Under the "How to use va-telephone" heading the bullet point "Add a 3 or 10 digit phone number to the component to have it formatted correctly for usage in a page." is highlighted. Below that under "Code usage", in the properties table the description for `contact` is once again highlighted.](https://user-images.githubusercontent.com/2008881/186280738-6be9f1e0-7810-4bc5-a4d6-c4cf3211024c.png)


## Testing done

- Local unit testing with ESLint's `RuleTester`
- Testing in `vets-website`

## Screenshots

Local testing in `vets-website` using:

```diff
diff --git a/package.json b/package.json
index b8e8ea8e0c..217bac41b7 100644
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "@babel/traverse": "^7.17.3",
     "@bahmutov/cypress-esbuild-preprocessor": "^2.1.2",
     "@cypress/code-coverage": "^3.10.0",
-    "@department-of-veterans-affairs/eslint-plugin": "^1.2.2",
+    "@department-of-veterans-affairs/eslint-plugin": "link:../veteran-facing-services-tools/packages/eslint-plugin",
     "@department-of-veterans-affairs/generator-vets-website": "^3.8.0",
     "@octokit/rest": "^18.11.0",
     "@pact-foundation/pact": "^9.16.4",
```

![A screenshot of vim with a file opened in the vets-website repo. There is an anchor link with a tel href, with an ESLint warning saying "The va-telephone web component should be used to display phone numbers".](https://user-images.githubusercontent.com/2008881/186227531-8a4f3f23-e931-4914-9b87-51ecc3632118.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
