### PR TITLE
modify units function to use scale rem helper

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "11.0.2",
+  "version": "11.0.3",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/base/_b-functions.scss
+++ b/packages/formation/sass/base/_b-functions.scss
@@ -1,3 +1,4 @@
+@import '../override-function';
 @charset "UTF-8";
 
 /// Returns a media context (media query / grid context) that can be stored in a variable and passed to `media()` as a single-keyword argument. Media contexts defined using `new-breakpoint` are used by the visual grid, as long as they are defined before importing Neat.
@@ -175,7 +176,8 @@
   }
 
   $val: map-get($units, $unit) ;
-  @return $val + rem;
+  $remVal: $val + rem;
+  @return scale-rem($remVal);
 }
 
 @function units-px($unit) {


### PR DESCRIPTION
## Description
Modifies the `units()` helper to use scale-rem before returning the value. 

## Testing
- local testing with verdaccio shows that the update here scales rem correctly down to 0.75rem, and that computed font-size value is identical to staging:

<details><summary>Local /health-care/refill-track-prescriptions/ page</summary>

![image](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/15097156/2673377f-bd77-44f1-bdd2-bfdc9dd3de33)

</details>


<details><summary>Staging /health-care/refill-track-prescriptions/ page </summary>

![Screenshot from 2024-05-07 08-30-04](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/15097156/8b05598a-4fd3-4899-b97d-432d245b6d22)

</details>