### PR TITLE
Update Font Awesome to v5.15.4

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -28,13 +28,13 @@
     "url": "https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/issues"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^5.6.3",
+    "@fortawesome/fontawesome-free": "^5.15.4",
     "domready": "^1.0.8",
     "element-closest": "^3.0.1",
     "foundation-sites": "5"
   },
   "peerDependencies": {
-    "@fortawesome/fontawesome-free": "^5.6.3",
+    "@fortawesome/fontawesome-free": "^5.15.4",
     "foundation-sites": "5",
     "uswds": "^1.6.10"
   }

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "The VA design system",
   "keywords": [
     "va",


### PR DESCRIPTION
## Description
This updates the Font Awesome version to the latest available release. 

related https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2280

## Testing done
Tested using Verdacio locally. I confirmed that before this update, the icon `fa-phone-alt` did not display in vets-website and after making this update, it displayed.

## Screenshots

Tested in vets-website locally

<img width="553" alt="Screenshot 2023-11-29 at 3 09 56 PM" src="https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/872479/308a6926-b19f-4356-b241-b560b49889c7">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
