### PR TITLE
updates to make injected header render correctly

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "11.0.3",
+  "version": "11.0.4",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -616,7 +616,7 @@ li {
 
   &-inner {
     margin: auto;
-    max-width: scale-rem(97.5rem);
+    max-width: 1000px;
     position: relative;
   }
 }

--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -629,7 +629,6 @@ issue: vets-design-system-documentation#2043
 .va-notice--banner {
   p {
     margin: 0;
-    font-size: scale-rem(1.2rem); //fixes official website of US Gov banner text
   }
 
   a {

--- a/packages/formation/sass/formation-overrides/components/_banner.scss
+++ b/packages/formation/sass/formation-overrides/components/_banner.scss
@@ -21,8 +21,8 @@
     width: 100%;
   
     @include media($medium-screen) {
-      padding-bottom: scale-rem(2.3rem);
-      padding-top: scale-rem(4rem);
+      padding-bottom: 23px;
+      padding-top: 40px;
     }
   
     @include media($nav-width) {
@@ -77,8 +77,8 @@
       width: scale-rem(2.4rem);
   
       @include media($small-screen) {
-        margin-right: scale-rem(0.7rem);
-        width: scale-rem(2rem);
+        margin-right: 7px;
+        width: 20px;
       }
     }
   }
@@ -129,11 +129,11 @@
   
   .usa-banner-button {
     @include button-unstyled;
-    @include padding(scale-rem(1.3rem) null null scale-rem(4.8rem));
+    @include padding(13px null null 48px);
     background-position-x: right;
     color: $color-primary;
     display: block;
-    font-size: scale-rem(1.2rem);
+    font-size: 12px;
     height: scale-rem(4.3rem);
     left: 0;
     position: absolute;
@@ -204,6 +204,6 @@
   }
   
   .usa-banner-icon {
-    width: scale-rem(3.8rem);
+    width: 38px;
   }
   

--- a/packages/formation/sass/formation-overrides/components/_forms.scss
+++ b/packages/formation/sass/formation-overrides/components/_forms.scss
@@ -7,7 +7,7 @@ $usa-form-width: scale-rem(32rem);
 
 [type=submit] {
   @include media($medium-screen) {
-    margin-top: calc(scale-rem(3rem) - .2em); // Label margin minus input bottom margin
+    margin-top: scale-rule(calc(3rem - .2em)); // Label margin minus input bottom margin
   }
 }
 

--- a/packages/formation/sass/formation-overrides/elements/_inputs.scss
+++ b/packages/formation/sass/formation-overrides/elements/_inputs.scss
@@ -27,17 +27,17 @@ input,
 textarea,
 select {
   appearance: none;
-  border: $input-border-width solid $color-gray;
+  border: 1px solid $color-gray;
   border-radius: 0;
   box-sizing: border-box;
   color: $color-base; // standardize on firefox
   display: block;
-  font-size: $base-font-size;
-  height: $input-height;
+  font-size: 16px;
+  height: 42px;
   line-height: $input-line-height;
   margin: 0.2em 0;
-  max-width: $input-max-width;
-  padding: $input-padding-vertical 0.7em;
+  max-width: 460px;
+  padding: 10px 11.2px;
   width: 100%;
 
   &.usa-input-success {

--- a/packages/formation/sass/modules/_m-form-elements.scss
+++ b/packages/formation/sass/modules/_m-form-elements.scss
@@ -200,8 +200,8 @@ legend.legend-label + .form-checkbox-buttons {
 
 .form-expanding-group > span {
   .usa-input-error {
-    padding-left: calc(scale-rem(1.5rem) - 6px);
-    right: calc(scale-rem(1.9rem) - 6px);
+    padding-left: scale-rule(calc(1.5rem - 6px));
+    right: scale-rule(calc(1.9rem - 6px));
   }
   .schemaform-expandUnder-indent {
     .usa-input-error {
@@ -217,7 +217,7 @@ legend.legend-label + .form-checkbox-buttons {
 }
 
 .form-expanding-group-open {
-  padding-left: calc(#{scale-rem(2rem)} - 7px);
+  padding-left: scale-rule(calc(2rem - 7px));
   border-left: 7px solid $color-primary-alt-light;
 
   // Avoid nested expanding group borders

--- a/packages/formation/sass/modules/_m-megamenu.scss
+++ b/packages/formation/sass/modules/_m-megamenu.scss
@@ -92,7 +92,7 @@ $marketing-container-height: 380px;
     .vetnav-panel--submenu:not([hidden]) {
       position: absolute;
       box-shadow: none;
-      width: scale-rem(26rem);
+      width: 260px;
       padding: 72px 0px 0px 28px;
       white-space: normal;
 
@@ -100,7 +100,7 @@ $marketing-container-height: 380px;
         display: block;
         color: $color-black;
         font-family: Source Sans Pro, sans serif;
-        font-size: scale-rem(1.6rem);
+        font-size: 16px;
         font-weight: bold;
         margin-top: 4px;
         padding: 0;
@@ -168,7 +168,7 @@ $marketing-container-height: 380px;
 
       &.vetnav-panel--submenu:not([hidden]) {
         padding: 86px 20px 20px 14px;
-        width: scale-rem(24rem);
+        width: 240px;
 
         &.panel-white {
           padding-top: 30px;
@@ -253,7 +253,7 @@ $marketing-container-height: 380px;
     .vetnav-panel--submenu:not([hidden]) {
       h3 {
         font-family: Source Sans Pro, sans serif;
-        font-size: scale-rem(1.6rem);
+        font-size: 16px;
       }
     }
   }
@@ -310,7 +310,7 @@ $marketing-container-height: 380px;
       position: absolute;
       height: 60px;
       width: $medium-large-screen - 297px;
-      left: scale-rem(28rem);
+      left: 280px;
       border-bottom: 1px solid #d0d0d0;
       z-index: 3;
       top: 0;
@@ -343,11 +343,11 @@ $marketing-container-height: 380px;
     }
 
     .column-one {
-      width: scale-rem(26rem);
+      width: 260px;
     }
 
     .column-two {
-      width: scale-rem(26rem);
+      width: 260px;
     }
 
     .column-three {

--- a/packages/formation/sass/site/_m-vet-nav.scss
+++ b/packages/formation/sass/site/_m-vet-nav.scss
@@ -120,7 +120,7 @@ body.va-pos-fixed {
   }
 
   .usa-button-secondary {
-    padding: calc(scale-rem(1rem) + 2px);
+    padding: scale-rule(calc(1rem + 2px));
     margin: scale-rule(0.8rem 1.6rem);
     width: auto;
     background-color: $color-gray-lightest;

--- a/packages/formation/sass/site/_m-vet-nav.scss
+++ b/packages/formation/sass/site/_m-vet-nav.scss
@@ -1,5 +1,3 @@
-// appears to be unused by header in vets-website
-
 @import '../override-function';
 
 // The distance from the top of the sceen that the mobile navigation menu should appear


### PR DESCRIPTION
## Description
This PR adds fixes to make the injected teamsites header render correctly.

related https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2730

## Testing done
Local testing with verdaccio / vets-website.

## Screenshots
<img width="1003" alt="Screenshot 2024-05-08 at 8 51 44 AM" src="https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/8867779/423005c1-9fdf-4f68-985c-12281a967498">

<hr/>

<img width="1101" alt="Screenshot 2024-05-08 at 8 54 50 AM" src="https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/8867779/bda201b8-cc96-4354-92ca-7cf5e395502f">

<hr /> 

<img width="428" alt="Screenshot 2024-05-08 at 8 58 24 AM" src="https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/8867779/fc93720a-c059-416c-b5ff-485110937138">

<hr />

<img width="1021" alt="Screenshot 2024-05-08 at 8 59 36 AM" src="https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/8867779/a0050ef8-9db5-49d6-af12-fa9dd4a84144">

### government banner font size

**before**
![Screenshot 2024-05-07 at 2 31 21 PM](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/872479/15eb1b2b-edb8-484b-a4d2-e084f1cdbda4)

**after**

![Screenshot 2024-05-07 at 2 31 25 PM](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/872479/234378af-c22f-4a62-aea7-23115d401a9e)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
