### PR TITLE
updating documentation for enabling and disabling flipper features URL

### DIFF
--- a/packages/documentation/src/pages/platform/tools/feature-toggles.mdx
+++ b/packages/documentation/src/pages/platform/tools/feature-toggles.mdx
@@ -183,8 +183,8 @@ You can enable or disable features in the Flipper UI:
 | Environment | URL                                         |
 | ----------- | ------------------------------------------- |
 | Dev         | http://localhost:3000/flipper/features      |
-| Staging     | https://staging-platform-api.va.gov/flipper/features |
-| Production  | https://platform-api.va.gov/flipper/features         |
+| Staging     | https://staging-api.va.gov/flipper/features |
+| Production  | https://api.va.gov/flipper/features         |
 
 2. To access the Flipper UI, you must sign in using an [identity-verified id.me user](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/identity-personalization/va.gov-login-process.md) that is listed in [settings.yml](https://github.com/department-of-veterans-affairs/vets-api/blob/master/config/settings.yml):
 


### PR DESCRIPTION
Documentation update, of flipper dash URLs, per  https://dsva.slack.com/archives/CBU0KDSB1/p1680787778994799