### PR TITLE
formation: update blue colors to USWDS v3 colors

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "7.0.9",
+  "version": "7.1.0-color-beta",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/base/_b-variables.scss
+++ b/packages/formation/sass/base/_b-variables.scss
@@ -31,33 +31,38 @@ $h6-font-size:        1.5rem;
 $text-max-width:      70rem; // Note: USWDS value is 53rem;
 $site-max-width:      100rem; // Worksout to about 1000px. USWDS value is 1040px
 
+
+//================
+//  USWDS Colors
+//===============
+$color-aqua:                 #00bde3;
+$color-aqua-dark:            #009ec1;
+$color-aqua-lightest:        #e1f3f8;
+$color-blue:                 #005ea2;
+$color-blue-darkest:         #162e51;
+
+$color-primary:              $color-blue;
+$color-primary-darker:       #1a4480;
+$color-primary-darkest:      $color-blue-darkest;
+
+$color-primary-alt:          $color-aqua;
+$color-primary-alt-light:    #97d4ea;
+$color-primary-alt-lightest: $color-aqua-lightest;
+$color-primary-alt-dark:     #28a0cb;
+
 //===================================
-// USWDS variables
-// Colors that override (or restate) USWDS values
+// Formation colors that override (or restate) USWDS values
 // Also see: https://standards.usa.gov/components/colors/
 //===================================
-$color-aqua:                 #02bfe7;
-$color-aqua-dark:            #00a6d2;
-$color-aqua-lightest:        #e1f3f8;
+
 $color-purple:               #4c2c92;
 $color-white:                #ffffff;
 $color-red:                  #e31c3d;
 $color-red-lightest:         #f9dede;
 $color-red-light:            #e59393;
 $color-red-dark:             #cd2026;
-$color-blue:                 #0071BB;
-$color-blue-darkest:         #112e51;
 
 $color-base:                 #212121;
-
-$color-primary:              $color-blue;
-$color-primary-darker:       #003E73;
-$color-primary-darkest:      #112e51;
-
-$color-primary-alt:          $color-aqua;
-$color-primary-alt-light:    #9bdaf1;
-$color-primary-alt-lightest: $color-aqua-lightest;
-$color-primary-alt-dark:     $color-aqua-dark;
 
 $color-secondary:            $color-red;
 $color-secondary-lightest:   $color-red-lightest;

--- a/packages/formation/sass/base/_b-variables.scss
+++ b/packages/formation/sass/base/_b-variables.scss
@@ -33,7 +33,7 @@ $site-max-width:      100rem; // Worksout to about 1000px. USWDS value is 1040px
 
 
 //================
-//  USWDS Colors
+//  USWDS V3 Colors
 //===============
 $color-aqua:                 #00bde3;
 $color-aqua-dark:            #009ec1;


### PR DESCRIPTION
## Description
Update the current blue colors in formation to use the USWDS v3 colors. Color mappings are as follows:

```
//================
//  USWDS Colors
//===============
$color-aqua:                 #00bde3;
$color-aqua-dark:            #009ec1;
$color-aqua-lightest:        #e1f3f8;
$color-blue:                 #005ea2;
$color-blue-darkest:         #162e51;

$color-primary:              $color-blue;
$color-primary-darker:       #1a4480;
$color-primary-darkest:      $color-blue-darkest;

$color-primary-alt:          $color-aqua;
$color-primary-alt-light:    #97d4ea;
$color-primary-alt-lightest: $color-aqua-lightest;
$color-primary-alt-dark:     #28a0cb;
```

Issue link: https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2228

## Testing done
- Local testing on vets-website. I am wanting to publish a beta version of formation for additional local testing

## Screenshots

Color change comparison:
![colors](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/1776069/e4fe329a-0e97-44fe-8ccb-044708dfef9c)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
