### PR TITLE
Formation: Update color-gray-dark to color-base

### DIFF
--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -11,7 +11,7 @@ html {
 
 body {
   background: $color-white;
-  color: $color-gray-dark;
+  color: $color-base;
   // font-family: $font-sans;
   font-size: $base-font-size;
   font-family: inherit;
@@ -319,7 +319,7 @@ article > h1 {
 #content {
   margin: 0;
   padding: 0;
-  color: $color-gray-dark;
+  color: $color-base;
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Description
This updates makes base text in Formation to be $color-base instead of $color-gray-dark.

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/935

## Acceptance criteria
- [ ] The base color for `body` and `#main` uses $color-base instead of $color-gray-dark.

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
