### PR TITLE
Update Formation to v9.0.0 for publishing

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "description": "The VA design system",
   "keywords": [
     "va",


### PR DESCRIPTION
We had previously thought that we could release v8.0.0 but this version was [already published](https://www.npmjs.com/package/@department-of-veterans-affairs/formation/v/7.0.3?activeTab=versions) 2 years ago. We want to make a major release though because the [auditing of shame.scss](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/992) is a potentially breaking change.

After some discussion, we decided to skip v8.0.0 entirely and go directly to v9.0.0.

<img width="866" alt="Screenshot 2023-11-29 at 3 45 37 PM" src="https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/872479/a4c61198-b2fa-47e8-874c-f7536e53d648">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
