### PR TITLE
Padding patch to match web component for _m-alert.scss

### DIFF
--- a/packages/formation/sass/modules/_m-alert.scss
+++ b/packages/formation/sass/modules/_m-alert.scss
@@ -3,11 +3,9 @@
   background-color: $color-gray-lightest;
   border-left-style: solid;
   border-left-width: 8px;
-  display: block;
   padding: units(2);
   @include media($medium) {
-    display: table;
-      padding: units(4) units(3);
+    padding: units(4) units(3);
   }
   width: 100%;
 

--- a/packages/formation/sass/modules/_m-alert.scss
+++ b/packages/formation/sass/modules/_m-alert.scss
@@ -2,9 +2,13 @@
   background: none;
   background-color: $color-gray-lightest;
   border-left-style: solid;
-  border-left-width: 10px;
-  display: table;
-  padding: units(4) units(8) units(4) units(3);
+  border-left-width: 8px;
+  display: block;
+  padding: units(2);
+  @include media($medium) {
+    display: table;
+      padding: units(4) units(3);
+  }
   width: 100%;
 
   &::before {


### PR DESCRIPTION
## Description

_m-alert.scss has too much padding for mobile screens making it really hard to read the content when you're view on a small mobile phone (320px)

Here is the link to the original issue: https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1874 

## Testing done
Tested in dev-tools

## Screenshots
Before: 
<img width="484" alt="Screenshot 2023-06-26 at 3 46 53 PM" src="https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/1631062/4879eb70-1134-46ed-9ce3-336e8acf82a1">
After: 
<img width="359" alt="Screenshot 2023-06-26 at 3 48 25 PM" src="https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/1631062/f005c19d-1300-41b4-9cba-0ccdfab35441">


## Acceptance criteria
- [x] Moible padding is decreased to make content more readable

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
