### PR TITLE
Comment out use-workspace-imports to unblock vets-website commits

### DIFF
--- a/packages/eslint-plugin/lib/config/recommended.js
+++ b/packages/eslint-plugin/lib/config/recommended.js
@@ -185,7 +185,7 @@ module.exports = {
     '@department-of-veterans-affairs/prefer-telephone-component': 1,
     '@department-of-veterans-affairs/telephone-contact-digits': 1,
     '@department-of-veterans-affairs/deprecated-classes': 1,
-    '@department-of-veterans-affairs/use-workspace-imports': 1,
+    // '@department-of-veterans-affairs/use-workspace-imports': 1, // Commented out until Cypress is reconfigured to support these aliases.
     '@department-of-veterans-affairs/remove-expanding-group': 1,
     '@department-of-veterans-affairs/prefer-button-component': 1,
     '@department-of-veterans-affairs/prefer-table-component': 1,

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/eslint-plugin",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "ESLint plugin for va.gov projects",
   "homepage": "https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/tree/master/packages/eslint-plugin#readme",
   "bugs": {


### PR DESCRIPTION
## Description
Follow up to [PR #1028](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/1028). Only commenting a rule out in index.js is causing an error when trying to commit to `vets-website`:

`error    Definition for rule '@department-of-veterans-affairs/use-workspace-imports' was not found  @department-of-veterans-affairs/use-workspace-imports`

It appears the reference in `recommended.js` is causing this error which prevents git commits. Commenting it out here fixes the issue when tested locally.

## Testing done
Tested committing to `vets-website` before and after the change
