### PR TITLE
Bug fix for action link icon having an underline in Safari

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "7.0.5",
+  "version": "7.0.6",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/modules/_m-action-link.scss
+++ b/packages/formation/sass/modules/_m-action-link.scss
@@ -4,14 +4,13 @@ a.vads-c-action-link--blue, a.vads-c-action-link--green, a.vads-c-action-link--w
     font-weight: 900;
     font-size: 175%;
     content: "\f138";
-    padding-right: 1rem;
-    transform: translateY(-9px); // "Center" the circle with the text
-    height: 0px; // So the height doesn't mess with the focus halo
-    float: left;
+    position: absolute; 
+    left: 0px;
+    top: 4px;
   }
   font-weight: bold;
-  padding: 13px 0px 8px 0px;
-  display: flex;
+  padding: 4px 0 4px 38px;
+  position: relative;
 }
 
 a.vads-c-action-link--blue:before {


### PR DESCRIPTION
## Description
Fix issue where there was an underline under the icon on the action link in Safari.
- Made the link position:relative
- Made the :before icon position absolute
- Adjusted spacing to match
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1706

## Testing done
Browser testing in chrome and safari

## Screenshots
### Before:
![Screenshot 2023-05-18 at 2 31 17 PM](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/1776069/42621f37-4023-40d9-974e-ed01ec802f19)

### After:
![Screenshot 2023-05-18 at 2 32 03 PM](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/1776069/47240a5a-0093-4cca-a2f6-97ec458a1b32)



## Acceptance criteria
- [ ] There is no underline beneath the icon in safari
- [ ] The change does not affect the appearance of the component
- [ ] The change does not affect the way the text wraps

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
