### PR TITLE
Removing unused styles from `base/_va.scss`

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "9.0.1",
+  "version": "10.0.0",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -295,14 +295,6 @@ article > h1 {
   overflow: hidden;
 }
 
-// ** ADDED TO CSS-LIBRARY - elements.scss
-.primary {
-  p {
-    padding-top: 0;
-    margin-top: 0;
-  }
-}
-
 // TODO: .usa-font-lead is now .usa-intro in USWDS v3.
 // This is a copy of USWDS's .usa-font-lead style
 // https://github.com/18F/web-design-standards/blob/develop/src/stylesheets/elements/_typography.scss#L164

--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -376,59 +376,6 @@ article > h1 {
 }
 
 // ** ADDED TO CSS-LIBRARY - elements.scss
-// Content lead paragraphs
-#content.interior .primary {
-  li p:first-of-type,
-  ul + p {
-    font-weight: normal !important;
-    color: $color-gray-dark;
-    font-size: 1em;
-    padding-bottom: 0;
-  }
-}
-
-// ** ADDED TO CSS-LIBRARY - elements.scss
-#content .section.primary {
-  background: none;
-  padding: 2em 0;
-  background: $color-primary;
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6,
-  p,
-  li {
-    color: $color-white;
-  }
-  p {
-    color: $color-white;
-  }
-  a {
-    color: $color-white;
-  }
-  ul li {
-    list-style: square;
-  }
-}
-
-// ** ADDED TO CSS-LIBRARY - elements.scss
-#content .section.secondary {
-  padding: 3em 0;
-  h3 {
-    font-size: 2.2em;
-  }
-}
-
-#content .panel {
-  background: $color-gray-lightest;
-  padding: 1em;
-  margin-bottom: 1.5em;
-  clear: both;
-}
-
-// ** ADDED TO CSS-LIBRARY - elements.scss
 // Used in content-build: src/site/includes/breadcrumbs-playbook.html
 //===== Playbook and Facility Locator
 .va-nav-breadcrumbs--playbook {

--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -573,9 +573,7 @@ li {
   span {
     display: block;
   }
-}
 
-.card {
   .number {
     font-family: $font-serif;
     font-size: 2em;

--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -320,7 +320,6 @@ article > h1 {
 // Content callout boxes
 // ===================
 
-// ** ADDED TO CSS-LIBRARY - elements.scss
 .feature {
   background: $color-primary-alt-lightest;
   padding: 1em;
@@ -355,7 +354,6 @@ article > h1 {
   }
 }
 
-// ** ADDED TO CSS-LIBRARY - elements.scss
 // Quick Links
 .va-quicklinks {
   ul {
@@ -375,7 +373,6 @@ article > h1 {
   }
 }
 
-// ** ADDED TO CSS-LIBRARY - elements.scss
 // Used in content-build: src/site/includes/breadcrumbs-playbook.html
 //===== Playbook and Facility Locator
 .va-nav-breadcrumbs--playbook {
@@ -543,7 +540,6 @@ li {
 //===================================
 
 
-// ** ADDED TO CSS-LIBRARY - elements.scss
 // Info cards
 .card {
   position: relative;

--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -182,11 +182,6 @@ input.va-input-medium-large {
   max-width: 18rem;
 }
 
-// TODO(crew): Remove this at some point. Fix this by using JS for title casing or passing nav labels as an object.
-.text-capitalize {
-  text-transform: capitalize;
-}
-
 hr {
   margin: 2.5em 0;
   margin: 3rem 0 2.5rem;
@@ -196,13 +191,6 @@ hr {
 // Default table width to being 100%
 table {
   width: 100%;
-}
-
-// Utility classes
-// TODO(css): Move these into a partial once there are enough
-.va-util-rel,
-.va-pos-rel {
-  position: relative;
 }
 
 .va-pos-fixed {
@@ -281,17 +269,6 @@ table {
   }
 }
 
-.va-header-search-widescr {
-  display: none;
-  line-height: 1em;
-  margin: 0;
-
-  @include media($medium-large-screen) {
-    display: inherit;
-    flex: 1 1 80%;
-  }
-}
-
 .vets-logo {
   display: block;
   height: inherit;
@@ -310,12 +287,7 @@ article > h1 {
   margin-top: 0;
 }
 
-.text-center {
-  text-align: center;
-}
-
 // Banner
-
 #content {
   margin: 0;
   padding: 0;
@@ -323,34 +295,7 @@ article > h1 {
   overflow: hidden;
 }
 
-.va-facloc-tagline {
-  color: $color-white;
-  // font-family: $font-sans;
-  margin: 0.5em 0 1em 0 !important;
-}
-
-// TODO(css): Remove .feature-list ul once it"s
-// refactored from the Markdown
-.feature-list ul,
-.va-list--feature {
-  margin: 0;
-  padding: 0;
-  list-style: none outside;
-
-  li {
-    border-bottom: 1px solid $color-gray-light;
-    padding: 1em 0;
-
-    &:last-of-type {
-      border-bottom: none;
-    }
-  }
-
-  a {
-    font-weight: bold;
-  }
-}
-
+// ** ADDED TO CSS-LIBRARY - elements.scss
 .primary {
   p {
     padding-top: 0;
@@ -358,6 +303,7 @@ article > h1 {
   }
 }
 
+// TODO: .usa-font-lead is now .usa-intro in USWDS v3.
 // This is a copy of USWDS's .usa-font-lead style
 // https://github.com/18F/web-design-standards/blob/develop/src/stylesheets/elements/_typography.scss#L164
 .va-introtext {
@@ -372,15 +318,6 @@ article > h1 {
   }
 }
 
-.secondary {
-  p:nth-child(1),
-  p:first-of-type {
-    color: initial;
-    font-size: 1em;
-    padding: 0;
-  }
-}
-
 // TODO: Integrate USWDS and elements/_typography.scss
 // and eliminate this declaration
 .usa-content {
@@ -391,6 +328,7 @@ article > h1 {
 // Content callout boxes
 // ===================
 
+// ** ADDED TO CSS-LIBRARY - elements.scss
 .feature {
   background: $color-primary-alt-lightest;
   padding: 1em;
@@ -425,54 +363,7 @@ article > h1 {
   }
 }
 
-.va-callout {
-  background: $color-primary-alt-lightest;
-  padding: 1em;
-  clear: both;
-  margin: 0 0 1.5em 0;
-
-  dt {
-    color: $color-primary-darkest;
-    font-size: 1.65em;
-    font-weight: bold;
-    margin: 0 0 0.5rem 0;
-  }
-
-  dd {
-    margin-left: 0;
-    padding-left: 0;
-  }
-  ul {
-    margin: 0 0 0.5rem 1.5rem;
-    padding: 0;
-  }
-}
-
-// Usually call out boxes will be definition lists, but
-// sometimes they"re unordered lists.
-ul,
-ol {
-  &.va-callout {
-    li {
-      margin-left: 3rem !important;
-    }
-  }
-}
-
-//====================
-// Home, 404 page, maintenance page
-// ===================
-
-.navigation--major {
-  .va-cards--2across {
-    display: block;
-  }
-
-  .home & {
-    padding: 1.5em 0.5em 4em;
-  }
-}
-
+// ** ADDED TO CSS-LIBRARY - elements.scss
 // Quick Links
 .va-quicklinks {
   ul {
@@ -490,53 +381,10 @@ ol {
     margin: 0 0 1rem 0;
     padding: 0 0 0.2em 0;
   }
-
-  &--commpop {
-    padding-bottom: 6.4rem;
-  }
 }
 
-.maintenance-page {
-  padding-top: 3.2rem;
-
-  .text-center {
-    margin: auto;
-  }
-}
-
-.faq-page {
-  padding-top: 3em;
-  padding-bottom: 3em;
-}
-
-//========================
-// 404 page only
-//========================
-
-#search_form {
-  position: relative;
-  width: 100%;
-
-  label {
-    left: -9999rem;
-    position: absolute;
-  }
-
-  [type="text"] {
-    height: 5.7rem;
-    margin: 0;
-    max-width: 100%;
-  }
-
-  [type="submit"] {
-    border-radius: 0 3px 3px 0;
-    height: 5.7rem;
-    margin: 0;
-  }
-}
-
+// ** ADDED TO CSS-LIBRARY - elements.scss
 // Content lead paragraphs
-
 #content.interior .primary {
   li p:first-of-type,
   ul + p {
@@ -547,6 +395,7 @@ ol {
   }
 }
 
+// ** ADDED TO CSS-LIBRARY - elements.scss
 #content .section.primary {
   background: none;
   padding: 2em 0;
@@ -572,6 +421,7 @@ ol {
   }
 }
 
+// ** ADDED TO CSS-LIBRARY - elements.scss
 #content .section.secondary {
   padding: 3em 0;
   h3 {
@@ -586,17 +436,8 @@ ol {
   clear: both;
 }
 
-// Action
-.action {
-  margin: 0 auto;
-  text-align: left;
-
-  .button {
-    font-size: 1.25em;
-    padding: 1em 3.5em;
-  }
-}
-
+// ** ADDED TO CSS-LIBRARY - elements.scss
+// Used in content-build: src/site/includes/breadcrumbs-playbook.html
 //===== Playbook and Facility Locator
 .va-nav-breadcrumbs--playbook {
   background: none;
@@ -622,36 +463,6 @@ ol {
     }
   }
 
-  .parent {
-    padding-top: 0.5em;
-    margin: 0 0 0.75em 0;
-
-    &:after {
-      content: " › ";
-      display: inline-block;
-      color: $color-white;
-      padding: 0 0.5em;
-    }
-  }
-
-  .active {
-    background: $color-gold;
-    color: $color-black;
-    font: 400 1.35em / 1.15em $font-serif;
-    margin: 0.5em 0;
-    padding: 0.2em;
-
-    @include media($medium-large-screen) {
-      font-size: 1.8em;
-    }
-
-    &:before {
-      content: "";
-      padding: 0;
-      margin: 0;
-    }
-  }
-
   a {
     border-bottom: 3px solid $color-white;
     text-decoration: none !important;
@@ -664,9 +475,38 @@ ol {
   }
 }
 
-.va-breadcrumbs-heading {
-  font-size: 1em !important;
+.va-nav-breadcrumbs--playbook {
+  .parent {
+    padding-top: 0.5em;
+    margin: 0 0 0.75em 0;
+  
+    &:after {
+      content: " › ";
+      display: inline-block;
+      color: $color-white;
+      padding: 0 0.5em;
+    }
+  }
+  
+  .active {
+    background: $color-gold;
+    color: $color-black;
+    font: 400 1.35em / 1.15em $font-serif;
+    margin: 0.5em 0;
+    padding: 0.2em;
+  
+    @include media($medium-large-screen) {
+      font-size: 1.8em;
+    }
+  
+    &:before {
+      content: "";
+      padding: 0;
+      margin: 0;
+    }
+  }
 }
+
 //===== General List Styles
 
 li {
@@ -678,14 +518,6 @@ li {
     font-weight: bold;
     float: right;
     margin: 0.5em 0 1em 1em;
-  }
-}
-.inline-list {
-  > li {
-    float: left;
-  }
-  > * {
-    display: block;
   }
 }
 
@@ -708,49 +540,6 @@ li {
   background: $color-link-default-hover;
   padding: 0.2em;
   display: inline-block;
-}
-
-// Information Grid
-
-.information-grid {
-  strong {
-    font-size: 1.3em;
-    color: $color-primary-darkest;
-  }
-
-  p {
-    font-size: 0.9em;
-  }
-
-  div {
-    background: $color-gray-lightest;
-    background: $color-link-default-hover;
-    margin: 0 0 0.5em 0;
-    padding: 0.75em;
-
-    &:hover,
-    &:focus,
-    &:active {
-      background: $color-link-default-hover;
-    }
-  }
-  a {
-    text-decoration: none;
-    border-bottom: 2px solid $color-primary-darkest;
-  }
-}
-
-.text-right {
-  text-align: right;
-}
-
-.primary blockquote {
-  margin: 0 0 1em 0;
-  padding: 0 0 0 1em;
-  border-left: 2px solid $color-gray-lighter;
-  p {
-    color: $color-primary-darker;
-  }
 }
 
 // Notice / feedback banners
@@ -783,7 +572,10 @@ li {
     max-width: 97.5rem;
     position: relative;
   }
+}
 
+// ** ADDED TO CSS-LIBRARY - elements.scss
+.va-notice--banner {
   p {
     margin: 0;
   }
@@ -792,34 +584,6 @@ li {
     background-image: none;
     color: inherit;
     padding: 0;
-  }
-}
-
-.incompatible-browser-warning {
-  padding: 0.5em;
-  font-weight: bold;
-  background: $color-gold-lightest;
-  color: $color-black;
-  font-size: 0.9em;
-  display: none;
-
-  &.visible {
-    display: block;
-  }
-}
-
-// Only used in the footer
-.va-notice--banner--alt {
-  background: $color-primary-darker;
-  color: $color-white;
-  padding: 1.25em 0;
-  margin: 1.5em 0 0 0;
-
-  @include media($medium-large-screen) {
-    .usa-grid {
-      padding-left: 0.9375rem;
-      padding-right: 2rem;
-    }
   }
 }
 
@@ -839,8 +603,9 @@ li {
 // Blog-related CSS
 //===================================
 
-// Info cards
 
+// ** ADDED TO CSS-LIBRARY - elements.scss
+// Info cards
 .card {
   position: relative;
   margin: 0 0 1.5em 0;
@@ -873,7 +638,9 @@ li {
   span {
     display: block;
   }
+}
 
+.card {
   .number {
     font-family: $font-serif;
     font-size: 2em;
@@ -946,30 +713,6 @@ li {
   }
 }
 
-// Panel list
-.panel-list {
-  background: $color-link-default-hover;
-  padding: 1em;
-  position: relative;
-  min-height: 12em;
-
-  dt {
-    color: $color-primary-darkest;
-    padding: 0;
-    font-weight: 700;
-    font-size: 1.2em;
-  }
-
-  dd {
-    padding: 0;
-    margin: 0;
-  }
-
-  a {
-    margin: 0.5em 0;
-  }
-}
-
 // Highlight headings
 // TODO(css): Consolidate these rules, possibly into a new class name
 .highlight,
@@ -1019,25 +762,6 @@ li {
   }
 }
 
-// Action bars
-[class^="va-action-bar"] {
-  background: $color-gray-lightest;
-}
-
-.va-action-bar--header {
-  padding: 0.5em 0;
-  text-align: right;
-}
-
-.va-action-bar--footer {
-  padding: 1em 0;
-}
-
-.va-action-bar--start {
-  background: $color-green-lightest;
-  border-bottom: 3px solid $color-white;
-}
-
 // TODO: Deprecate .va-action-bar--header a.usa-button-primary.
 // Use .va-button-primary and .va-button-secondary
 // going forward.
@@ -1061,178 +785,10 @@ li {
   }
 }
 
-.va-button-secondary {
-  background-color: $color-primary-darker !important;
-
-  &:hover,
-  &:focus {
-    background-color: $color-primary-darkest !important;
-  }
-}
-
 // USDS component styles
 // Accordion
 .usa-accordion-content[aria-hidden="true"] {
   display: none !important;
-}
-
-// Disclaimer
-.disclaimer {
-  padding: 1em 0;
-  padding-left: 0.9375rem;
-
-  p {
-    font-size: 1.28rem;
-  }
-
-  a {
-    background-image: none;
-    color: inherit;
-    padding: 0;
-
-    &:hover {
-      color: $color-gold;
-    }
-  }
-}
-
-// Info block
-
-.info-block {
-  p {
-    padding: 0;
-    margin: 0;
-  }
-}
-
-// vets.gov branded apps
-.vets-app {
-  border-left: 3px solid $color-gold;
-  display: inline-block;
-  padding: 0 0 0 0.5em !important;
-}
-
-// Tooltip
-.js-simple-tooltip {
-  font-family: "Courier New", "Courier", serif;
-  font-weight: bold;
-  cursor: pointer;
-  display: inline-block;
-  padding: 0;
-  border-radius: 1.75em;
-  background: $color-gray-dark;
-  margin: 0 0 0 0.5em;
-  color: $color-white;
-  height: 1.75em;
-  font-size: 0.8em;
-  width: 1.75em;
-  text-align: center;
-  vertical-align: middle;
-}
-.simpletooltip[aria-hidden="true"] {
-  display: none;
-}
-.simpletooltip_container {
-  position: relative;
-  display: inline-block;
-}
-
-.simpletooltip {
-  position: absolute;
-  z-index: 777;
-  width: 11em;
-  border-radius: 0.3em;
-  background: $color-gray-dark;
-  color: $color-white;
-  padding: 0.6em;
-  text-align: left;
-  font-size: 1em;
-  font-weight: 300;
-  line-height: 1.3;
-  right: auto;
-  left: 100%;
-  margin-left: 0.8em;
-  white-space: normal;
-  top: -110%;
-
-  &:before {
-    border-bottom: 10px solid transparent; // left arrow slant
-    border-top: 10px solid transparent; // right arrow slant
-    border-right: 10px solid $color-gray-dark;
-    content: "";
-    font-size: 0;
-    position: absolute;
-    left: 0px;
-    line-height: 0;
-    margin-left: -10px;
-    width: 0;
-    height: 0;
-    top: 39%;
-  }
-}
-
-@include media($medium-screen) {
-  .simpletooltip {
-    top: 100%;
-    left: 45%;
-    right: 0;
-    margin: 0;
-    margin-top: 0.7em;
-    margin-left: -5em;
-
-    &:before {
-      top: -10px !important;
-      right: auto;
-      left: 45%;
-      margin-left: -5px;
-      margin-top: -10px;
-      border: 10px solid transparent;
-      border-bottom: 10px solid $color-gray-dark;
-    }
-  }
-}
-
-html.no-touchevents {
-  .touch {
-    display: none;
-  }
-  .no-touch {
-    display: block;
-  }
-}
-
-html.touchevents {
-  .touch {
-    display: block;
-  }
-  .no-touch {
-    display: none;
-  }
-}
-
-@-webkit-keyframes fadeIn {
-  0% {
-    opacity: 0;
-  }
-
-  100% {
-    opacity: 1;
-  }
-}
-
-@keyframes fadeIn {
-  0% {
-    opacity: 0;
-  }
-
-  100% {
-    opacity: 1;
-  }
-}
-
-.fadeIn {
-  -webkit-animation-name: fadeIn;
-  animation-name: fadeIn;
 }
 
 .va-address-block {
@@ -1247,44 +803,12 @@ html.touchevents {
   display: flex;
 }
 
-// Vertically aligns at top when flex-direction: row;
-// Aligns flush left when flex-direction: column
-.va-flex--top {
-  -webkit-align-items: flex-start;
-  align-items: flex-start;
-}
-
-// Vertically aligns in the middle when flex-direction: row;
-// Aligns center horizontally when flex-direction: column
-.va-flex--ctr {
-  -webkit-align-items: center;
-  align-items: center;
-}
-
-// Horizontally aligns in the center when flex-direction: row;
-// Aligns middle vertically when flex-direction: column
-.va-flex--jctr {
-  -webkit-justify-items: center;
-  justify-items: center;
-}
-
-// Stretches all flexbox items to be the same height when
-// flex-direction: row
-.va-flex--stretch {
-  -webkit-align-items: stretch;
-  align-items: stretch;
-}
-
 .react-container {
   padding: 2em 0;
 }
 
 .react-container {
   padding: 2em 0;
-}
-
-p.info-message {
-  font-size: 1.5em;
 }
 
 //==================
@@ -1294,15 +818,6 @@ p.info-message {
 .va-list--plain {
   list-style: none;
   padding-left: 0;
-}
-
-// Used for sidebar / aside style lists of links
-.va-rellinks {
-  margin-top: 0;
-
-  li {
-    padding: 0.8rem 0;
-  }
 }
 
 // Last updated
@@ -1373,53 +888,6 @@ p.info-message {
   position: absolute;
 }
 
-.legend-heading-wrapper {
-  max-width: 100%;
-  margin: 0.08em 0;
-  width: 100%;
-}
-
-.legend-label {
-  display: block;
-  margin-top: 3rem;
-  max-width: 46rem;
-  font-weight: inherit;
-  font-size: inherit;
-  color: inherit;
-  line-height: inherit;
-}
-
 .fieldset-input {
   margin-top: 3rem;
-  .health-record-fieldset {
-    //specificity used to override
-    margin-top: 1.5rem;
-  }
-}
-
-[itemprop="acceptedAnswer"] {
-  // margin-bottom: 3em;
-}
-
-// Error standardization
-.usa-alert,
-.plaintext-message {
-  .alert-actions {
-    margin-top: 0.5em;
-  }
-}
-
-.usa-label {
-  &.va-label-primary {
-    background-color: $color-green;
-    color: #fff;
-  }
-}
-
-.label-above-checkbox {
-  display: block;
-  margin: 3rem 0 1rem;
-  & + input + label {
-    margin-top: 0;
-  }
 }


### PR DESCRIPTION
## Description

I did an audit of the styles in [formation/sass/base/_va.scss](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/master/packages/formation/sass/base/_va.scss) and this PR is doing a few things:

1. Remove any classes that I could not find being used in vets-website or content-build
2. Remove the styles that were only being used on the PageNotFound page in the dhp-connected-devices app and moved them to the app: https://github.com/department-of-veterans-affairs/vets-website/pull/27086
3. Labeled the styles that are being moved to the CSS Library: https://github.com/department-of-veterans-affairs/component-library/pull/981
 
**related issue** 
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2043

## Testing done
tested locally with vets-website and verdaccio

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
