### PR TITLE
Account for CD being disabled in support dashboard

### DIFF
--- a/packages/documentation/src/components/dashboard/CommitsTable.jsx
+++ b/packages/documentation/src/components/dashboard/CommitsTable.jsx
@@ -105,7 +105,12 @@ export default function CommitsTable({
                       </div>
                     </td>
                     <td>
-                      <div><b>{message.slice(0, 100)}</b></div>
+                      <div>
+                        <b>{message.slice(0, 100)}</b>
+                        {deploys[sha]?.['continuousDeployment'] && (
+                          <i className="fas fa-bolt dash-span-right" aria-hidden="true"></i>
+                        )}
+                      </div>
                       <div>
                         <a href={html_url /* eslint-disable-line camelcase */}>{sha}</a>
                         <span className="dash-span-right">

--- a/packages/documentation/src/components/dashboard/CommitsTable.jsx
+++ b/packages/documentation/src/components/dashboard/CommitsTable.jsx
@@ -108,7 +108,12 @@ export default function CommitsTable({
                       <div>
                         <b>{message.slice(0, 100)}</b>
                         {deploys[sha]?.['continuousDeployment'] && (
-                          <i className="fas fa-bolt dash-span-right" aria-hidden="true"></i>
+                          <i
+                            className="fas fa-bolt dash-span-right"
+                            aria-label="Continuous deployment enabled for commit"
+                            title="Continuous deployment enabled"
+                            role="img"
+                          />
                         )}
                       </div>
                       <div>

--- a/packages/documentation/src/components/dashboard/DashboardDataFetch.jsx
+++ b/packages/documentation/src/components/dashboard/DashboardDataFetch.jsx
@@ -171,6 +171,7 @@ export async function deploysFetch(
       prod:
         isOnProd ||
         (isContinuousDeploymentEnabled && hasSuccessfulSingleAppBuild),
+      continuousDeployment: isContinuousDeploymentEnabled,
     };
   }
 

--- a/packages/documentation/src/components/dashboard/DashboardDataFetch.jsx
+++ b/packages/documentation/src/components/dashboard/DashboardDataFetch.jsx
@@ -12,21 +12,24 @@ function getWorkflowRunsAsCommitStatusObject(repo) {
     page: 1,
   };
 
-  return octokit.rest.actions.listWorkflowRuns(params).then(response => {
-    if (response.status !== 200) {
-      throw new Error(`Response ${response.status} from ${response.url}.`);
-    }
-    return response.data;
-  }).then(({ workflow_runs }) => {
-    if (workflow_runs.length === 0) {
-      throw new Error('No workflows found.');
-    }
+  return octokit.rest.actions
+    .listWorkflowRuns(params)
+    .then(response => {
+      if (response.status !== 200) {
+        throw new Error(`Response ${response.status} from ${response.url}.`);
+      }
+      return response.data;
+    })
+    .then(({ workflow_runs }) => {
+      if (workflow_runs.length === 0) {
+        throw new Error('No workflows found.');
+      }
 
-    return workflow_runs.reduce((map, obj) => {
-      map[obj["head_sha"]] = obj["conclusion"];
-      return map;
-    }, {});
-  });
+      return workflow_runs.reduce((map, obj) => {
+        map[obj['head_sha']] = obj['conclusion'];
+        return map;
+      }, {});
+    });
 }
 
 export async function DeployStatusDataFetch(repo) {
@@ -134,6 +137,10 @@ export async function deploysFetch(
   let isOnStaging = false;
   let isOnProd = false;
 
+  // Gets the value of a property in a text file
+  const getValueFromFile = (fileContents, propertyName) =>
+    fileContents.match(`${propertyName}=(\\w+)`)?.[1];
+
   // Add each commit to results
   for (const { sha } of commits) {
     if (sha === devRef) isOnDev = true;
@@ -142,22 +149,28 @@ export async function deploysFetch(
 
     // If commit wasn't deployed by a full build, check for single-app build
     let hasSuccessfulSingleAppBuild = false;
+    let isContinuousDeploymentEnabled = false;
     if (isVetsWebsite && (!isOnDev || !isOnStaging || !isOnProd)) {
       const buildArtifactUrl = `${repo.buildArtifacts}/${sha}.txt`;
       const response = await fetch(buildArtifactUrl);
       if (response.ok) {
         const fileText = await response.text();
-        const matchText = fileText.match(/IS_SINGLE_APP_BUILD=(\w+)/)[1];
-        const isSingleAppBuild = matchText === 'true';
+        const isSingleAppBuild =
+          getValueFromFile(fileText, 'IS_SINGLE_APP_BUILD') === 'true';
         const workflowSucceeded = workflowConclusions[sha] === 'success';
         hasSuccessfulSingleAppBuild = isSingleAppBuild && workflowSucceeded;
+        isContinuousDeploymentEnabled =
+          getValueFromFile(fileText, 'IS_CONTINUOUS_DEPLOYMENT_ENABLED') ===
+          'true';
       }
     }
 
     results[sha] = {
       dev: isOnDev || hasSuccessfulSingleAppBuild,
       staging: isOnStaging || hasSuccessfulSingleAppBuild,
-      prod: isOnProd || hasSuccessfulSingleAppBuild,
+      prod:
+        isOnProd ||
+        (isContinuousDeploymentEnabled && hasSuccessfulSingleAppBuild),
     };
   }
 


### PR DESCRIPTION
## Description
Currently, the FE support dashboard shows that all successful single app build commits were deployed to prod. This may not be the case if the app is opted out of continuous deployment. This PR updates the dashboard to account for continuous deployment being disabled for apps in single app build commits in the prod column. Additionally, an icon will be displayed whenever a commit has continuous deployment enabled.

## Testing done
Tested locally.

## Screenshots
The last two commits in the screenshots are for single app builds that are opted out of continuous deployment.

**Current dashboard**

![current-dashboard](https://user-images.githubusercontent.com/9042882/192445060-fb5e7bce-99b2-474a-b1d0-b08338eb2015.png)

**Updated dashboard**

![updated-dashboard](https://user-images.githubusercontent.com/9042882/192445161-f73d56d1-30aa-4d08-b770-3b414954280b.png)

**Commits with continuous deployment icon**

![image (1)](https://user-images.githubusercontent.com/9042882/192918348-88aeff65-835b-472e-8fe1-d59f409bb351.png)

## Acceptance criteria
- [x] FE support dashboard does **not** show a single app build commit was deployed to prod if the app is opted out of CD

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
