### PR TITLE
Add a comment to styles that have been added to the CSS Library

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/base/_b-breakpoints.scss
+++ b/packages/formation/sass/base/_b-breakpoints.scss
@@ -19,9 +19,21 @@ $grid-columns-medium: 6 !default;
 $grid-columns-large: 12 !default;
 
 // Breakpoint variables from USWDS 1.4.2
-$small-screen:  481px !default; // ** ADDED TO CSS-LIBRARY - tokens/breakpoints.scss
+/* 
+ADDED TO CSS-LIBRARY
+file: tokens/breakpoints.json
+issue: vets-design-system-documentation#2042
+*/
+$small-screen:  481px !default;
+
 $medium-screen: 600px !default;
-$large-screen:  1201px !default; // ** ADDED TO CSS-LIBRARY - tokens/breakpoints.scss
+
+/* 
+ADDED TO CSS-LIBRARY
+file: tokens/breakpoints.json
+issue: vets-design-system-documentation#2042
+*/
+$large-screen:  1201px !default;
 
 $small: new-breakpoint(min-width $small-screen $grid-columns-small);
 $medium: new-breakpoint(min-width $medium-screen $grid-columns-medium);

--- a/packages/formation/sass/base/_b-breakpoints.scss
+++ b/packages/formation/sass/base/_b-breakpoints.scss
@@ -19,9 +19,9 @@ $grid-columns-medium: 6 !default;
 $grid-columns-large: 12 !default;
 
 // Breakpoint variables from USWDS 1.4.2
-$small-screen:  481px !default;
+$small-screen:  481px !default; // ** ADDED TO CSS-LIBRARY - tokens/breakpoints.scss
 $medium-screen: 600px !default;
-$large-screen:  1201px !default;
+$large-screen:  1201px !default; // ** ADDED TO CSS-LIBRARY - tokens/breakpoints.scss
 
 $small: new-breakpoint(min-width $small-screen $grid-columns-small);
 $medium: new-breakpoint(min-width $medium-screen $grid-columns-medium);

--- a/packages/formation/sass/base/_b-variables.scss
+++ b/packages/formation/sass/base/_b-variables.scss
@@ -114,7 +114,7 @@ $color-cool-blue-lightest:  #dce4ef;
 //===================================
 
 $color-black:                #000;
-$color-link-default-hover:   rgba($color-black, 0.05);
+$color-link-default-hover:   rgba($color-black, 0.05); // ** ADDED TO CSS-LIBRARY - tokens/color.json
 
 $color-green-darker:         #195c27;
 $color-va-accent:            #988530; // New gold "metal" acccent

--- a/packages/formation/sass/base/_b-variables.scss
+++ b/packages/formation/sass/base/_b-variables.scss
@@ -114,7 +114,12 @@ $color-cool-blue-lightest:  #dce4ef;
 //===================================
 
 $color-black:                #000;
-$color-link-default-hover:   rgba($color-black, 0.05); // ** ADDED TO CSS-LIBRARY - tokens/color.json
+/* 
+ADDED TO CSS-LIBRARY
+file: tokens/color.json
+issue: vets-design-system-documentation#2042
+*/
+$color-link-default-hover:   rgba($color-black, 0.05);
 
 $color-green-darker:         #195c27;
 $color-va-accent:            #988530; // New gold "metal" acccent

--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -1,22 +1,34 @@
-// ** ADDED TO CSS-LIBRARY - elements.scss
+/* 
+ADDED TO CSS-LIBRARY
+file: stylesheets/elements.scss
+issue: vets-design-system-documentation#2042
+*/
 html,
 body {
   padding: 0;
   margin: 0;
 }
 
-// ** ADDED TO CSS-LIBRARY - elements.scss
+/* 
+ADDED TO CSS-LIBRARY
+file: stylesheets/elements.scss
+issue: vets-design-system-documentation#2042
+*/
 html {
-  font-size: $em-base;
+  font-size: $em-base; // ** TODO: update base font for USWDS v3
   font-weight: 500;
 }
 
