### PR TITLE
Fix readme 199

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ This packages has been moved to
 
 ## Formation
 
-Please see documentation on [contributing to the design system](https://design.va.gov/documentation/contributing-to-the-design-system).
+Please see documentation on [contributing to the design system](https://design.va.gov/about/developers/contributing).
 
 ## Keyboard E2E
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains front end code and documentation used by the Veteran facing services on VA.gov. It's a monorepo managed by Lerna, a tool for managing versioning and publishing for multiple modules located in a single repo.
 
-There is [another repository for the documentation site](https://github.com/department-of-veterans-affairs/vets-design-system-documentation). The documentation site can be viewed at [design.va.gov](https://design.va.gov). See also: [contributing to the Design System](https://design.va.gov/about/developers#contributing-to-the-design-system/).
+There is [another repository for the documentation site](https://github.com/department-of-veterans-affairs/vets-design-system-documentation). The documentation site can be viewed at [design.va.gov](https://design.va.gov). See also: [contributing to the Design System](https://design.va.gov/about/developers#contributing-to-the-design-system).
 
 ## Packages
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains front end code and documentation used by the Veteran facing services on VA.gov. It's a monorepo managed by Lerna, a tool for managing versioning and publishing for multiple modules located in a single repo.
 
-There is [another repository for the documentation site](https://github.com/department-of-veterans-affairs/vets-design-system-documentation). The documentation site can be viewed at [design.va.gov](https://design.va.gov). See also: [contributing to Formation](https://design.va.gov/documentation/contributing-to-formation).
+There is [another repository for the documentation site](https://github.com/department-of-veterans-affairs/vets-design-system-documentation). The documentation site can be viewed at [design.va.gov](https://design.va.gov). See also: [contributing to the Design System](https://design.va.gov/about/developers#contributing-to-the-design-system/).
 
 ## Packages
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains front end code and documentation used by the Veteran facing services on VA.gov. It's a monorepo managed by Lerna, a tool for managing versioning and publishing for multiple modules located in a single repo.
 
-There is [another repository for the documentation site](https://github.com/department-of-veterans-affairs/vets-design-system-documentation). The documentation site can be viewed at [design.va.gov](https://design.va.gov). See also: [contributing to the Design System](https://design.va.gov/about/developers#contributing-to-the-design-system).
+There is [another repository for the documentation site](https://github.com/department-of-veterans-affairs/vets-design-system-documentation). The documentation site can be viewed at [design.va.gov](https://design.va.gov). See also: [contributing to the Design System](https://design.va.gov/about/developers/contributing).
 
 ## Packages
 


### PR DESCRIPTION
## Description
[Chelen had asked that this link be fixed 3 years ago](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/199#issuecomment-660284430), and lo that day is today!

## Testing done
This PR is dependent on https://github.com/department-of-veterans-affairs/vets-design-system-documentation/pull/1562. I tested locally that the page loads and that a redirect from the previous location works.

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
