### PR TITLE
Change background property to color on a:active

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "10.1.0",
+  "version": "10.1.1",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "10.1.1",
+  "version": "10.1.2",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -113,7 +113,7 @@ a {
     text-decoration: underline;
   }
   &:active {
-    background: $color-link-active;
+    color: $color-link-active;
   }
   &:visited,
   &:visited abbr {


### PR DESCRIPTION
## Description
Update the style to set the font color instead of the background color. The background color was causing the text to disappear in the link active state. The variable was being used to set the wrong property.

Ticket: https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2321

## Testing done
Local testing using chrome inspector

## Screenshots
Before: 
![Screenshot 2024-01-12 at 2 15 01 PM](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/1776069/a1aed279-92fb-435e-b72f-bc188a50a78b)

After:
![Screenshot 2024-01-12 at 2 14 29 PM](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/1776069/96765ae2-55cc-4846-adb6-af4fe6cdd315)



## Acceptance criteria
- [x] Link text is visible when active

## Definition of done
- [ ] Changes have been tested in vets-website
- [x] Changes have been tested in IE11, if applicable
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
