### PR TITLE
add a tag to va-introtext styles

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "11.0.11",
+  "version": "11.0.12",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/base/_va.scss
+++ b/packages/formation/sass/base/_va.scss
@@ -417,7 +417,7 @@ article > h1 {
   line-height: $lead-line-height;
   max-width: $lead-max-width;
 
-  p {
+  p, a {
     font-family: $font-serif;
     font-size: $lead-font-size;
     font-weight: $font-weight-normal;


### PR DESCRIPTION
## Description
Original issue - https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2981

## Testing done
Local testing with verdaccio to confirm the fix works

## Screenshots
![Screenshot from 2024-06-28 12-28-34](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/assets/15097156/99587d32-fb1a-4738-bd2c-775cafb9ae95)


## Acceptance criteria
- [ ]

## Definition of done
- [x] Changes have been tested in vets-website
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
