### PR TITLE
Update va-icon name prop migration guidance with icon name mapping link

### DIFF
--- a/packages/eslint-plugin/lib/rules/prefer-icon-component.js
+++ b/packages/eslint-plugin/lib/rules/prefer-icon-component.js
@@ -44,7 +44,7 @@ module.exports = {
                 fixer.insertTextAfter(iconNode.name, ` size={4}`),
 
                 //  add the icon prop
-                fixer.insertTextAfter(iconNode.name, ` icon="see Storybook for icon names: https://design.va.gov/storybook/?path=/docs/uswds-va-icon--default"`),
+                fixer.insertTextAfter(iconNode.name, ` icon="see name mappings here https://design.va.gov/foundation/icons"`),
 
                 // re-adding classes without font awesome classes
                 classNameClasses && fixer.replaceText(classNameProp, `className="${classNameClasses}"`),

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/eslint-plugin",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "description": "ESLint plugin for va.gov projects",
   "homepage": "https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/tree/master/packages/eslint-plugin#readme",
   "bugs": {

--- a/packages/eslint-plugin/tests/lib/rules/prefer-icon-component.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-icon-component.js
@@ -17,7 +17,7 @@ ruleTester.run('prefer-icon-component', rule, {
   valid: [
     {
       code: `
-      const phone = () => (<va-icon size={4} icon="see Storybook for icon names: https://design.va.gov/storybook/?path=/docs/uswds-va-icon--default" srtext="phone" />)
+      const phone = () => (<va-icon size={4} icon="see name mappings here https://design.va.gov/foundation/icons" srtext="phone" />)
       `,
     },
     {
@@ -43,7 +43,7 @@ ruleTester.run('prefer-icon-component', rule, {
         },
       ],
       output: `
-        const phone = () => (<va-icon size={4} icon="see Storybook for icon names: https://design.va.gov/storybook/?path=/docs/uswds-va-icon--default\" srtext="phone" className="vads-u-margin-right--1" aria-hidden="true" />)
+        const phone = () => (<va-icon size={4} icon="see name mappings here https://design.va.gov/foundation/icons\" srtext="phone" className="vads-u-margin-right--1" aria-hidden="true" />)
       `,
     },
     {
@@ -57,7 +57,7 @@ ruleTester.run('prefer-icon-component', rule, {
         },
       ],
       output: `
-        const phone = () => (<va-icon size={4} icon="see Storybook for icon names: https://design.va.gov/storybook/?path=/docs/uswds-va-icon--default" srtext="phone"   aria-hidden="true" />)
+        const phone = () => (<va-icon size={4} icon="see name mappings here https://design.va.gov/foundation/icons" srtext="phone"   aria-hidden="true" />)
       `,
     },
     {
@@ -71,7 +71,7 @@ ruleTester.run('prefer-icon-component', rule, {
         },
       ],
       output: `
-        const phone = () => (<va-icon size={4} icon="see Storybook for icon names: https://design.va.gov/storybook/?path=/docs/uswds-va-icon--default" srtext="phone"   />)
+        const phone = () => (<va-icon size={4} icon="see name mappings here https://design.va.gov/foundation/icons" srtext="phone"   />)
       `,
     },
   ],


### PR DESCRIPTION
## Description

We have a Font Awesome to USWDS [name mapping table](https://design.va.gov/foundation/icons) available now so this PR will update the Storybook link to the mapping tables

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
