### PR TITLE
Add comment to deprecated .card class

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -87,9 +87,9 @@ jobs:
       - name: Build
         run: GITHUB_API_KEY=${{ env.VA_VSP_BOT_GITHUB_TOKEN }} yarn build
 
-      - name: Compress documentation build
-        if: github.ref == 'refs/heads/master'
-        run: tar -C packages/documentation/public -cvf documentation.tar.bz2 .
+      # - name: Compress documentation build
+      #   if: github.ref == 'refs/heads/master'
+      #   run: tar -C packages/documentation/public -cvf documentation.tar.bz2 .
 
       # - name: Upload documentation build artifact
       #   if: github.ref == 'refs/heads/master'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -87,17 +87,17 @@ jobs:
       - name: Build
         run: GITHUB_API_KEY=${{ env.VA_VSP_BOT_GITHUB_TOKEN }} yarn build
 
-      # - name: Compress documentation build
-      #   if: github.ref == 'refs/heads/master'
-      #   run: tar -C packages/documentation/public -cvf documentation.tar.bz2 .
+      - name: Compress documentation build
+        if: github.ref == 'refs/heads/master'
+        run: tar -C packages/documentation/public -cvf documentation.tar.bz2 .
 
-      # - name: Upload documentation build artifact
-      #   if: github.ref == 'refs/heads/master'
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: documentation.tar.bz2
-      #     path: documentation.tar.bz2
-      #     retention-days: 1
+      - name: Upload documentation build artifact
+        if: github.ref == 'refs/heads/master'
+        uses: actions/upload-artifact@v2
+        with:
+          name: documentation.tar.bz2
+          path: documentation.tar.bz2
+          retention-days: 1
 
   deploy:
     name: Deploy
@@ -129,7 +129,7 @@ jobs:
           YARN_CACHE_FOLDER: ~/.cache/yarn
 
       - name: Download documentation build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v2
         with:
           name: documentation.tar.bz2
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Upload documentation build artifact
         if: github.ref == 'refs/heads/master'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: documentation.tar.bz2
           path: documentation.tar.bz2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -129,7 +129,7 @@ jobs:
           YARN_CACHE_FOLDER: ~/.cache/yarn
 
       - name: Download documentation build artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: documentation.tar.bz2
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -91,13 +91,13 @@ jobs:
         if: github.ref == 'refs/heads/master'
         run: tar -C packages/documentation/public -cvf documentation.tar.bz2 .
 
-      - name: Upload documentation build artifact
-        if: github.ref == 'refs/heads/master'
-        uses: actions/upload-artifact@v4
-        with:
-          name: documentation.tar.bz2
-          path: documentation.tar.bz2
-          retention-days: 1
+      # - name: Upload documentation build artifact
+      #   if: github.ref == 'refs/heads/master'
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: documentation.tar.bz2
+      #     path: documentation.tar.bz2
+      #     retention-days: 1
 
   deploy:
     name: Deploy

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "10.1.2",
+  "version": "10.1.3",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -651,8 +651,7 @@ issue: vets-design-system-documentation#2043
 // Blog-related CSS
 //===================================
 
-
-// Info cards
+// DEPRECATED: Replaced with va-card web component
 .card {
   position: relative;
   margin: 0 0 1.5em 0;


### PR DESCRIPTION
## Description

We have removed .card usages in vets-website and content-build so this PR adds a comment above the class identifying it as deprecated.

## Related Issues & PRs
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2337
- https://github.com/department-of-veterans-affairs/content-build/pull/1888
- https://github.com/department-of-veterans-affairs/vets-website/pull/27541

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
