### PR TITLE
Add button eslint rule for va-button and va-table

### DIFF
--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -15,6 +15,7 @@ module.exports = {
     'use-new-utility-classes': require('./lib/rules/use-new-utility-classes'),
     'use-workspace-imports': require('./lib/rules/use-workspace-imports'),
     'remove-expanding-group': require('./lib/rules/remove-expanding-group'),
+    'prefer-button-component': require('./lib/rules/prefer-button-component'),
   },
   configs: {
     recommended: require('./lib/config/recommended'),

--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -16,6 +16,7 @@ module.exports = {
     'use-workspace-imports': require('./lib/rules/use-workspace-imports'),
     'remove-expanding-group': require('./lib/rules/remove-expanding-group'),
     'prefer-button-component': require('./lib/rules/prefer-button-component'),
+    'prefer-table-component': require('./lib/rules/prefer-table-component'),
   },
   configs: {
     recommended: require('./lib/config/recommended'),

--- a/packages/eslint-plugin/lib/config/recommended.js
+++ b/packages/eslint-plugin/lib/config/recommended.js
@@ -187,5 +187,6 @@ module.exports = {
     '@department-of-veterans-affairs/deprecated-classes': 1,
     '@department-of-veterans-affairs/use-workspace-imports': 1,
     '@department-of-veterans-affairs/remove-expanding-group': 1,
+    '@department-of-veterans-affairs/prefer-button-component': 1,
   },
 };

--- a/packages/eslint-plugin/lib/config/recommended.js
+++ b/packages/eslint-plugin/lib/config/recommended.js
@@ -188,5 +188,6 @@ module.exports = {
     '@department-of-veterans-affairs/use-workspace-imports': 1,
     '@department-of-veterans-affairs/remove-expanding-group': 1,
     '@department-of-veterans-affairs/prefer-button-component': 1,
+    '@department-of-veterans-affairs/prefer-table-component': 1,
   },
 };

--- a/packages/eslint-plugin/lib/rules/prefer-button-component.js
+++ b/packages/eslint-plugin/lib/rules/prefer-button-component.js
@@ -3,7 +3,7 @@ const jsxAstUtils = require('jsx-ast-utils');
 const { elementType, getProp, getLiteralPropValue } = jsxAstUtils;
 
 const MESSAGE =
