### PR TITLE
update references to platform-release-tools to va-platform-cop-frontend

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Review the CODEOWNERS guide before editing:
 # https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/codeowners.md
 
-*       @department-of-veterans-affairs/platform-release-tools
+*       @department-of-veterans-affairs/va-platform-cop-frontend
 packages/formation @department-of-veterans-affairs/platform-design-system-fe
 packages/formation-react @department-of-veterans-affairs/platform-design-system-fe
 packages/eslint-plugin/lib/rules/prefer-web-component-library.js @department-of-veterans-affairs/platform-design-system-fe

--- a/packages/documentation/src/pages/getting-started/workflow/deploy.mdx
+++ b/packages/documentation/src/pages/getting-started/workflow/deploy.mdx
@@ -250,8 +250,8 @@ of the test owner).
 
 #### A flaky test in `master` when an auto-deploy is nearing
 
-If a unit test fails in `main` and a scheduled deploy is nearing, [platform release tools support
-team member](https://github.com/orgs/department-of-veterans-affairs/teams/platform-release-tools) should
+If a unit test fails in `main` and a scheduled deploy is nearing, [va frontend cop support
+team member](https://github.com/orgs/department-of-veterans-affairs/teams/va-platform-cop-frontend) should
 refresh the pipeline immediately, open up a pull request to skip the test, and alert the code owner
 for a fix and/or pull request approval to skip the test. Ideally the test gets fixed, but in reality,
 the process to merge can often take longer than is allowed for by the timing of the deploy. This is

--- a/packages/documentation/src/pages/platform/front-end-standards/manual-reviews.mdx
+++ b/packages/documentation/src/pages/platform/front-end-standards/manual-reviews.mdx
@@ -5,7 +5,7 @@ tags: vagovprod, vagovstaging, vagovdev
 
 # Automated code quality
 
-Each pull request (PR) on `vets-website` runs through an automated process that looks for code additions and modifications that don't meet code quality standards. If no issues are found, the code does not need to be reviewed by a VSP engineer. If a potential issue is found, a bot will leave an automated comment and request a manual review from the **platform-release-tools**.
+Each pull request (PR) on `vets-website` runs through an automated process that looks for code additions and modifications that don't meet code quality standards. If no issues are found, the code does not need to be reviewed by a VSP engineer. If a potential issue is found, a bot will leave an automated comment and request a manual review from the **va-platform-cop-frontend**.
 
 ![Screen Shot](https://images.zenhubusercontent.com/5e387fa505ac7e30c820a2da/a09c4c8c-ae32-4142-8fa5-0fc81b6a1892)
 

--- a/packages/documentation/src/pages/platform/front-end-standards/security.mdx
+++ b/packages/documentation/src/pages/platform/front-end-standards/security.mdx
@@ -16,7 +16,7 @@ _This is an overview not an implementation guide. These rules apply to VA.gov pr
 ## Cross-Origin Resource Sharing (CORS)
 
 - Some cross origin connections made to VA.gov must support CORS including **all** XHR connections and web font downloads. 
-- Updates to CORS headers returned by `vets-api` services or `vets-website` assets must be made through the devops team and must be reviewed by [platform release tools](https://github.com/orgs/department-of-veterans-affairs/teams/platform-release-tools). Example:  
+- Updates to CORS headers returned by `vets-api` services or `vets-website` assets must be made through the devops team and must be reviewed by [va platform frontend cop](https://github.com/orgs/department-of-veterans-affairs/teams/va-platform-cop-frontend). Example:  
   - Your application is on a VA.gov subdomain, needs to connect to `vets-api`, but is not currently listed in the allowed origins
 - More [info on cors](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
 - CORS configurations: 
@@ -29,7 +29,7 @@ _This is an overview not an implementation guide. These rules apply to VA.gov pr
 - The CSP is enforced i.e. not set to `report-only`
 - The `report-uri` points to a VA platform error capturing service (Sentry)
   - VA.gov throttles these reports by including the `report-uri` only on a small % of responses
-- Updates to CSP headers returned by or `vets-website` assets must be made through the devops team and must be reviewed by [platform release tools](https://github.com/orgs/department-of-veterans-affairs/teams/platform-release-tools)
+- Updates to CSP headers returned by or `vets-website` assets must be made through the devops team and must be reviewed by [va platform frontend cop](https://github.com/orgs/department-of-veterans-affairs/teams/va-platform-cop-frontend)
 - More [info on CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
 - CSP configurations:
   - [production](https://github.com/department-of-veterans-affairs/devops/blob/master/ansible/deployment/config/revproxy-vagov/vars/content_security_policy_vagov-prod.yml)


### PR DESCRIPTION
## Description
update references to platform-release-tools to va-platform-cop-frontend to account for reorg team changes

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
