### PR TITLE
Remove Table eslint transformer

### DIFF
--- a/packages/eslint-plugin/lib/rules/prefer-web-component-library.js
+++ b/packages/eslint-plugin/lib/rules/prefer-web-component-library.js
@@ -247,92 +247,6 @@ const paginationTransformer = (context, node) => {
   });
 };
 
-const tableTransformer = (context, node) => {
-  const componentName = node.openingElement.name;
-  const currentSortNode = getPropNode(node, 'currentSort');
-  const dataNode = getPropNode(node, 'data');
-  const fieldsNode = getPropNode(node, 'fields');
-  const dataValue = dataNode?.value.expression || dataNode?.value;
-  const fieldsValue = fieldsNode?.value.expression || fieldsNode?.value;
-  const sourceCode = context.getSourceCode();
-  const importNode = context
-    .getAncestors()[0]
-    .body.find(
-      node =>
-        node.type === 'ImportDeclaration' &&
-        node.source.value.includes(
-          `@department-of-veterans-affairs/component-library/${componentName.name}`,
-        ),
-    );
-
-  context.report({
-    node,
-    message: MESSAGE,
-    data: {
-      reactComponent: componentName.name,
-      webComponent: 'va-table',
-    },
-    suggest: [
-      {
-        desc: 'Migrate component',
-        fix: fixer => {
-          return [
-            // Import utility function that can easily handle the existing props
-            // for the React version of `<Table>`
-            fixer.replaceText(
-              importNode.specifiers[0].local,
-              `{ generateTableChildren }`,
-            ),
-
-            // Remove Table name from import path
-            fixer.replaceText(
-              importNode.source,
-              `'@department-of-veterans-affairs/component-library'`,
-            ),
-
-            // Rename component tag
-            fixer.replaceText(componentName, 'va-table'),
-
-            // Remove the data prop
-            fixer.remove(dataNode),
-
-            // Remove the fields prop
-            fixer.remove(fieldsNode),
-
-            // Remove the currentSort prop
-            currentSortNode && fixer.remove(currentSortNode),
-
-            // Add `sort-column` prop
-            currentSortNode &&
-              fixer.insertTextBefore(currentSortNode, 'sort-column="0"'),
-
-            // Add `descending` prop
-            currentSortNode &&
-              fixer.insertTextBefore(currentSortNode, ' descending'),
-
-            // Add a closing tag along with calling the helper
-            // function to generate children
-            fixer.insertTextAfter(
-              node.openingElement,
-              `{generateTableChildren(${sourceCode.getText(
-                dataValue,
-              )}, ${sourceCode.getText(fieldsValue)})}</va-table>`,
-            ),
-            // Remove self-closing tag slash
-            fixer.removeRange(
-              [
-                node.openingElement.range[1] - 2,
-                node.openingElement.range[1] - 1,
-              ],
-              '',
-            ),
-          ].filter(i => !!i);
-        },
-      },
-    ],
-  });
-};
-
 const ombInfoTransformer = (context, node) => {
   const openingTagNode = node.openingElement.name;
   const closingTagNode = node.closingElement?.name;
@@ -459,9 +373,6 @@ module.exports = {
             break;
           case 'Pagination':
             paginationTransformer(context, node);
-            break;
-          case 'Table':
-            tableTransformer(context, node);
             break;
           case 'Telephone':
             telephoneTransformer(context, node);

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/eslint-plugin",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "ESLint plugin for va.gov projects",
   "homepage": "https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/tree/master/packages/eslint-plugin#readme",
   "bugs": {

--- a/packages/eslint-plugin/tests/lib/rules/prefer-web-component-library.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-web-component-library.js
@@ -321,46 +321,6 @@ ruleTester.run('prefer-web-component-library', rule, {
     },
     {
       code: mockFile(
-        'Table',
-        'const TableSample = () => (<Table data={data} fields={fields} />)',
-      ),
-      errors: [
-        {
-          suggestions: [
-            {
-              desc: 'Migrate component',
-              output: mockFileComponentLibraryNamedImport(
-                'generateTableChildren',
-                // Extra space before first closing tag is because prettier hasn't run yet
-                'const TableSample = () => (<va-table   >{generateTableChildren(data, fields)}</va-table>)',
-              ),
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: mockFile(
-        'Table',
-        'const TableSample = () => (<Table data={data} fields={fields} currentSort={currentSort} />)',
-      ),
-      errors: [
-        {
-          suggestions: [
-            {
-              desc: 'Migrate component',
-              output: mockFileComponentLibraryNamedImport(
-                'generateTableChildren',
-                // Extra space before first closing tag is because prettier hasn't run yet
-                'const TableSample = () => (<va-table   sort-column="0" descending >{generateTableChildren(data, fields)}</va-table>)',
-              ),
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: mockFile(
         'TextInput',
         'const Component = () => (<TextInput label="First name" name="first_name" field={field} required additionalClass="some-class" onValueChange={handler} />)',
       ),


### PR DESCRIPTION
## Description
The design system team has deprecated the Table React component. Now that the component has been completely removed from vets-website, this will remove the eslint transformer which is no longer needed.

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1658

## Testing done


## Screenshots
N/A

## Acceptance criteria
- [ ] The Table eslint transformer has been removed.

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
