### PR TITLE
Set alt text for action link icon to hide from JAWS

### DIFF
--- a/packages/formation/sass/modules/_m-action-link.scss
+++ b/packages/formation/sass/modules/_m-action-link.scss
@@ -3,7 +3,9 @@ a.vads-c-action-link--blue, a.vads-c-action-link--green, a.vads-c-action-link--w
     font-family: "Font Awesome 5 Free";
     font-weight: 900;
     font-size: 175%;
+    // Sets alt text for the icon to blank to hide it from screen readers. The content property is duplicated as a fallback for browsers that do not support alt text for it (Firefox, Safari).
     content: "\f138";
+    content: "\f138" / "";
     position: absolute; 
     left: 0px;
     top: -4px;


### PR DESCRIPTION
## Description

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2208

The icon for action link uses a pseudo-selector. The way to hide this from screen readers is to provide blank alt text to that property.

Unfortunately, not all browsers support it (Firefox, Safari), so a fallback is needed to show the icon. In these browsers, JAWS would still land on the icon. This may be the best we can do at the moment because this icon comes from the CSS.

## Testing done

- I tested with and without this setting in JAWS. Video attached. You will see that when this is added, it skips over the icon. When it is removed, it stops on the icon.
    https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/100248909/17f352c8-52b8-496d-8dd0-469eb2903c35
- I also tested with Firefox to ensure the fallback method still shows the icon as expected. The unsupported `content: "\f138" / "";` is ignored.
    <img width="1299" alt="image" src="https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/100248909/2d9e7927-0601-47d9-9ba4-7f47c6d6cb92">


## Acceptance criteria
- [x] JAWS ignores the icon (Edge, Chrome).

