### PR TITLE
Remove !important from `abbr` tag

### DIFF
--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -69,8 +69,8 @@ body .row.full {
 
 // Abbr
 
-abbr {
-  border-bottom: 0px !important;
+#content abbr {
+  border-bottom: 0px;
   text-decoration: none;
   font-weight: inherit;
   font-style: inherit;


### PR DESCRIPTION
## Description
To avoid having to bring in `!important` declarations to the CSS Library, this PR increases the specificity on the `abbr` element.

Otherwise, normalize.scss is overriding the underline style:

**before**

![Screenshot 2023-12-12 at 11 57 33 AM](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/872479/51a923e7-588b-46b2-a2a5-c3d2672c668e)

**after**

![Screenshot 2023-12-12 at 12 29 22 PM](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/872479/6cdd3e57-a86d-450f-aba9-96ca4e92e136)

related issue
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2042

## Testing done
tested Formation locally with Verdaccio an vets-website


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
