### PR TITLE
Add CSS Library notation to breakpoints

### DIFF
--- a/packages/formation/sass/base/_b-breakpoints.scss
+++ b/packages/formation/sass/base/_b-breakpoints.scss
@@ -39,6 +39,11 @@ $small: new-breakpoint(min-width $small-screen $grid-columns-small);
 $medium: new-breakpoint(min-width $medium-screen $grid-columns-medium);
 $large: new-breakpoint(min-width $large-screen $grid-columns-large);
 
+/* 
+ADDED TO CSS-LIBRARY
+file: tokens/breakpoints.json
+issue: vets-design-system-documentation#2334
+*/
 // We do a custom override here, setting our site's medium breakpoint to 768 instead of how USWDS defines it at 600.
 $xsmall-screen:       320px; // QVGA display
 $medium-large-screen: 768px;


### PR DESCRIPTION
## Description
We have added the breakpoints to the CSS Library and this just adds a notation in the corresponding Formation file.

- https://github.com/department-of-veterans-affairs/component-library/pull/1042

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
