### PR TITLE
Add ESLint rule for the ExpandingGroup React component

### DIFF
--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -15,6 +15,7 @@ module.exports = {
     'use-new-utility-classes': require('./lib/rules/use-new-utility-classes'),
     'use-workspace-imports': require('./lib/rules/use-workspace-imports'),
     'migrate-radio-buttons': require('./lib/rules/migrate-radio-buttons'),
+    'remove-expanding-group': require('./lib/rules/remove-expanding-group'),
   },
   configs: {
     recommended: require('./lib/config/recommended'),

--- a/packages/eslint-plugin/lib/config/recommended.js
+++ b/packages/eslint-plugin/lib/config/recommended.js
@@ -186,5 +186,6 @@ module.exports = {
     '@department-of-veterans-affairs/telephone-contact-digits': 1,
     '@department-of-veterans-affairs/deprecated-classes': 1,
     '@department-of-veterans-affairs/use-workspace-imports': 1,
+    '@department-of-veterans-affairs/remove-expanding-group': 1,
   },
 };

--- a/packages/eslint-plugin/lib/rules/remove-expanding-group.js
+++ b/packages/eslint-plugin/lib/rules/remove-expanding-group.js
@@ -1,0 +1,25 @@
+const jsxAstUtils = require('jsx-ast-utils');
+const { elementType } = jsxAstUtils;
+
+const MESSAGE = 'The ExpandingGroup React component is deprecated. Please replace with a custom solution. Also note that the wizard pattern deprecated as well. See "Retrofit this pattern" for additional guidance if needed: https://design.va.gov/patterns/wizards#retrofit-this-pattern';
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    fixable: 'code',
+  },
+  
+  create(context) {
+      return {
+        JSXOpeningElement(node) {
+            // Exit early if we aren't on an ExpandingGroup component
+            if (elementType(node) !== 'ExpandingGroup') return;
+                
+            context.report({
+              node,
+              message: MESSAGE,
+            });
+          },
+      };
+    }
+};

--- a/packages/eslint-plugin/lib/rules/remove-expanding-group.js
+++ b/packages/eslint-plugin/lib/rules/remove-expanding-group.js
@@ -1,7 +1,7 @@
 const jsxAstUtils = require('jsx-ast-utils');
 const { elementType } = jsxAstUtils;
 
-const MESSAGE = 'The ExpandingGroup React component is deprecated. Please replace with a custom solution. Also note that the wizard pattern deprecated as well. See "Retrofit this pattern" for additional guidance if needed: https://design.va.gov/patterns/wizards#retrofit-this-pattern';
+const MESSAGE = 'The ExpandingGroup React component is deprecated. Please replace with a custom solution. Also note that the wizard pattern is deprecated as well. See "Retrofit this pattern" for additional guidance if needed: https://design.va.gov/patterns/wizards#retrofit-this-pattern';
 
 module.exports = {
   meta: {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/eslint-plugin",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "ESLint plugin for va.gov projects",
   "homepage": "https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/tree/master/packages/eslint-plugin#readme",
   "bugs": {


### PR DESCRIPTION
## Description
This will add a warning for the `ExpandingGroup` React component's deprecation.

The warning message will read:

> The ExpandingGroup React component is deprecated. Please replace with a custom solution. Also note that the wizard pattern is deprecated as well. See "Retrofit this pattern" for additional guidance if needed: https://design.va.gov/patterns/wizards#retrofit-this-pattern

![Screenshot 2023-02-17 at 10 04 52 AM](https://user-images.githubusercontent.com/872479/219706138-2751cf58-f2e3-4beb-bea7-2f7bcad31183.png)

Related issue: https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1378

## Testing done
VS Code
vets-website locally

![Screenshot 2023-02-17 at 10 19 38 AM](https://user-images.githubusercontent.com/872479/219707803-0d62955f-97d0-4ffc-9560-8f80ded95d86.png)


## Acceptance criteria
- [ ] A ESLint warning message displays where the ExpandingGroup react component is used.

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
