### PR TITLE
remove breadcrumb eslint transformer

### DIFF
--- a/packages/eslint-plugin/lib/rules/prefer-web-component-library.js
+++ b/packages/eslint-plugin/lib/rules/prefer-web-component-library.js
@@ -42,35 +42,6 @@ const textInputTransformer = (context, node) => {
   });
 };
 
-const breadcrumbsTransformer = (context, node) => {
-  const componentName = node.openingElement.name;
-  const closingTag = node.closingElement.name;
-  const selectedFacilityNode = getPropNode(node, 'selectedFacility');
-
-  context.report({
-    node,
-    message: MESSAGE,
-    data: {
-      reactComponent: componentName.name,
-      webComponent: 'va-breadcrumbs',
-    },
-    suggest: [
-      {
-        desc: 'Migrate component',
-        fix: fixer => {
-          // Replace opening and close tags
-          // and remove `selectedFacilityNode` prop if present
-          return [
-            fixer.replaceText(componentName, 'va-breadcrumbs'),
-            fixer.replaceText(closingTag, 'va-breadcrumbs'),
-            selectedFacilityNode && fixer.remove(selectedFacilityNode),
-          ].filter(i => !!i);
-        },
-      },
-    ],
-  });
-};
-
 const modalTransformer = (context, node) => {
   const openingTagNode = node.openingElement.name;
   const closingTagNode = node.closingElement?.name;
@@ -282,9 +253,6 @@ module.exports = {
         if (!isLibraryImport(context, componentName)) return;
 
         switch (componentName) {
-          case 'Breadcrumbs':
-            breadcrumbsTransformer(context, node);
-            break;
           case 'Modal':
             modalTransformer(context, node);
             break;

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/eslint-plugin",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "ESLint plugin for va.gov projects",
   "homepage": "https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/tree/master/packages/eslint-plugin#readme",
   "bugs": {

--- a/packages/eslint-plugin/tests/lib/rules/prefer-web-component-library.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-web-component-library.js
@@ -35,6 +35,8 @@ const mockFileComponentLibraryNamedImport = (name, snippet) => {
 ruleTester.run('prefer-web-component-library', rule, {
   // This rule should not trigger on application components, only React components
   // from the `component-library`
+  valid: [
+  ],
   invalid: [
     {
       code: mockFile(

--- a/packages/eslint-plugin/tests/lib/rules/prefer-web-component-library.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-web-component-library.js
@@ -35,54 +35,7 @@ const mockFileComponentLibraryNamedImport = (name, snippet) => {
 ruleTester.run('prefer-web-component-library', rule, {
   // This rule should not trigger on application components, only React components
   // from the `component-library`
-  valid: [
-    {
-      code: `
-        import Breadcrumbs from '../../components/Breadcrumbs';
-        const breadcrumbs = () => (<Breadcrumbs><a href="#home">Home</a></Breadcrumbs>)
-      `,
-    },
-  ],
   invalid: [
-    {
-      code: mockFile(
-        'Breadcrumbs',
-        'const breadcrumb = () => (<Breadcrumbs><a href="/">Home</a></Breadcrumbs>)',
-      ),
-      errors: [
-        {
-          suggestions: [
-            {
-              desc: 'Migrate component',
-              output: mockFile(
-                'Breadcrumbs',
-                'const breadcrumb = () => (<va-breadcrumbs><a href="/">Home</a></va-breadcrumbs>)',
-              ),
-            },
-          ],
-        },
-      ],
-    },
-    {
-      code: mockFile(
-        'Breadcrumbs',
-        'const breadcrumb = () => (<Breadcrumbs selectedFacility={selectedResult}><a href="/">Home</a></Breadcrumbs>)',
-      ),
-      errors: [
-        {
-          suggestions: [
-            {
-              desc: 'Migrate component',
-              // There is an extra space which would get removed on an autosave format
-              output: mockFile(
-                'Breadcrumbs',
-                'const breadcrumb = () => (<va-breadcrumbs ><a href="/">Home</a></va-breadcrumbs>)',
-              ),
-            },
-          ],
-        },
-      ],
-    },
     {
       code: mockFile(
         'Modal',


### PR DESCRIPTION
## Description
This PR removes the `breadcrumb` eslint transformer as its no longer needed because it has been replaced with the web component.

closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1632

## Acceptance criteria
- [ ] Remove breadcrumb eslint transformer.

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
