### PR TITLE
Add eslint rule for RadioButtons deprecation

### DIFF
--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -13,6 +13,7 @@ module.exports = {
     'telephone-contact-3-or-10-digits': require('./lib/rules/telephone-contact-3-or-10-digits'),
     'deprecated-classes': require('./lib/rules/deprecated-classes'),
     'use-workspace-imports': require('./lib/rules/use-workspace-imports'),
+    'migrate-radio-buttons': require('./lib/rules/migrate-radio-buttons'),
   },
   configs: {
     recommended: require('./lib/config/recommended'),

--- a/packages/eslint-plugin/lib/rules/migrate-radio-buttons.js
+++ b/packages/eslint-plugin/lib/rules/migrate-radio-buttons.js
@@ -1,0 +1,25 @@
+const jsxAstUtils = require('jsx-ast-utils');
+const { elementType } = jsxAstUtils;
+
+const MESSAGE = 'The RadioButtons React component is deprecated. Please use the web component version at https://design.va.gov/storybook/?path=/docs/components-va-radio--default';
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    fixable: 'code',
+  },
+  
+  create(context) {
+      return {
+        JSXOpeningElement(node) {
+            // Exit early if we aren't on a RadioButtons component
+            if (elementType(node) !== 'RadioButtons') return;
+                
+            context.report({
+              node,
+              message: MESSAGE,
+            });
+          },
+      };
+    }
+};


### PR DESCRIPTION
## Description
With the deprecation of the React RadioButtons component in favor of [va-button web component](https://design.va.gov/storybook/?path=/docs/components-va-radio--default), we are changing the ESLint warning to an error.

Related ESLint rule references in vets-website: https://github.com/department-of-veterans-affairs/vets-website/pull/22331

## Original issue(s)
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1114

## Testing done
VS Code

## Screenshots
![Screen Shot 2022-10-24 at 11 19 59 AM](https://user-images.githubusercontent.com/872479/197575776-2ee4da5d-7fea-459d-a0ee-0ab4fb623d2d.png)

## Acceptance criteria
- [ ] An eslint error is displayed for `RadioButtons` when a file containing that React component is changed.

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
