### PR TITLE
Update telephone-contact eslint rule for SMS variation

### DIFF
--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -10,7 +10,7 @@ module.exports = {
     'cypress-viewport-deprecated': require('./lib/rules/cypress-viewport-deprecated.js'),
     'prefer-web-component-library': require('./lib/rules/prefer-web-component-library'),
     'prefer-telephone-component': require('./lib/rules/prefer-telephone-component'),
-    'telephone-contact-3-or-10-digits': require('./lib/rules/telephone-contact-3-or-10-digits'),
+    'telephone-contact-digits': require('./lib/rules/telephone-contact-digits'),
     'deprecated-classes': require('./lib/rules/deprecated-classes'),
     'use-workspace-imports': require('./lib/rules/use-workspace-imports'),
     'migrate-radio-buttons': require('./lib/rules/migrate-radio-buttons'),

--- a/packages/eslint-plugin/lib/config/recommended.js
+++ b/packages/eslint-plugin/lib/config/recommended.js
@@ -183,7 +183,7 @@ module.exports = {
     '@department-of-veterans-affairs/cypress-viewport-deprecated': 1,
     '@department-of-veterans-affairs/prefer-web-component-library': 1,
     '@department-of-veterans-affairs/prefer-telephone-component': 1,
-    '@department-of-veterans-affairs/telephone-contact-3-or-10-digits': 1,
+    '@department-of-veterans-affairs/telephone-contact-digits': 1,
     '@department-of-veterans-affairs/deprecated-classes': 1,
     '@department-of-veterans-affairs/use-workspace-imports': 1,
   },

--- a/packages/eslint-plugin/lib/rules/telephone-contact-digits.js
+++ b/packages/eslint-plugin/lib/rules/telephone-contact-digits.js
@@ -3,7 +3,7 @@ const jsxAstUtils = require('jsx-ast-utils');
 const { elementType, getProp, getLiteralPropValue } = jsxAstUtils;
 
 const MESSAGE =
-  'The <va-telephone> contact prop should only contain digits and be 3 or 10 digits long. Consider the international prop if you want the number to begin with a 1.';
+  'The <va-telephone> contact prop should only contain digits and be 3, 5, 6, or 10 digits long. Consider the international prop if you want the number to begin with a 1.';
 
 module.exports = {
   meta: {
@@ -21,10 +21,12 @@ module.exports = {
         const contactValue = getLiteralPropValue(contactProp);
 
         // If contactValue is undefined then the first part of the expression will
-        // fail, since undefined doesn't equal 3 or 10
+        // fail, since undefined doesn't equal 3, 5, 6, or 10
         if (
           contactValue &&
           contactValue?.length !== 3 &&
+          contactValue?.length !== 5 &&
+          contactValue?.length !== 6 &&
           contactValue?.length !== 10
         ) {
           context.report({

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/eslint-plugin",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "ESLint plugin for va.gov projects",
   "homepage": "https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/tree/master/packages/eslint-plugin#readme",
   "bugs": {

--- a/packages/eslint-plugin/tests/lib/rules/telephone-contact-3-or-10-digits.js
+++ b/packages/eslint-plugin/tests/lib/rules/telephone-contact-3-or-10-digits.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const rule = require('../../../lib/rules/telephone-contact-3-or-10-digits');
+const rule = require('../../../lib/rules/telephone-contact-digits');
 const RuleTester = require('eslint').RuleTester;
 
 const parserOptions = {
@@ -12,7 +12,7 @@ const parserOptions = {
 
 const ruleTester = new RuleTester({ parserOptions });
 
-ruleTester.run('telephone-contact-3-or-10-digits', rule, {
+ruleTester.run('telephone-contact-digits', rule, {
   valid: [
     {
       code: `

--- a/packages/eslint-plugin/tests/lib/rules/telephone-contact-digits.js
+++ b/packages/eslint-plugin/tests/lib/rules/telephone-contact-digits.js
@@ -37,6 +37,12 @@ ruleTester.run('telephone-contact-digits', rule, {
         const phone = () => (<va-telephone contact={partialContact} />)
       `,
     },
+    {
+      code: `
+        const phoneContact = "123456";
+        const phone = () => (<va-telephone contact={phoneContact} />)
+      `,
+    },
   ],
   invalid: [
     {
@@ -46,7 +52,7 @@ ruleTester.run('telephone-contact-digits', rule, {
       errors: [
         {
           message:
-            'The <va-telephone> contact prop should only contain digits and be 3 or 10 digits long. Consider the international prop if you want the number to begin with a 1.',
+            'The <va-telephone> contact prop should only contain digits and be 3, 5, 6, or 10 digits long. Consider the international prop if you want the number to begin with a 1.',
         },
       ],
       output: `
@@ -60,7 +66,7 @@ ruleTester.run('telephone-contact-digits', rule, {
       errors: [
         {
           message:
-            'The <va-telephone> contact prop should only contain digits and be 3 or 10 digits long. Consider the international prop if you want the number to begin with a 1.',
+            'The <va-telephone> contact prop should only contain digits and be 3, 5, 6, or 10 digits long. Consider the international prop if you want the number to begin with a 1.',
         },
       ],
       // This is the only case where the output is any different
@@ -76,7 +82,7 @@ ruleTester.run('telephone-contact-digits', rule, {
       errors: [
         {
           message:
-            'The <va-telephone> contact prop should only contain digits and be 3 or 10 digits long. Consider the international prop if you want the number to begin with a 1.',
+            'The <va-telephone> contact prop should only contain digits and be 3, 5, 6, or 10 digits long. Consider the international prop if you want the number to begin with a 1.',
         },
       ],
       output: `


### PR DESCRIPTION
## Description
We have added the [SMS prop](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1246) to va-telephone and this update adds 5 and 6 digit linting for that component so that the rule now allows 3, 5, 6, and 10 digits. Because we expanded this beyond the original 3 and 10 digits, the file was renamed to something more general as well (from `telephone-contact-3-or-10-digits` to `telephone-contact-digits`).

https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1257

## Testing done
vets-website locally

## Screenshots

![Screen Shot 2022-11-17 at 10 16 14 AM](https://user-images.githubusercontent.com/872479/202506346-78590d71-0de4-4ef6-b480-89eebb0b04d8.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
