### PR TITLE
Formation: update megamenu marketing text card font-size

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "11.0.7",
+  "version": "11.0.8",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/formation-overrides/elements/_typography.scss
+++ b/packages/formation/sass/formation-overrides/elements/_typography.scss
@@ -80,27 +80,46 @@ h6 {
 
 h1 {
   @include h1();
+  a {
+    @include h1();
+  }
 }
 
 h2 {
   @include h2();
+  a {
+    @include h2();
+  }
 }
 
 h3 {
   @include h3();
+  a {
+    @include h3();
+  }
 }
 
 h4 {
   @include h4();
+  a {
+    @include h4();
+  }
 }
 
 h5 {
   @include h5();
+  a {
+    @include h5();
+  }
 }
 
 h6 {
   @include h6();
   font-family: $font-sans;
+  a {
+    @include h6();
+    font-family: $font-sans;
+  }
 }
 
 // Remove user agent styles

--- a/packages/formation/sass/modules/_m-megamenu.scss
+++ b/packages/formation/sass/modules/_m-megamenu.scss
@@ -231,7 +231,7 @@ $marketing-container-height: 380px;
     }
 
     p {
-      font-size: 13.2px;
+      font-size: 16px;
       margin-top: 5px;
     }
   }


### PR DESCRIPTION
## Description
We got [feedback from QA review](https://dsva.slack.com/archives/C06V7AAFVH7/p1718743093470589?thread_ts=1718742362.995919&cid=C06V7AAFVH7) that the megamenu marketing card paragraph font size was too small. 

This also adds header style to linked headers.

related pr https://github.com/department-of-veterans-affairs/vets-website/pull/30089
related issue https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2909

## Testing done
locally

## Screenshots

**before**

![Screenshot 2024-06-18 at 3 49 40 PM](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/872479/d181c778-ec00-4c0f-bf61-e1d45da60814)

**after**

![Screenshot 2024-06-18 at 3 49 24 PM](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/872479/958efb99-2a0b-4d24-823d-a9f1d30c0cba)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
