### PR TITLE
Formation: add sign-in button line-height

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "11.0.10",
+  "version": "11.0.11",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/site/_m-vet-nav.scss
+++ b/packages/formation/sass/site/_m-vet-nav.scss
@@ -422,6 +422,7 @@ body.va-pos-fixed {
 
   .va-dropdown,
   .sign-in-link {
+    line-height: 16px;
     margin-left: scale-rem(1rem);
   }
 

--- a/packages/formation/sass/site/_m-vet-nav.scss
+++ b/packages/formation/sass/site/_m-vet-nav.scss
@@ -422,7 +422,6 @@ body.va-pos-fixed {
 
   .va-dropdown,
   .sign-in-link {
-    line-height: 16px;
     margin-left: scale-rem(1rem);
   }
 
@@ -432,6 +431,7 @@ body.va-pos-fixed {
 }
 
 .sign-in-link {
+  line-height: 16px;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
## Description

The sign-in button needs a line-height added because the normalization default line-height of 1.5 was creating too much spacing compared to prod. The value added is the line-height value calculated from prod.

## Testing done


## Screenshots

**before**

![Screenshot 2024-06-24 at 12 45 06 PM](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/872479/bef7a0c6-70da-447a-a7de-af2d5cd4a952)

**after**

![Screenshot 2024-06-24 at 12 45 14 PM](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/872479/126fac8d-4abe-4294-adcc-405b7169bb52)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
