### PR TITLE
Bump eslint-plugin version to 1.16.0

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/eslint-plugin",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "ESLint plugin for va.gov projects",
   "homepage": "https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/tree/master/packages/eslint-plugin#readme",
   "bugs": {


### PR DESCRIPTION
## Description
Bump eslint-plugin version to 1.16.0 to release the updated React Modal eslint rule