-  'The <va-button> Web Component should be used to instead of the button HTML element.';
+  'The <va-button> Web Component should be used instead of the button HTML element.';
 
 module.exports = {
   meta: {

--- a/packages/eslint-plugin/lib/rules/prefer-button-component.js
+++ b/packages/eslint-plugin/lib/rules/prefer-button-component.js
@@ -1,6 +1,6 @@
 const jsxAstUtils = require('jsx-ast-utils');
 
-const { elementType } = jsxAstUtils;
+const { elementType, getProp, getLiteralPropValue } = jsxAstUtils;
 
 const MESSAGE =
   'The <va-button> Web Component should be used to instead of the button HTML element.';
@@ -14,13 +14,18 @@ module.exports = {
   create(context) {
     return {
       JSXElement(node) {
-        // Exit early if we aren't on a button
-        if (elementType(node.openingElement) !== 'button') return;
+        const anchorNode = node.openingElement;
+        const typeProp = getProp(anchorNode.attributes, 'type');
         
-        context.report({
-          node,
-          message:  MESSAGE,
-        })
+        // Only display if we are on a button or input with type button
+        if (elementType(anchorNode) === 'button' || 
+          (elementType(anchorNode) === 'input' && getLiteralPropValue(typeProp) === 'button')){
+          
+          context.report({
+            node,
+            message:  MESSAGE,
+          })
+        }
       },
     };
   },

--- a/packages/eslint-plugin/lib/rules/prefer-button-component.js
+++ b/packages/eslint-plugin/lib/rules/prefer-button-component.js
@@ -1,0 +1,27 @@
+const jsxAstUtils = require('jsx-ast-utils');
+
+const { elementType } = jsxAstUtils;
+
+const MESSAGE =
+  'The <va-button> Web Component should be used to instead of the button HTML element.';
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    fixable: 'code',
+  },
+
+  create(context) {
+    return {
+      JSXElement(node) {
+        // Exit early if we aren't on a button
+        if (elementType(node.openingElement) !== 'button') return;
+        
+        context.report({
+          node,
+          message:  MESSAGE,
+        })
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin/lib/rules/prefer-table-component.js
+++ b/packages/eslint-plugin/lib/rules/prefer-table-component.js
@@ -1,0 +1,30 @@
+const jsxAstUtils = require('jsx-ast-utils');
+
+const { elementType } = jsxAstUtils;
+
+const MESSAGE =
+  'The <va-table> Web Component should be used to instead of the table HTML element.';
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    fixable: 'code',
+  },
+
+  create(context) {
+    return {
+      JSXElement(node) {
+        const anchorNode = node.openingElement;
+        
+        // Only display if we are on a table element
+        if (elementType(anchorNode) === 'table'){
+          
+          context.report({
+            node,
+            message:  MESSAGE,
+          })
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/eslint-plugin",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "ESLint plugin for va.gov projects",
   "homepage": "https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/tree/master/packages/eslint-plugin#readme",
   "bugs": {

--- a/packages/eslint-plugin/tests/lib/rules/prefer-button-component.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-button-component.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const rule = require('../../../lib/rules/prefer-button-component');
+const RuleTester = require('eslint').RuleTester;
+
+const parserOptions = {
+  ecmaVersion: 2018,
+  // sourceType: 'module',
+  ecmaFeatures: {
+    jsx: true,
+  },
+};
+
+const ruleTester = new RuleTester({ parserOptions });
+
+ruleTester.run('prefer-button-component', rule, {
+  valid: [
+    {
+      code: `
+        const button = () => (<va-button
+          id="cancel"
+          onClick={handlers.onCancel}
+          text="Cancel"
+        />)
+      `,
+    }
+  ],
+  invalid: [
+    {
+      code: `
+        const button = () => (
+          <button
+          className="foo"
+          id="bar"
+          onClick={() => window.print()}
+        >
+          Print this page
+        </button>
+        )
+      `,
+      errors: [
+        {
+          message:
+            'The <va-button> Web Component should be used to instead of the button HTML element.'
+        },
+      ],
+    },
+    {
+      code: `
+        const button = () => (<button
+          onClick={() => window.print()}
+        >
+          {variable}
+        </button>)
+      `,
+      errors: [
+        {
+          message:
+            'The <va-button> Web Component should be used to instead of the button HTML element.'
+        },
+      ],
+     },
+     {
+      code: `
+        const button = () => (<button
+          onClick={() => window.print()}
+        >
+         Some plain text next to a {variable}
+        </button>)
+      `,
+      errors: [
+        {
+          message:
+            'The <va-button> Web Component should be used to instead of the button HTML element.'
+        },
+      ]
+     },
+     {
+      code: `
+        const button = () => (<button
+          onClick={() => window.print()}
+        >
+          <span>Button Text</span>
+        </button>)
+      `,
+      errors: [
+        {
+          message:
+          'The <va-button> Web Component should be used to instead of the button HTML element.'
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin/tests/lib/rules/prefer-button-component.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-button-component.js
@@ -90,5 +90,31 @@ ruleTester.run('prefer-button-component', rule, {
         },
       ],
     },
+    {
+      code: `
+        const button = () => (
+          <input type="button">Click me</input>
+        )
+      `,
+      errors: [
+        {
+          message:
+            'The <va-button> Web Component should be used to instead of the button HTML element.'
+        },
+      ],
+    },
+    {
+      code: `
+        const button = () => (
+          <input type="button" value="Click me" />
+        )
+      `,
+      errors: [
+        {
+          message:
+            'The <va-button> Web Component should be used to instead of the button HTML element.'
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/tests/lib/rules/prefer-button-component.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-button-component.js
@@ -41,7 +41,7 @@ ruleTester.run('prefer-button-component', rule, {
       errors: [
         {
           message:
-            'The <va-button> Web Component should be used to instead of the button HTML element.'
+            'The <va-button> Web Component should be used instead of the button HTML element.'
         },
       ],
     },
@@ -56,7 +56,7 @@ ruleTester.run('prefer-button-component', rule, {
       errors: [
         {
           message:
-            'The <va-button> Web Component should be used to instead of the button HTML element.'
+            'The <va-button> Web Component should be used instead of the button HTML element.'
         },
       ],
      },
@@ -71,7 +71,7 @@ ruleTester.run('prefer-button-component', rule, {
       errors: [
         {
           message:
-            'The <va-button> Web Component should be used to instead of the button HTML element.'
+            'The <va-button> Web Component should be used instead of the button HTML element.'
         },
       ]
      },
@@ -86,7 +86,7 @@ ruleTester.run('prefer-button-component', rule, {
       errors: [
         {
           message:
-          'The <va-button> Web Component should be used to instead of the button HTML element.'
+          'The <va-button> Web Component should be used instead of the button HTML element.'
         },
       ],
     },
@@ -99,7 +99,7 @@ ruleTester.run('prefer-button-component', rule, {
       errors: [
         {
           message:
-            'The <va-button> Web Component should be used to instead of the button HTML element.'
+            'The <va-button> Web Component should be used instead of the button HTML element.'
         },
       ],
     },
@@ -112,7 +112,7 @@ ruleTester.run('prefer-button-component', rule, {
       errors: [
         {
           message:
-            'The <va-button> Web Component should be used to instead of the button HTML element.'
+            'The <va-button> Web Component should be used instead of the button HTML element.'
         },
       ],
     },

--- a/packages/eslint-plugin/tests/lib/rules/prefer-table-component.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-table-component.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const rule = require('../../../lib/rules/prefer-table-component');
+const RuleTester = require('eslint').RuleTester;
+
+const parserOptions = {
+  ecmaVersion: 2018,
+  // sourceType: 'module',
+  ecmaFeatures: {
+    jsx: true,
+  },
+};
+
+const ruleTester = new RuleTester({ parserOptions });
+
+ruleTester.run('prefer-table-component', rule, {
+  valid: [
+    {
+      code: `
+        const table = () => (<va-table
+          id="cancel"
+          onClick={handlers.onCancel}
+          text="Cancel"
+        />)
+      `,
+    }
+  ],
+  invalid: [
+    {
+      code: `
+        const table = () => (
+          <table>
+            <thead>
+              <tr>
+                <th>Date</th>
+                <th>Name</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Nov 9</td>
+                <td>Kelly</td>
+              </tr>
+              <tr>
+                <td>Dec 19</td>
+                <td>Franklin</td>
+              </tr>
+            </tbody>
+          </table>
+        )
+      `,
+      errors: [
+        {
+          message:
+            'The <va-table> Web Component should be used to instead of the table HTML element.'
+        },
+      ],
+    },
+    {
+      code: `
+        const table = () => (
+          <table></table>
+        )
+      `,
+      errors: [
+        {
+          message:
+            'The <va-table> Web Component should be used to instead of the table HTML element.'
+        },
+      ],
+    }
+  ],
+});


### PR DESCRIPTION
## Description
Closes [2046 add eslint for va-button and va-table](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2046)

### `va-button`
Display eslint rule when html tag `button` or `input` with type `button` is used instead of `va-button`.

Note: tried to add a fixer as well, but found that it would break if the button text was a variable or JSX because they would already be evaluated so it wouldn't be possible to move them to the `va-button`'s `text` prop.

### `va-table`
Display eslint rule when html tag `table` is used instead of `va-button`.

Due to similar complexities, no fixer was written for this rule.

## Testing done
Local unit tests
Tested in `vets-website` repo locally

## Screenshots
<img width="820" alt="Screenshot 2023-11-01 at 10 22 14" src="https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/1413938/5c4af856-d180-4bc6-afd9-ac2293c4875e">
<img width="814" alt="Screenshot 2023-11-01 at 11 22 53" src="https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/1413938/f2a59b23-d1e9-43c9-89e4-0c659a3176a2">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
