### PR TITLE
Add rule to warn not to migrate certain models

### DIFF
--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -18,6 +18,7 @@ module.exports = {
     'prefer-button-component': require('./lib/rules/prefer-button-component'),
     'prefer-table-component': require('./lib/rules/prefer-table-component'),
     'prefer-icon-component': require('./lib/rules/prefer-icon-component'),
+    'keep-react-modal': require('./lib/rules/keep-react-modal'),
   },
   configs: {
     recommended: require('./lib/config/recommended'),

--- a/packages/eslint-plugin/lib/config/recommended.js
+++ b/packages/eslint-plugin/lib/config/recommended.js
@@ -190,5 +190,6 @@ module.exports = {
     '@department-of-veterans-affairs/prefer-button-component': 1,
     '@department-of-veterans-affairs/prefer-table-component': 1,
     '@department-of-veterans-affairs/prefer-icon-component': 1,
+    '@department-of-veterans-affairs/keep-react-modal': 1,
   },
 };

--- a/packages/eslint-plugin/lib/rules/keep-react-modal.js
+++ b/packages/eslint-plugin/lib/rules/keep-react-modal.js
@@ -1,0 +1,28 @@
+const jsxAstUtils = require('jsx-ast-utils');
+const { elementType } = jsxAstUtils;
+
+// this will only show in /platform/forms/save-in-progress and platform/user/authentication
+const MESSAGE =
+  'DO NOT MIGRATE this React Modal to the web component version.';
+
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    fixable: 'code',
+  },
+  
+  create(context) {
+      return {
+        JSXOpeningElement(node) {
+            // Exit early if we aren't on an Modal component
+            if (elementType(node) !== 'Modal') return;
+                
+            context.report({
+              node,
+              message: MESSAGE,
+            });
+          },
+      };
+    }
+};

--- a/packages/eslint-plugin/tests/lib/rules/keep-react-modal.js
+++ b/packages/eslint-plugin/tests/lib/rules/keep-react-modal.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const rule = require('../../../lib/rules/keep-react-modal');
+const RuleTester = require('eslint').RuleTester;
+
+const parserOptions = {
+  ecmaVersion: 2018,
+  sourceType: 'module',
+  ecmaFeatures: {
+    jsx: true,
+  },
+};
+
+const ruleTester = new RuleTester({ parserOptions });
+
+ruleTester.run('keep-react-modal', rule, {
+  valid: [
+    {
+      code: `
+        const modal = () => (<va-modal
+          id="cancel"
+          onClick={handlers.onCancel}
+          text="Cancel"
+        />)
+      `,
+    }
+  ],
+  invalid: [
+    {
+      code: `
+        const modal = () => (
+          <Modal
+          cssClass="foo"
+          id="bar"
+          title="Title"
+          onClose={() => this.toggleModal}
+        >
+          <p>Modal content</p>
+        </Modal>
+        )
+      `,
+      errors: [
+        {
+          message:
+            'DO NOT MIGRATE this React Modal to the web component version.'
+        },
+      ],
+    }
+  ],
+});


### PR DESCRIPTION
## Description
Add a warning not to migrate React Modals that need to remain for the injected header. This will only show in certain directories based on `.eslintrc` files in `vets-website`.

## Testing done
Added test. Tested eslint in vet-website locally.

## Screenshots
![Screenshot 2024-04-10 at 14 42 34](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/1413938/cf35cde9-de96-4fc3-ae15-6cb1bddfbdcb)

## Acceptance criteria
- [ ] Add warning not to upgrade Modals

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