-// ** ADDED TO CSS-LIBRARY - elements.scss
+/* 
+ADDED TO CSS-LIBRARY
+file: stylesheets/elements.scss
+issue: vets-design-system-documentation#2042
+*/
 body {
   background: $color-white;
   color: $color-base;
   // font-family: $font-sans;
-  font-size: $base-font-size;
+  font-size: $base-font-size; // ** TODO:  update base font for USWDS v3
   font-family: inherit;
 
   &.modal-open {
@@ -71,7 +83,11 @@ body .row.full {
 }
 
 // Abbr
-// ** ADDED TO CSS-LIBRARY - elements.scss
+/* 
+ADDED TO CSS-LIBRARY
+file: stylesheets/elements.scss
+issue: vets-design-system-documentation#2042
+*/
 #content abbr {
   border-bottom: 0px;
   text-decoration: none;
@@ -81,7 +97,11 @@ body .row.full {
   cursor: pointer;
 }
 
-// ** ADDED TO CSS-LIBRARY - elements.scss
+/* 
+ADDED TO CSS-LIBRARY
+file: stylesheets/elements.scss
+issue: vets-design-system-documentation#2042
+*/
 a {
   color: $color-link-default;
   text-decoration: underline;
@@ -104,12 +124,20 @@ a {
 // ====== Headings
 
 // H1 should only be used once at the top-level, so we can safely remove the margin-top.
-// ** ADDED TO CSS-LIBRARY - elements.scss
+/* 
+ADDED TO CSS-LIBRARY
+file: stylesheets/elements.scss
+issue: vets-design-system-documentation#2042
+*/
 h1 {
   margin-top: 0;
 }
 
-// ** ADDED TO CSS-LIBRARY - elements.scss
+/* 
+ADDED TO CSS-LIBRARY
+file: stylesheets/elements.scss
+issue: vets-design-system-documentation#2042
+*/
 h6 {
   margin: 0.5em 0 0;
   text-transform: none;
@@ -117,19 +145,31 @@ h6 {
 }
 
 //======= Lists
-// ** ADDED TO CSS-LIBRARY - elements.scss
+/* 
+ADDED TO CSS-LIBRARY
+file: stylesheets/elements.scss
+issue: vets-design-system-documentation#2042
+*/
 ul {
   padding: 0 0 0 1.5em;
   list-style: square;
 }
 
-// ** ADDED TO CSS-LIBRARY - elements.scss
+/* 
+ADDED TO CSS-LIBRARY
+file: stylesheets/elements.scss
+issue: vets-design-system-documentation#2042
+*/
 ol {
   margin: 0 0 0 1.25em;
   list-style-position: outside;
 }
 
-// ** ADDED TO CSS-LIBRARY - elements.scss
+/* 
+ADDED TO CSS-LIBRARY
+file: stylesheets/elements.scss
+issue: vets-design-system-documentation#2042
+*/
 ul,
 ol {
   > ul,
@@ -139,18 +179,30 @@ ol {
 }
 
 // Definition lists
-// ** ADDED TO CSS-LIBRARY - elements.scss
+/* 
+ADDED TO CSS-LIBRARY
+file: stylesheets/elements.scss
+issue: vets-design-system-documentation#2042
+*/
 dd {
   margin-left: 0;
 }
 
-// ** ADDED TO CSS-LIBRARY - elements.scss
+/* 
+ADDED TO CSS-LIBRARY
+file: stylesheets/elements.scss
+issue: vets-design-system-documentation#2042
+*/
 dd + dt {
   margin-top: 1.5em;
 }
 
 // Figure / Caption
-// ** ADDED TO CSS-LIBRARY - elements.scss
+/* 
+ADDED TO CSS-LIBRARY
+file: stylesheets/elements.scss
+issue: vets-design-system-documentation#2042
+*/
 figure {
   font-size: 0.85em;
   margin-left: -$column-gutter/2;
@@ -162,36 +214,64 @@ figure {
   }
 }
 
-// ** ADDED TO CSS-LIBRARY - elements.scss
+/* 
+ADDED TO CSS-LIBRARY
+file: stylesheets/elements.scss
+issue: vets-design-system-documentation#2042
+*/
 figcaption {
   color: $color-primary-darker;
 }
 
-// ** ADDED TO CSS-LIBRARY - elements.scss
+/* 
+ADDED TO CSS-LIBRARY
+file: stylesheets/elements.scss
+issue: vets-design-system-documentation#2042
+*/
 input::-webkit-input-placeholder {
   color: $color-gray;
 }
-// ** ADDED TO CSS-LIBRARY - elements.scss
+/* 
+ADDED TO CSS-LIBRARY
+file: stylesheets/elements.scss
+issue: vets-design-system-documentation#2042
+*/
 input::-moz-placeholder {
   color: $color-gray;
 }
-// ** ADDED TO CSS-LIBRARY - elements.scss
+/* 
+ADDED TO CSS-LIBRARY
+file: stylesheets/elements.scss
+issue: vets-design-system-documentation#2042
+*/
 input:-ms-input-placeholder {
   color: $color-gray;
 }
 
 // Visually clear placeholder text on focus
-// ** ADDED TO CSS-LIBRARY - elements.scss
+/* 
+ADDED TO CSS-LIBRARY
+file: stylesheets/elements.scss
+issue: vets-design-system-documentation#2042
+*/
 input:focus::-webkit-input-placeholder {
   color: transparent;
 }
 
-// ** ADDED TO CSS-LIBRARY - elements.scss
+/* 
+ADDED TO CSS-LIBRARY
+file: stylesheets/elements.scss
+issue: vets-design-system-documentation#2042
+*/
 input:focus::-moz-placeholder {
   color: transparent;
 }
 
-// ** ADDED TO CSS-LIBRARY - elements.scss
+/* 
+ADDED TO CSS-LIBRARY
+file: stylesheets/elements.scss
+issue: vets-design-system-documentation#2042
+*/
 input:focus:-ms-input-placeholder {
   color: transparent;
 }
@@ -200,7 +280,11 @@ input.va-input-medium-large {
   max-width: 18rem;
 }
 
-// ** ADDED TO CSS-LIBRARY - elements.scss
+/* 
+ADDED TO CSS-LIBRARY
+file: stylesheets/elements.scss
+issue: vets-design-system-documentation#2042
+*/
 hr {
   margin: 2.5em 0;
   margin: 3rem 0 2.5rem;
@@ -302,7 +386,11 @@ table {
   }
 }
 
-// ** ADDED TO CSS-LIBRARY - elements.scss
+/* 
+ADDED TO CSS-LIBRARY
+file: stylesheets/elements.scss
+issue: vets-design-system-documentation#2042
+*/
 article > h1 {
   margin-top: 0;
 }
@@ -530,7 +618,11 @@ li {
   }
 }
 
-// ** ADDED TO CSS-LIBRARY - elements.scss
+/* 
+ADDED TO CSS-LIBRARY
+file: stylesheets/elements.scss
+issue: vets-design-system-documentation#2043
+*/
 .va-notice--banner {
   p {
     margin: 0;

--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -1,14 +1,17 @@
+// ** ADDED TO CSS-LIBRARY - elements.scss
 html,
 body {
   padding: 0;
   margin: 0;
 }
 
+// ** ADDED TO CSS-LIBRARY - elements.scss
 html {
   font-size: $em-base;
   font-weight: 500;
 }
 
+// ** ADDED TO CSS-LIBRARY - elements.scss
 body {
   background: $color-white;
   color: $color-base;
@@ -68,7 +71,7 @@ body .row.full {
 }
 
 // Abbr
-
+// ** ADDED TO CSS-LIBRARY - elements.scss
 #content abbr {
   border-bottom: 0px;
   text-decoration: none;
@@ -78,6 +81,7 @@ body .row.full {
   cursor: pointer;
 }
 
+// ** ADDED TO CSS-LIBRARY - elements.scss
 a {
   color: $color-link-default;
   text-decoration: underline;
@@ -99,11 +103,13 @@ a {
 
 // ====== Headings
 
+// ** ADDED TO CSS-LIBRARY - elements.scss
 // H1 should only be used once at the top-level, so we can safely remove the margin-top.
 h1 {
   margin-top: 0;
 }
 
+// ** ADDED TO CSS-LIBRARY - elements.scss
 h6 {
   margin: 0.5em 0 0;
   text-transform: none;
@@ -111,16 +117,19 @@ h6 {
 }
 
 //======= Lists
+// ** ADDED TO CSS-LIBRARY - elements.scss
 ul {
   padding: 0 0 0 1.5em;
   list-style: square;
 }
 
+// ** ADDED TO CSS-LIBRARY - elements.scss
 ol {
   margin: 0 0 0 1.25em;
   list-style-position: outside;
 }
 
+// ** ADDED TO CSS-LIBRARY - elements.scss
 ul,
 ol {
   > ul,
@@ -130,15 +139,18 @@ ol {
 }
 
 // Definition lists
+// ** ADDED TO CSS-LIBRARY - elements.scss
 dd {
   margin-left: 0;
 }
 
+// ** ADDED TO CSS-LIBRARY - elements.scss
 dd + dt {
   margin-top: 1.5em;
 }
 
 // Figure / Caption
+// ** ADDED TO CSS-LIBRARY - elements.scss
 figure {
   font-size: 0.85em;
   margin-left: -$column-gutter/2;
@@ -150,30 +162,36 @@ figure {
   }
 }
 
+// ** ADDED TO CSS-LIBRARY - elements.scss
 figcaption {
   color: $color-primary-darker;
 }
 
+// ** ADDED TO CSS-LIBRARY - elements.scss
 input::-webkit-input-placeholder {
   color: $color-gray;
 }
+// ** ADDED TO CSS-LIBRARY - elements.scss
 input::-moz-placeholder {
   color: $color-gray;
 }
-
+// ** ADDED TO CSS-LIBRARY - elements.scss
 input:-ms-input-placeholder {
   color: $color-gray;
 }
 
 // Visually clear placeholder text on focus
+// ** ADDED TO CSS-LIBRARY - elements.scss
 input:focus::-webkit-input-placeholder {
   color: transparent;
 }
 
+// ** ADDED TO CSS-LIBRARY - elements.scss
 input:focus::-moz-placeholder {
   color: transparent;
 }
 
+// ** ADDED TO CSS-LIBRARY - elements.scss
 input:focus:-ms-input-placeholder {
   color: transparent;
 }
@@ -182,6 +200,7 @@ input.va-input-medium-large {
   max-width: 18rem;
 }
 
+// ** ADDED TO CSS-LIBRARY - elements.scss
 hr {
   margin: 2.5em 0;
   margin: 3rem 0 2.5rem;
@@ -283,6 +302,7 @@ table {
   }
 }
 
+// ** ADDED TO CSS-LIBRARY - elements.scss
 article > h1 {
   margin-top: 0;
 }

--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -103,8 +103,8 @@ a {
 
 // ====== Headings
 
-// ** ADDED TO CSS-LIBRARY - elements.scss
 // H1 should only be used once at the top-level, so we can safely remove the margin-top.
+// ** ADDED TO CSS-LIBRARY - elements.scss
 h1 {
   margin-top: 0;
 }

--- a/packages/formation/sass/modules/_m-print.scss
+++ b/packages/formation/sass/modules/_m-print.scss
@@ -1,9 +1,11 @@
 // For the print view
 
+// ** ADDED TO CSS-LIBRARY - elements.scss
 .print-only {
   display: none;
 }
 
+// ** ADDED TO CSS-LIBRARY - elements.scss
 @media print {
   header, footer, nav {
     display: none;

--- a/packages/formation/sass/modules/_m-print.scss
+++ b/packages/formation/sass/modules/_m-print.scss
@@ -1,11 +1,19 @@
 // For the print view
 
-// ** ADDED TO CSS-LIBRARY - elements.scss
+/* 
+ADDED TO CSS-LIBRARY
+file: stylesheets/print.scss
+issue: vets-design-system-documentation#2042
+*/
 .print-only {
   display: none;
 }
 
-// ** ADDED TO CSS-LIBRARY - elements.scss
+/* 
+ADDED TO CSS-LIBRARY
+file: stylesheets/print.scss
+issue: vets-design-system-documentation#2042
+*/
 @media print {
   header, footer, nav {
     display: none;


### PR DESCRIPTION
## Description
We moved some styles over to the CSS Library in the following PRs and this will just add a comment in Formation to help us identify them:

- https://github.com/department-of-veterans-affairs/component-library/pull/981
- https://github.com/department-of-veterans-affairs/component-library/pull/982


## Testing done
N/A

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
