### PR TITLE
Comment out eslint rule around aliasing until Cypress is reconfigured…

### DIFF
--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -13,7 +13,7 @@ module.exports = {
     'telephone-contact-digits': require('./lib/rules/telephone-contact-digits'),
     'deprecated-classes': require('./lib/rules/deprecated-classes'),
     'use-new-utility-classes': require('./lib/rules/use-new-utility-classes'),
-    'use-workspace-imports': require('./lib/rules/use-workspace-imports'),
+    // 'use-workspace-imports': require('./lib/rules/use-workspace-imports'), // Commented out until Cypress is reconfigured to support these aliases.
     'remove-expanding-group': require('./lib/rules/remove-expanding-group'),
     'prefer-button-component': require('./lib/rules/prefer-button-component'),
     'prefer-table-component': require('./lib/rules/prefer-table-component'),


### PR DESCRIPTION
## Summary

- disables the linting rule throwing warnings for aliases not being used that are not supported by Cypress. This was commented as we should reimplement it once Cypress config is adjusted to support these aliases and we make an effort to correct these. However in the interim, these warnings number in the thousands and is likely slowing down CI.
