### PR TITLE
Add comment to deprecated .va-button-primary class

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "10.2.0",
+  "version": "10.1.1",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "10.1.0",
+  "version": "10.2.0",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -807,29 +807,6 @@ issue: vets-design-system-documentation#2043
   }
 }
 
-// TODO: Deprecate .va-action-bar--header a.usa-button-primary.
-// Use .va-button-primary and .va-button-secondary
-// going forward.
-// Drop !important from the lines below when everything
-// is refactored.
-.va-button-primary {
-  background: $color-green !important;
-
-  &:hover,
-  &:focus {
-    background-color: $color-green-darker !important;
-    text-decoration: none !important;
-  }
-
-  svg {
-    display: inline-block;
-    height: 1.2rem;
-    margin-left: 0.5rem;
-    width: 1.2rem;
-    vertical-align: -1px;
-  }
-}
-
 // USDS component styles
 // Accordion
 .usa-accordion-content[aria-hidden="true"] {

--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -807,6 +807,25 @@ issue: vets-design-system-documentation#2043
   }
 }
 
+// DEPRECATED: Replaced with va-button web component
+.va-button-primary {
+  background: $color-green !important;
+
+  &:hover,
+  &:focus {
+    background-color: $color-green-darker !important;
+    text-decoration: none !important;
+  }
+
+  svg {
+    display: inline-block;
+    height: 1.2rem;
+    margin-left: 0.5rem;
+    width: 1.2rem;
+    vertical-align: -1px;
+  }
+}
+
 // USDS component styles
 // Accordion
 .usa-accordion-content[aria-hidden="true"] {

--- a/packages/formation/sass/modules/_m-nav-sidebar.scss
+++ b/packages/formation/sass/modules/_m-nav-sidebar.scss
@@ -12,10 +12,6 @@ $level-3-hover-padding: 8px 12px 8px 30px;
     font-size: 15px;
     text-decoration: none;
     padding: $level-2-default-padding;
-
-    &.va-button-primary {
-      padding: 1rem 2rem;
-    }
   }
 }
 

--- a/packages/formation/sass/modules/_m-nav-sidebar.scss
+++ b/packages/formation/sass/modules/_m-nav-sidebar.scss
@@ -12,6 +12,11 @@ $level-3-hover-padding: 8px 12px 8px 30px;
     font-size: 15px;
     text-decoration: none;
     padding: $level-2-default-padding;
+
+    // DEPRECATED: Replaced with va-button web component
+    &.va-button-primary {
+      padding: 1rem 2rem;
+    }
   }
 }
 

--- a/packages/formation/sass/site/_m-vet-nav.scss
+++ b/packages/formation/sass/site/_m-vet-nav.scss
@@ -97,23 +97,6 @@ body.va-pos-fixed {
     margin-bottom: 0;
   }
 
-  .va-button-primary {
-    border: 2px solid $color-white;
-    color: $color-white;
-    padding: 1rem;
-    margin: 0.8rem 1.6rem;
-    width: auto;
-
-    &:visited {
-      color: $color-white;
-    }
-
-    @include media($medium-large-screen) {
-      border-color: transparent;
-      display: inline-block;
-    }
-  }
-
   .usa-button-secondary {
     padding: calc(1rem + 2px);
     margin: 0.8rem 1.6rem;

--- a/packages/formation/sass/site/_m-vet-nav.scss
+++ b/packages/formation/sass/site/_m-vet-nav.scss
@@ -97,6 +97,24 @@ body.va-pos-fixed {
     margin-bottom: 0;
   }
 
+  // DEPRECATED: Replaced with va-button web component
+  .va-button-primary {
+    border: 2px solid $color-white;
+    color: $color-white;
+    padding: 1rem;
+    margin: 0.8rem 1.6rem;
+    width: auto;
+
+    &:visited {
+      color: $color-white;
+    }
+
+    @include media($medium-large-screen) {
+      border-color: transparent;
+      display: inline-block;
+    }
+  }
+
   .usa-button-secondary {
     padding: calc(1rem + 2px);
     margin: 0.8rem 1.6rem;


### PR DESCRIPTION
## Description

We have removed `.va-button-primary` usages in vets-website and content-build so this PR adds a comment above the class identifying it as deprecated.

## Related Issues & PRs
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2312
- https://github.com/department-of-veterans-affairs/vets-website/pull/27307
- https://github.com/department-of-veterans-affairs/content-build/pull/1860
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/pull/2386

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
