### PR TITLE
hard code height and width of search icon svg in px for teamsites

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "11.0.1",
+  "version": "11.0.2",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/base/_b-variables.scss
+++ b/packages/formation/sass/base/_b-variables.scss
@@ -32,7 +32,7 @@ $h6-font-size:        scale-rem(1.5rem);
 //===================================
 
 $text-max-width:      scale-rem(70rem); // Note: USWDS value is 53rem;
-$site-max-width:      scale-rem(100rem); // Worksout to about 1000px. USWDS value is 1040px
+$site-max-width:      1000px; //USWDS value is 1040px
 
 
 //================

--- a/packages/formation/sass/modules/_m-button.scss
+++ b/packages/formation/sass/modules/_m-button.scss
@@ -112,10 +112,10 @@ button.short {
 
     @include media($medium-large-screen) {
       display: block;
-      height: scale-rem(1.5rem);
+      height: 15px;
       margin-right: scale-rem(0.25rem);
       pointer-events: none;
-      width: scale-rem(1.5rem);
+      width: 15px;
     }
   }
 }

--- a/packages/formation/sass/modules/_m-button.scss
+++ b/packages/formation/sass/modules/_m-button.scss
@@ -113,7 +113,7 @@ button.short {
     @include media($medium-large-screen) {
       display: block;
       height: 15px;
-      margin-right: scale-rem(0.25rem);
+      margin-right: 2.5px;
       pointer-events: none;
       width: 15px;
     }

--- a/packages/formation/sass/modules/_m-dropdown.scss
+++ b/packages/formation/sass/modules/_m-dropdown.scss
@@ -6,12 +6,12 @@
   // This should always be a button element
   &-trigger {
     background: transparent url('#{$formation-image-path}/arrow-down-white.svg') no-repeat;
-    background-position: right scale-rem(.8rem) center;
-    background-size: scale-rule(1rem 1rem);
+    background-position: right 8px center;
+    background-size: 10px 10px;
     border-radius: 0;
     border-top: 3px solid transparent;
     margin: 0;
-    padding: scale-rule(.9rem 2.5rem .8rem .8rem);
+    padding: 9px 25px 8px 8px;
 
     &:hover {
       background-color: $color-primary;


### PR DESCRIPTION
## Description
Hard code in px the height and width of the size of the "search" icon in the header to make the injected header on teamsites look the same as the header on va.gov.

## Testing done
local testing

## Screenshots
**search icon in header before**:

<img width="361" alt="Screenshot 2024-04-30 at 3 14 04 PM" src="https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/8867779/c29ed7b5-6be3-4053-bff0-549dda61760d">

**search icon in header after**:
<img width="297" alt="Screenshot 2024-04-30 at 3 14 34 PM" src="https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/8867779/31fe2e00-6541-4951-8fda-28e82f91780e">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
