### PR TITLE
Check single app builds for prod

### DIFF
--- a/packages/documentation/src/components/dashboard/DashboardDataFetch.jsx
+++ b/packages/documentation/src/components/dashboard/DashboardDataFetch.jsx
@@ -157,8 +157,7 @@ export async function deploysFetch(
     results[sha] = {
       dev: isOnDev || hasSuccessfulSingleAppBuild,
       staging: isOnStaging || hasSuccessfulSingleAppBuild,
-      // Single-app builds are not yet enabled on prod, so ignore for now
-      prod: isOnProd, // || hasSuccessfulSingleAppBuild,
+      prod: isOnProd || hasSuccessfulSingleAppBuild,
     };
   }
 


### PR DESCRIPTION
## Description
Enables single app build check for prod column in the support dashboard.

## Testing done
Tested locally.

## Acceptance criteria
- [x] The support dashboard checks if prod commits are single app builds

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
