### PR TITLE
Add va-icon eslint rule with message only

### DIFF
--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -17,7 +17,7 @@ module.exports = {
     'remove-expanding-group': require('./lib/rules/remove-expanding-group'),
     'prefer-button-component': require('./lib/rules/prefer-button-component'),
     'prefer-table-component': require('./lib/rules/prefer-table-component'),
-    'prefer-icon-component': require('./lib/rules/prefer-icon-component'),
+    'prefer-icon-component-message': require('./lib/rules/prefer-icon-component-message'),
     'keep-react-modal': require('./lib/rules/keep-react-modal'),
   },
   configs: {

--- a/packages/eslint-plugin/lib/config/recommended.js
+++ b/packages/eslint-plugin/lib/config/recommended.js
@@ -189,7 +189,7 @@ module.exports = {
     '@department-of-veterans-affairs/remove-expanding-group': 1,
     '@department-of-veterans-affairs/prefer-button-component': 1,
     '@department-of-veterans-affairs/prefer-table-component': 1,
-    '@department-of-veterans-affairs/prefer-icon-component': 1,
+    '@department-of-veterans-affairs/prefer-icon-component-message': 1,
     '@department-of-veterans-affairs/keep-react-modal': 1,
   },
 };

--- a/packages/eslint-plugin/lib/rules/prefer-icon-component-message.js
+++ b/packages/eslint-plugin/lib/rules/prefer-icon-component-message.js
@@ -1,0 +1,34 @@
+const jsxAstUtils = require('jsx-ast-utils');
+
+const { elementType, getProp, getLiteralPropValue } = jsxAstUtils;
+
+const MESSAGE =
+  'The <va-icon> Web Component should be used instead of Font Awesome. See: https://design.va.gov/about/developers/using-web-components#how-to-migrate-from-font-awesome-to-va-icon';
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    fixable: 'code',
+  },
+
+  create(context) {
+    return {
+      JSXElement(node) {
+        const iconNode = node.openingElement;
+        const classNameProp = getProp(iconNode.attributes, 'className');
+        const classValue = getLiteralPropValue(classNameProp);
+
+        const isFontAwesomeIcon = classValue && classValue.includes('fa-') || elementType(iconNode) === 'i';
+
+        if (!isFontAwesomeIcon) return;
+
+        context.report({
+          node,
+          message: MESSAGE,
+        });
+
+      },
+    };
+  },
+};
+

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/eslint-plugin",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "description": "ESLint plugin for va.gov projects",
   "homepage": "https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/tree/master/packages/eslint-plugin#readme",
   "bugs": {

--- a/packages/eslint-plugin/tests/lib/rules/prefer-icon-component-message.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-icon-component-message.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const rule = require('../../../lib/rules/prefer-icon-component-message');
+const RuleTester = require('eslint').RuleTester;
+
+const parserOptions = {
+  ecmaVersion: 2018,
+  // sourceType: 'module',
+  ecmaFeatures: {
+    jsx: true,
+  },
+};
+
+const ruleTester = new RuleTester({ parserOptions });
+
+ruleTester.run('prefer-icon-component-message', rule, {
+  valid: [
+    {
+      code: `
+      const icon = () => (<va-icon size={4} icon="see name mappings here https://design.va.gov/foundation/icons" srtext="phone" />)
+      `,
+    },
+    {
+      code: `
+        const icon = () => (<va-icon size={4} icon="star" />)
+      `,
+    },
+    {
+      code: `
+        const icon = () => (<va-icon size={4} icon="star" className="vads-u-margin-right--1" />)
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        const icon = () => (<i aria-label="phone" className="fas fa-phone vads-u-color--link-default vads-u-margin-right--1" aria-hidden="true" />)
+      `,
+      errors: [
+        {
+          message:
+            'The <va-icon> Web Component should be used instead of Font Awesome. See: https://design.va.gov/about/developers/using-web-components#how-to-migrate-from-font-awesome-to-va-icon',
+        },
+      ],
+    },
+    {
+      code: `
+        const icon = () => (<i aria-label="phone" role="img" className="fas fa-phone" aria-hidden="true" />)
+      `,
+      errors: [
+        {
+          message:
+            'The <va-icon> Web Component should be used instead of Font Awesome. See: https://design.va.gov/about/developers/using-web-components#how-to-migrate-from-font-awesome-to-va-icon',
+        },
+      ],
+    },
+    {
+      code: `
+        const icon = () => (<i aria-label="phone" alt="alt stuff" className="fas fa-phone" />)
+      `,
+      errors: [
+        {
+          message:
+            'The <va-icon> Web Component should be used instead of Font Awesome. See: https://design.va.gov/about/developers/using-web-components#how-to-migrate-from-font-awesome-to-va-icon',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Description

We're adding a separate eslint rule for va-icon that will just display a message instead of a [migration script.](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/1025) We realized that the migration was happening during `git commit` unexpectedly and it was causing confusion. 

For now, this message only eslint rule can be used until we're ready to replace it with the migration script.

This PR also removes the original migration rule `prefer-icon-component` from being loaded completely so it should not be connected whatsoever in vets-website until added back here again.

## Testing done
Locally

## Screenshots

![Screenshot 2024-05-01 at 12 16 26 PM](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/872479/1d35c8aa-5ec3-42ec-b4dd-160c32d1bbcb)

![Screenshot 2024-05-01 at 12 16 32 PM](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/872479/1f47da0d-65c7-4266-a07b-f4ee464bf013)

related issue: https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2534

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
