### PR TITLE
Add ESLint rule for new CSS Classes

### DIFF
--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -12,6 +12,7 @@ module.exports = {
     'prefer-telephone-component': require('./lib/rules/prefer-telephone-component'),
     'telephone-contact-digits': require('./lib/rules/telephone-contact-digits'),
     'deprecated-classes': require('./lib/rules/deprecated-classes'),
+    'use-new-utility-classes': require('./lib/rules/use-new-utility-classes'),
     'use-workspace-imports': require('./lib/rules/use-workspace-imports'),
     'migrate-radio-buttons': require('./lib/rules/migrate-radio-buttons'),
   },

--- a/packages/eslint-plugin/lib/config/recommended.js
+++ b/packages/eslint-plugin/lib/config/recommended.js
@@ -185,6 +185,7 @@ module.exports = {
     '@department-of-veterans-affairs/prefer-telephone-component': 1,
     '@department-of-veterans-affairs/telephone-contact-digits': 1,
     '@department-of-veterans-affairs/deprecated-classes': 1,
+    '@department-of-veterans-affairs/use-new-utility-classes': 1,
     '@department-of-veterans-affairs/use-workspace-imports': 1,
   },
 };

--- a/packages/eslint-plugin/lib/config/recommended.js
+++ b/packages/eslint-plugin/lib/config/recommended.js
@@ -185,7 +185,6 @@ module.exports = {
     '@department-of-veterans-affairs/prefer-telephone-component': 1,
     '@department-of-veterans-affairs/telephone-contact-digits': 1,
     '@department-of-veterans-affairs/deprecated-classes': 1,
-    '@department-of-veterans-affairs/use-new-utility-classes': 1,
     '@department-of-veterans-affairs/use-workspace-imports': 1,
   },
 };

