### PR TITLE
1798 - Overflowing button

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "7.0.7",
+  "version": "7.0.8",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/modules/_m-button.scss
+++ b/packages/formation/sass/modules/_m-button.scss
@@ -10,6 +10,7 @@ button,
   -webkit-font-smoothing: inherit;
   -moz-osx-font-smoothing: inherit;
   background-color: $color-primary;
+  box-sizing: border-box;
 
   &.usa-button-secondary {
     background: transparent;


### PR DESCRIPTION
close https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1798

## Description
A few tickets have come in with buttons that overflow from the container they are in when viewing a form in a mobile resolution. This has been fixable in many of these tickets by adding `box-sizing: border-box` to the buttons so their width can be calculated correctly. This PR addresses this by adding `box-sizing: border-box` to all buttons.

## Testing done
Manual testing

## Screenshots
Before:
![image](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/15200011/10ed6e53-4d53-4dba-9e9d-05a38071cf1c)

After:
![image](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/15200011/88f53b6c-65dc-4ad5-9757-55df01152727)


## Acceptance criteria
- [ ] Overflowing button is fixed on VA Travel Pay Reimbursement page

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
