### PR TITLE
2931 Add prefer-icon-component rule to eslint-plugin/index.js file

### DIFF
--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -17,7 +17,6 @@ module.exports = {
     'remove-expanding-group': require('./lib/rules/remove-expanding-group'),
     'prefer-button-component': require('./lib/rules/prefer-button-component'),
     'prefer-table-component': require('./lib/rules/prefer-table-component'),
-    'prefer-icon-component-message': require('./lib/rules/prefer-icon-component-message'),
     'keep-react-modal': require('./lib/rules/keep-react-modal'),
     'prefer-icon-component': require('./lib/rules/prefer-icon-component'),
   },

--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -19,6 +19,7 @@ module.exports = {
     'prefer-table-component': require('./lib/rules/prefer-table-component'),
     'prefer-icon-component-message': require('./lib/rules/prefer-icon-component-message'),
     'keep-react-modal': require('./lib/rules/keep-react-modal'),
+    'prefer-icon-component': require('./lib/rules/prefer-icon-component'),
   },
   configs: {
     recommended: require('./lib/config/recommended'),

--- a/packages/eslint-plugin/lib/config/recommended.js
+++ b/packages/eslint-plugin/lib/config/recommended.js
@@ -189,7 +189,7 @@ module.exports = {
     '@department-of-veterans-affairs/remove-expanding-group': 1,
     '@department-of-veterans-affairs/prefer-button-component': 1,
     '@department-of-veterans-affairs/prefer-table-component': 1,
-    '@department-of-veterans-affairs/prefer-icon-component-message': 1,
+    '@department-of-veterans-affairs/prefer-icon-component': 1,
     '@department-of-veterans-affairs/keep-react-modal': 1,
   },
 };

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/eslint-plugin",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "description": "ESLint plugin for va.gov projects",
   "homepage": "https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/tree/master/packages/eslint-plugin#readme",
   "bugs": {


### PR DESCRIPTION
## Description
- Add prefer-icon-component rule to eslint-plugin/index.js file
- Bump package.json version for eslint-plugin/package.json

## Acceptance criteria
- [ ] eslint rule has been added

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