--- a/packages/eslint-plugin/lib/rules/use-new-utility-classes.js
+++ b/packages/eslint-plugin/lib/rules/use-new-utility-classes.js
@@ -1,0 +1,95 @@
+const MESSAGE = 'The new utility classes should be used instead.';
+
+const oldToNew = {
+  'vads-u-align-content': 'vads-align-content-',
+  'vads-u-align-items': 'vads-align-items-',
+  'vads-u-align-self': 'vads-align-self-',
+  'vads-u-background-color': 'vads-bg-color-',
+  'vads-u-border': 'vads-border-',
+  'vads-u-border-top': 'vads-border-top-',
+  'vads-u-border-bottom': 'vads-border-bottom-',
+  'vads-u-border-right': 'vads-border-right-',
+  'vads-u-border-left': 'vads-border-left-',
+  'vads-u-border-style': 'vads-border-style-',
+  'vads-u-border-color': 'vads-border-color-',
+  'vads-u-color': 'vads-color-',
+  'vads-u-display': 'vads-display-',
+  'vads-u-flex': 'vads-flex-',
+  'vads-u-flex-direction': 'vads-flex-direction-',
+  'vads-u-flex-wrap': 'vads-flex-wrap-',
+  'vads-u-font-family': 'vads-font-family-',
+  'vads-u-font-size': 'vads-font-size-',
+  'vads-u-font-style': 'vads-font-style-',
+  'vads-u-font-weight': 'vads-font-weight-',
+  'vads-u-height': 'vads-height-',
+  'vads-u-justify-content': 'vads-justify-content-',
+  'vads-u-line-height': 'vads-line-height-',
+  'vads-u-margin': 'vads-margin-',
+  'vads-u-margin-x': 'vads-margin-x-',
+  'vads-u-margin-y': 'vads-margin-y-',
+  'vads-u-margin-top': 'vads-margin-top-',
+  'vads-u-margin-bottom': 'vads-margin-bottom-',
+  'vads-u-margin-right': 'vads-margin-right-',
+  'vads-u-margin-left': 'vads-margin-left-',
+  'vads-u-max-height': 'vads-max-height-',
+  'vads-u-max-width': 'vads-max-width-',
+  'vads-u-measure': 'vads-measure-',
+  'vads-u-min-height': 'vads-min-height-',
+  'vads-u-min-width': 'vads-min-width-',
+  'vads-u-order': 'vads-order-',
+  'vads-u-padding': 'vads-padding-',
+  'vads-u-padding-x': 'vads-padding-x-',
+  'vads-u-padding-y': 'vads-padding-y-',
+  'vads-u-padding-top': 'vads-padding-top-',
+  'vads-u-padding-bottom': 'vads-padding-bottom-',
+  'vads-u-padding-right': 'vads-padding-right-',
+  'vads-u-padding-left': 'vads-padding-left-',
+  'vads-u-position': 'vads-position-',
+  'vads-u-text-align': 'vads-text-align-',
+  'vads-u-text-decoration': 'vads-text-decoration-',
+  'vads-u-visibility': 'vads-visibility-',
+  'vads-u-width': 'vads-width-',
+};
+
+function getNewClass(errorClass) {
+  const [oldClass, value] = errorClass.split('--');
+  const newClass = `"${oldToNew[oldClass]}${value}"`;
+  return newClass
+}
+
+function getErrorMessage(classes) {
+  const classesArray = classes.split(" ");
+  const firstErrorClass = classesArray.find(element => element.includes('vads-u'));
+  const newClass = getNewClass(firstErrorClass);
+
+  return newClass.includes('undefined') ? MESSAGE : `${MESSAGE} Try using ${newClass} instead of "${firstErrorClass}"`;
+}
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'VA.gov Design System new classes',
+      category: 'Best Practices',
+    },
+    type: 'suggestion',
+  },
+
+  create(context) {
+    return {
+      JSXAttribute(node) {
+        if (node.name.name !== 'className') return;
+
+        const classes = node.value.value;
+        if (!classes.includes('vads-u')) return;
+
+        const finalMessage = getErrorMessage(classes);
+        
+        context.report({
+          node,
+          message: finalMessage,
+        });
+        
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin/lib/rules/use-new-utility-classes.js
+++ b/packages/eslint-plugin/lib/rules/use-new-utility-classes.js
@@ -62,7 +62,7 @@ function getErrorMessage(classes) {
   const firstErrorClass = classesArray.find(element => element.includes('vads-u'));
   const newClass = getNewClass(firstErrorClass);
 
-  return newClass.includes('undefined') ? MESSAGE : `${MESSAGE} Try using ${newClass} instead of "${firstErrorClass}"`;
+  return newClass.includes('undefined') ? MESSAGE : `${MESSAGE} Use ${newClass} instead of "${firstErrorClass}"`;
 }
 
 module.exports = {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/eslint-plugin",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "ESLint plugin for va.gov projects",
   "homepage": "https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/tree/master/packages/eslint-plugin#readme",
   "bugs": {

--- a/packages/eslint-plugin/tests/lib/rules/use-new-utility-classes.js
+++ b/packages/eslint-plugin/tests/lib/rules/use-new-utility-classes.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const rule = require('../../../lib/rules/use-new-utility-classes');
+const RuleTester = require('eslint').RuleTester;
+
+const parserOptions = {
+  ecmaVersion: 2018,
+  // sourceType: 'module',
+  ecmaFeatures: {
+    jsx: true,
+  },
+};
+
+const ruleTester = new RuleTester({ parserOptions });
+
+ruleTester.run('prefer-new-utility-classes', rule, {
+  valid: [
+    {
+      code: `
+        const phone = () => (<a href="/foo/bar">Link text</a>)
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        const phone = () => (<span className="vads-color--blue vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">Content</span>)
+      `,
+      errors: [
+        {
+          message: 'The new utility classes should be used instead. Try using "vads-bg-color-gray-lightest" instead of "vads-u-background-color--gray-lightest"',
+        },
+      ],
+      output: `
+        const phone = () => (<span className="vads-color--blue vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-top--2">Content</span>)
+      `,
+    },
+  ],
+});

--- a/packages/eslint-plugin/tests/lib/rules/use-new-utility-classes.js
+++ b/packages/eslint-plugin/tests/lib/rules/use-new-utility-classes.js
@@ -28,7 +28,7 @@ ruleTester.run('prefer-new-utility-classes', rule, {
       `,
       errors: [
         {
-          message: 'The new utility classes should be used instead. Try using "vads-bg-color-gray-lightest" instead of "vads-u-background-color--gray-lightest"',
+          message: 'The new utility classes should be used instead. Use "vads-bg-color-gray-lightest" instead of "vads-u-background-color--gray-lightest"',
         },
       ],
       output: `


### PR DESCRIPTION
## Description

Part of https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1343

This adds two new custom ESLint rules:

### use-new-utility-classes

This Eslint rule will help VFS teams to easily update to the new CSS Class library based on USWDS v3. 

This is a recommendable ESLint rule which will trigger on the pattern `vads-u`. 

![css rule eslint](https://user-images.githubusercontent.com/55560129/207447095-4b12d0bf-2c63-4622-9df5-eec9c20db4e8.png)


## Testing done
- Testing in `vets-website`

## Screenshots
Local testing in `vets-website` using:

<img width="875" alt="Screen Shot 2022-12-13 at 4 10 56 PM" src="https://user-images.githubusercontent.com/55560129/207447870-a119174b-bd2b-4471-9784-d8f93984ea5b.png">



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
