### PR TITLE
Refactor: Change $h1-font-size from !important to !default

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "11.0.0-rc1",
+  "version": "11.0.1",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "11.0.0",
+  "version": "11.0.0-rc1",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/formation-overrides/_variables.scss
+++ b/packages/formation/sass/formation-overrides/_variables.scss
@@ -8,7 +8,7 @@ $base-font-size:      1rem !default;
 $small-font-size:     scale-rem(1.4rem) !default;
 $lead-font-size:      scale-rem(2rem) !default;
 $title-font-size:     scale-rem(5.2rem) !default;
-$h1-font-size:        scale-rem(4rem) !important;
+$h1-font-size:        scale-rem(4rem) !default;
 $h2-font-size:        scale-rem(3rem) !default;
 $h3-font-size:        scale-rem(2rem) !default;
 $h4-font-size:        scale-rem(1.7rem) !default;

--- a/packages/formation/sass/mobile-typography.scss
+++ b/packages/formation/sass/mobile-typography.scss
@@ -7,7 +7,7 @@
 @media (max-width: $small-screen)  {
 
   h1 {
-    font-size: 30px;
+    font-size: 30px !important;
   }
 
   h2 {

--- a/packages/formation/sass/mobile-typography.scss
+++ b/packages/formation/sass/mobile-typography.scss
@@ -7,7 +7,7 @@
 @media (max-width: $small-screen)  {
 
   h1 {
-    font-size: 30px !important;
+    font-size: 30px;
   }
 
   h2 {


### PR DESCRIPTION
## Description
This PR updates the `$h1-font-size `variable definition in formation from using the `!important` flag to the `!default` flag.

## Testing done
Manual testing

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
