### PR TITLE
updating action-links styling for proper long text wrap

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "7.0.4",
+  "version": "7.0.5",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/modules/_m-action-link.scss
+++ b/packages/formation/sass/modules/_m-action-link.scss
@@ -3,14 +3,15 @@ a.vads-c-action-link--blue, a.vads-c-action-link--green, a.vads-c-action-link--w
     font-family: "Font Awesome 5 Free";
     font-weight: 900;
     font-size: 175%;
-    display: inline-block; // Remove the underline text decoration
     content: "\f138";
     padding-right: 1rem;
-    transform: translateY(5px); // "Center" the circle with the text
+    transform: translateY(-9px); // "Center" the circle with the text
     height: 0px; // So the height doesn't mess with the focus halo
+    float: left;
   }
   font-weight: bold;
-  padding: 8px 0px;
+  padding: 13px 0px 8px 0px;
+  display: flex;
 }
 
 a.vads-c-action-link--blue:before {

--- a/packages/formation/sass/modules/_m-action-link.scss
+++ b/packages/formation/sass/modules/_m-action-link.scss
@@ -6,11 +6,7 @@ a.vads-c-action-link--blue, a.vads-c-action-link--green, a.vads-c-action-link--w
     display: inline-block; // Remove the underline text decoration
     content: "\f138";
     padding-right: 1rem;
-    position: absolute;
-    transform: translate(
-      -35px,
-      -8px
-    ); // "Center" the circle with the text and shift it to the left from text
+    transform: translateY(5px); // "Center" the circle with the text
     height: 0px; // So the height doesn't mess with the focus halo
   }
   font-weight: bold;

--- a/packages/formation/sass/modules/_m-action-link.scss
+++ b/packages/formation/sass/modules/_m-action-link.scss
@@ -6,7 +6,11 @@ a.vads-c-action-link--blue, a.vads-c-action-link--green, a.vads-c-action-link--w
     display: inline-block; // Remove the underline text decoration
     content: "\f138";
     padding-right: 1rem;
-    transform: translateY(5px); // "Center" the circle with the text
+    position: absolute;
+    transform: translate(
+      -35px,
+      -8px
+    ); // "Center" the circle with the text and shift it to the left from text
     height: 0px; // So the height doesn't mess with the focus halo
   }
   font-weight: bold;


### PR DESCRIPTION
## Description
Long text in an action link would wrap underneath an icon, particularly the case on mobile view where a screen width is narrow. 
Related to the following issue https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1590

## Testing done
Only tested within vets-website. Not familiar with any other testing methods here. If someone from design team could please test on your end.

## Screenshots
Before
![image](https://user-images.githubusercontent.com/87077843/222553444-7a7dd563-d7bd-40b0-904e-a7ac339ff1fb.png)

After
<img width="303" alt="image" src="https://user-images.githubusercontent.com/87077843/222554884-3b4f4d20-b28f-40e6-a19b-1de91d8a0611.png"> 
<img width="487" alt="image" src="https://user-images.githubusercontent.com/87077843/222555053-dfc80b2a-1b63-4a32-8ebc-e44684647ad2.png">


## Acceptance criteria
- [ ]

## Definition of done
- [x] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
