### PR TITLE
remove eslint transformer for OMBInfo

### DIFF
--- a/packages/eslint-plugin/lib/rules/prefer-web-component-library.js
+++ b/packages/eslint-plugin/lib/rules/prefer-web-component-library.js
@@ -203,42 +203,6 @@ const paginationTransformer = (context, node) => {
   });
 };
 
-const ombInfoTransformer = (context, node) => {
-  const openingTagNode = node.openingElement.name;
-  const closingTagNode = node.closingElement?.name;
-  const resBurdenNode = getPropNode(node, 'resBurden');
-  const ombNumberNode = getPropNode(node, 'ombNumber');
-  const expDateNode = getPropNode(node, 'expDate');
-
-  context.report({
-    node,
-    message: MESSAGE,
-    data: {
-      reactComponent: openingTagNode.name,
-      webComponent: 'va-omb-info',
-    },
-    suggest: [
-      {
-        desc: 'Migrate component',
-        fix: fixer => {
-          return [
-            // Rename component tags
-            fixer.replaceText(openingTagNode, 'va-omb-info'),
-            closingTagNode && fixer.replaceText(closingTagNode, 'va-omb-info'),
-
-            // Rename props if they exist
-            resBurdenNode &&
-              fixer.replaceText(resBurdenNode.name, 'res-burden'),
-            ombNumberNode &&
-              fixer.replaceText(ombNumberNode.name, 'omb-number'),
-            expDateNode && fixer.replaceText(expDateNode.name, 'exp-date'),
-          ].filter(i => !!i);
-        },
-      },
-    ],
-  });
-};
-
 /**
  * Stores the result of a check that determines if a component is part of
  * the Design System component-library.
@@ -323,9 +287,6 @@ module.exports = {
             break;
           case 'Modal':
             modalTransformer(context, node);
-            break;
-          case 'OMBInfo':
-            ombInfoTransformer(context, node);
             break;
           case 'Pagination':
             paginationTransformer(context, node);

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/eslint-plugin",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "ESLint plugin for va.gov projects",
   "homepage": "https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/tree/master/packages/eslint-plugin#readme",
   "bugs": {

--- a/packages/eslint-plugin/tests/lib/rules/prefer-web-component-library.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-web-component-library.js
@@ -197,43 +197,5 @@ ruleTester.run('prefer-web-component-library', rule, {
         },
       ],
     },
-    {
-      code: mockFile(
-        'OMBInfo',
-        'const component = () => (<OMBInfo resBurden={10} ombNumber="12345" expDate="01/01/01" />)',
-      ),
-      errors: [
-        {
-          suggestions: [
-            {
-              desc: 'Migrate component',
-              output: mockFile(
-                'OMBInfo',
-                'const component = () => (<va-omb-info res-burden={10} omb-number="12345" exp-date="01/01/01" />)',
-              ),
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: mockFile(
-        'OMBInfo',
-        'const component = () => (<OMBInfo resBurden={10} ombNumber="12345" expDate="01/01/01">Some content here</OMBInfo>)',
-      ),
-      errors: [
-        {
-          suggestions: [
-            {
-              desc: 'Migrate component',
-              output: mockFile(
-                'OMBInfo',
-                'const component = () => (<va-omb-info res-burden={10} omb-number="12345" exp-date="01/01/01">Some content here</va-omb-info>)',
-              ),
-            },
-          ],
-        },
-      ],
-    },
   ],
 });


### PR DESCRIPTION
## Description
This PR removes an eslint transformer for the OMBInfo React component which has been removed from the component-library repo

## Testing done
local testing

## Screenshots
n/a

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
