### PR TITLE
Add repo access instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,7 @@ To fix the `Expected corresponding JSX closing tag for <img>` error, you need to
      - Whitespace push
 
 ##### Example `va.gov-team` PR: https://github.com/department-of-veterans-affairs/va.gov-team/pull/9869
+
+## Not a member of the repository and want to be added?
+- If you're on a VA.gov Platform team, contact your Program Manager.
+- If you're on a VFS team, you must complete [Platform Orientation](https://depo-platform-documentation.scrollhelp.site/getting-started/platform-orientation) to be added to this repository. This includes completing your Platform Orientation ticket(s) in GitHub.


### PR DESCRIPTION
## Description
Adding instructions to README on how to get access to the repo to [align with VA GitHub Handbook](https://github.com/department-of-veterans-affairs/va.gov-team/issues/75538). Please reach out to me if you have any questions.

## Testing done
N/A. Updates to README only.

## Screenshots
N/A. Updates to README only.

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
