### PR TITLE
Add my-health entry for FE performance dashboard

### DIFF
--- a/packages/documentation/src/pages/frontend-support-dashboard/lighthouse-performance-report/lighthouse-report.json
+++ b/packages/documentation/src/pages/frontend-support-dashboard/lighthouse-performance-report/lighthouse-report.json
@@ -193,6 +193,11 @@
     "s3": "/manage-va-debt/your-debt.html",
     "app": "debt-letters"
   },
+  "my-health": {
+    "path": "/my-health",
+    "s3": "/my-health.html",
+    "app": "my-health"
+  },
   "/my-va": {
     "path": "/my-va",
     "s3": "/my-va.html",


### PR DESCRIPTION
## Description

Add entry for MHV Landing page to FE Performance Report dashboard.

Currently, [the report exists in s3](https://vetsgov-website-builds-s3-upload-test.s3-us-gov-west-1.amazonaws.com/lighthouse/my-health.html), although it is showing a warning due to a client-side redirect related to feature flags currently in place.

## Related

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/56326

## Definition of done

- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
