### PR TITLE
File input web component migration rule

### DIFF
--- a/packages/eslint-plugin/lib/rules/prefer-web-component-library.js
+++ b/packages/eslint-plugin/lib/rules/prefer-web-component-library.js
@@ -369,6 +369,48 @@ const ombInfoTransformer = (context, node) => {
   });
 };
 
+const fileInputTransformer = (context, node) => {
+  const openingTagNode = node.openingElement.name;
+  const closingTagNode = node.closingElement?.name;
+  const buttonTextNode = getPropNode(node, 'buttonText');
+  const errorMessageNode = getPropNode(node, 'errorMessage');
+  const additionalClassNode = getPropNode(node, 'additionalClass');
+  const additionalErrorClassNode = getPropNode(node, 'additionalErrorClass');
+  const multipleNode = getPropNode(node, 'multiple');
+
+  context.report({
+    node,
+    message: MESSAGE  +
+    `\nBEWARE: multiple, additionalClass, and additionalErrorClass properties have been removed.` + 
+    `\nSee the File Input design system guidance: https://design.va.gov/components/form/file-input`,
+    data: {
+      reactComponent: openingTagNode.name,
+      webComponent: 'va-file-input',
+    },
+    suggest: [
+      {
+        desc: 'Migrate component',
+        fix: fixer => {
+          return [
+            // Rename component tags
+            fixer.replaceText(openingTagNode, 'va-file-input'),
+            closingTagNode && fixer.replaceText(closingTagNode, 'va-file-input'),
+
+            // Rename props if they exist
+            buttonTextNode && fixer.replaceText(buttonTextNode.name, 'button-text'),
+            errorMessageNode && fixer.replaceText(errorMessageNode.name, 'error'),
+
+            // Remove props that are no longer available
+            additionalClassNode && fixer.remove(additionalClassNode),
+            additionalErrorClassNode && fixer.remove(additionalErrorClassNode),
+            multipleNode && fixer.remove(multipleNode),
+          ].filter(i => !!i);
+        }
+      }
+    ]
+  })
+}
+
 /**
  * Stores the result of a check that determines if a component is part of
  * the Design System component-library.
@@ -450,6 +492,9 @@ module.exports = {
         switch (componentName) {
           case 'Breadcrumbs':
             breadcrumbsTransformer(context, node);
+            break;
+          case 'FileInput':
+            fileInputTransformer(context, node);
             break;
           case 'Modal':
             modalTransformer(context, node);

--- a/packages/eslint-plugin/lib/rules/prefer-web-component-library.js
+++ b/packages/eslint-plugin/lib/rules/prefer-web-component-library.js
@@ -377,28 +377,30 @@ const fileInputTransformer = (context, node) => {
   const additionalClassNode = getPropNode(node, 'additionalClass');
   const additionalErrorClassNode = getPropNode(node, 'additionalErrorClass');
   const multipleNode = getPropNode(node, 'multiple');
+  const changeHandler = getPropNode(node, 'onChange');
 
   context.report({
     node,
     message: MESSAGE  +
-    `\nBEWARE: multiple, additionalClass, and additionalErrorClass properties have been removed.` + 
+    `\nBEWARE: The multiple, additionalClass, and additionalErrorClass properties are no longer available.` + 
     `\nSee the File Input design system guidance: https://design.va.gov/components/form/file-input`,
     data: {
       reactComponent: openingTagNode.name,
-      webComponent: 'va-file-input',
+      webComponent: 'VaFileInput',
     },
     suggest: [
       {
         desc: 'Migrate component',
         fix: fixer => {
           return [
-            // Rename component tags
-            fixer.replaceText(openingTagNode, 'va-file-input'),
-            closingTagNode && fixer.replaceText(closingTagNode, 'va-file-input'),
+            // Rename component tags (Bindings)
+            fixer.replaceText(openingTagNode, 'VaFileInput'),
+            closingTagNode && fixer.replaceText(closingTagNode, 'VaFileInput'),
 
             // Rename props if they exist
             buttonTextNode && fixer.replaceText(buttonTextNode.name, 'button-text'),
             errorMessageNode && fixer.replaceText(errorMessageNode.name, 'error'),
+            changeHandler && fixer.replaceText(changeHandler.name, 'onVaChange'),
 
             // Remove props that are no longer available
             additionalClassNode && fixer.remove(additionalClassNode),

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/eslint-plugin",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "ESLint plugin for va.gov projects",
   "homepage": "https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/tree/master/packages/eslint-plugin#readme",
   "bugs": {

--- a/packages/eslint-plugin/tests/lib/rules/prefer-web-component-library.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-web-component-library.js
@@ -416,5 +416,24 @@ ruleTester.run('prefer-web-component-library', rule, {
         },
       ],
     },
+    {
+      code: mockFile(
+        'FileInput',
+        'const component = () => (<FileInput additionalClass="my-class" buttonText="Upload file" onChange={handleChange} name="my-upload" accept="png" errorMessage="my error" />)',
+      ),
+      errors: [
+        {
+          suggestions: [
+            {
+              desc: 'Migrate component',
+              output: mockFile(
+                'FileInput',
+                'const component = () => (<VaFileInput  button-text="Upload file" onVaChange={handleChange} name="my-upload" accept="png" error="my error" />)',
+              ),
+            },
+          ],
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
## Description
Create an ESLint rule for the FileInput component. 

Closes: https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1048

## Testing done
VS Code

## Screenshots

<img width="782" alt="Screen Shot 2022-09-12 at 3 43 38 PM" src="https://user-images.githubusercontent.com/872479/189755179-c898d34d-3e46-4c9e-934d-37e778a970a7.png">


## Acceptance criteria
- [ ] Create an ESLint rule (warning) for the FileInput React component
- [ ] Notify teams using this component and encourage them to migrate to the web component version

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
