### PR TITLE
Formation: add font-family to linked header styles

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "11.0.8",
+  "version": "11.0.9",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/formation-overrides/elements/_typography.scss
+++ b/packages/formation/sass/formation-overrides/elements/_typography.scss
@@ -82,6 +82,7 @@ h1 {
   @include h1();
   a {
     @include h1();
+    font-family: $font-serif;
   }
 }
 
@@ -89,6 +90,7 @@ h2 {
   @include h2();
   a {
     @include h2();
+    font-family: $font-serif;
   }
 }
 
@@ -96,6 +98,7 @@ h3 {
   @include h3();
   a {
     @include h3();
+    font-family: $font-serif;
   }
 }
 
@@ -103,6 +106,7 @@ h4 {
   @include h4();
   a {
     @include h4();
+    font-family: $font-serif;
   }
 }
 
@@ -110,6 +114,7 @@ h5 {
   @include h5();
   a {
     @include h5();
+    font-family: $font-serif;
   }
 }
 


### PR DESCRIPTION
## Description

Sometimes a header is linked so it includes the `a` element. With the font normalization styles being applied from the CSS Library, this was causing a regression with the header styles which have distinct sizing and font-family. This update will make sure that anchor links used inside of header tags will have the "Bitter" serif font.

## Testing done


## Screenshots

**before**

![Screenshot 2024-06-20 at 12 57 35 PM](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/872479/827cf755-8ae5-4069-ba6e-440fba8eb5d4)

**after**

![Screenshot 2024-06-20 at 1 06 05 PM](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/872479/ae206f7a-7df3-4f1d-bd57-beaa084be0e6)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
