### PR TITLE
[Chore] Replace `babel-eslint` with `@babel/eslint-parser`

### DIFF
--- a/packages/eslint-plugin/lib/config/recommended.js
+++ b/packages/eslint-plugin/lib/config/recommended.js
@@ -1,5 +1,5 @@
 module.exports = {
-  parser: 'babel-eslint',
+  parser: '@babel/eslint-parser',
   parserOptions: {
     ecmaVersion: 11,
     sourceType: 'module',


### PR DESCRIPTION
## Description
In two different repos as I have found uses `babel-eslint`.
- `vets-website`
- `veterans-facing-services-tools`

Please see the package at https://www.npmjs.com/package/babel-eslint which suggests using `@babel/eslint-parser`.

Why do we need this updated?

- The package `babel-eslint` has been deprecated and has not been active for 3 years now. It has been deprecated in favor of `@babel/eslint-parser`.
- The package also has not been receiving maintenance and also no updates either.
- This will also help anyone in the future that wants to create a new repo and would like to utilize the `@department-of-veterans-affairs/recommended` eslint plugin.
- For our Identity team,  we are creating our own Sign-in-Service dashboard, it would be great to be able to take small steps to update and replace this deprecated package with the current package.

## Testing done
There seems to be no negative effect in updating `babel-eslint` with `@babel/eslint-parser` in `veterans-facing-services-tools`, but this has not been tested in `vets-website`, though I would like to update this as well.

There is a pair PR in `vets-website`: https://github.com/department-of-veterans-affairs/vets-website/pull/24355

Link to Zenhub issue: https://app.zenhub.com/workspaces/identity-5f5bab705a94c9001ba33734/issues/gh/department-of-veterans-affairs/va.gov-team/59030

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [x] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
