### PR TITLE
Add OMBInfo ESLint migration rule

### DIFF
--- a/packages/eslint-plugin/lib/rules/prefer-web-component-library.js
+++ b/packages/eslint-plugin/lib/rules/prefer-web-component-library.js
@@ -339,7 +339,6 @@ const ombInfoTransformer = (context, node) => {
   const resBurdenNode = getPropNode(node, 'resBurden');
   const ombNumberNode = getPropNode(node, 'ombNumber');
   const expDateNode = getPropNode(node, 'expDate');
-  const benefitsTypeNode = getPropNode(node, 'resBurden');
 
   context.report({
     node,

--- a/packages/eslint-plugin/lib/rules/prefer-web-component-library.js
+++ b/packages/eslint-plugin/lib/rules/prefer-web-component-library.js
@@ -207,9 +207,7 @@ const paginationTransformer = (context, node) => {
       node =>
         node.type === 'ImportDeclaration' &&
         node.source.value.includes(
-          `@department-of-veterans-affairs/component-library/${
-            componentName.name
-          }`,
+          `@department-of-veterans-affairs/component-library/${componentName.name}`,
         ),
     );
 
@@ -248,6 +246,7 @@ const paginationTransformer = (context, node) => {
     ],
   });
 };
+
 const tableTransformer = (context, node) => {
   const componentName = node.openingElement.name;
   const currentSortNode = getPropNode(node, 'currentSort');
@@ -262,9 +261,7 @@ const tableTransformer = (context, node) => {
       node =>
         node.type === 'ImportDeclaration' &&
         node.source.value.includes(
-          `@department-of-veterans-affairs/component-library/${
-            componentName.name
-          }`,
+          `@department-of-veterans-affairs/component-library/${componentName.name}`,
         ),
     );
 
@@ -329,6 +326,43 @@ const tableTransformer = (context, node) => {
               ],
               '',
             ),
+          ].filter(i => !!i);
+        },
+      },
+    ],
+  });
+};
+
+const ombInfoTransformer = (context, node) => {
+  const openingTagNode = node.openingElement.name;
+  const closingTagNode = node.closingElement?.name;
+  const resBurdenNode = getPropNode(node, 'resBurden');
+  const ombNumberNode = getPropNode(node, 'ombNumber');
+  const expDateNode = getPropNode(node, 'expDate');
+  const benefitsTypeNode = getPropNode(node, 'resBurden');
+
+  context.report({
+    node,
+    message: MESSAGE,
+    data: {
+      reactComponent: openingTagNode.name,
+      webComponent: 'va-omb-info',
+    },
+    suggest: [
+      {
+        desc: 'Migrate component',
+        fix: fixer => {
+          return [
+            // Rename component tags
+            fixer.replaceText(openingTagNode, 'va-omb-info'),
+            closingTagNode && fixer.replaceText(closingTagNode, 'va-omb-info'),
+
+            // Rename props if they exist
+            resBurdenNode &&
+              fixer.replaceText(resBurdenNode.name, 'res-burden'),
+            ombNumberNode &&
+              fixer.replaceText(ombNumberNode.name, 'omb-number'),
+            expDateNode && fixer.replaceText(expDateNode.name, 'exp-date'),
           ].filter(i => !!i);
         },
       },
@@ -420,6 +454,9 @@ module.exports = {
             break;
           case 'Modal':
             modalTransformer(context, node);
+            break;
+          case 'OMBInfo':
+            ombInfoTransformer(context, node);
             break;
           case 'Pagination':
             paginationTransformer(context, node);

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/eslint-plugin",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "ESLint plugin for va.gov projects",
   "homepage": "https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/tree/master/packages/eslint-plugin#readme",
   "bugs": {

--- a/packages/eslint-plugin/tests/lib/rules/prefer-web-component-library.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-web-component-library.js
@@ -378,5 +378,43 @@ ruleTester.run('prefer-web-component-library', rule, {
         },
       ],
     },
+    {
+      code: mockFile(
+        'OMBInfo',
+        'const component = () => (<OMBInfo resBurden={10} ombNumber="12345" expDate="01/01/01" />)',
+      ),
+      errors: [
+        {
+          suggestions: [
+            {
+              desc: 'Migrate component',
+              output: mockFile(
+                'OMBInfo',
+                'const component = () => (<va-omb-info res-burden={10} omb-number="12345" exp-date="01/01/01" />)',
+              ),
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: mockFile(
+        'OMBInfo',
+        'const component = () => (<OMBInfo resBurden={10} ombNumber="12345" expDate="01/01/01">Some content here</OMBInfo>)',
+      ),
+      errors: [
+        {
+          suggestions: [
+            {
+              desc: 'Migrate component',
+              output: mockFile(
+                'OMBInfo',
+                'const component = () => (<va-omb-info res-burden={10} omb-number="12345" exp-date="01/01/01">Some content here</va-omb-info>)',
+              ),
+            },
+          ],
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
## Description
Part of https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1049

## Testing done
<img width="1117" alt="Screen Shot 2022-09-01 at 4 50 05 PM" src="https://user-images.githubusercontent.com/36863582/188009997-74c7b217-b9bf-4ca8-b466-d4724fb7cf66.png">

## Acceptance criteria
- [x] ESLint warning rule has been created for the OMB info component
