### PR TITLE
CSS Library - Utilities - Swap background-color and color imports 

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "11.1.0rm1",
+  "version": "11.0.13",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "11.0.12",
+  "version": "11.1.0rm1",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/core.scss
+++ b/packages/formation/sass/core.scss
@@ -81,9 +81,9 @@
 @import 'layout/flex-grid';
 
 // ----- VA UTILITIES (UTILITIY OOCSS) ---- //
-@import 'utilities/background-color';
+// @import 'utilities/background-color';  // [x]
 @import 'utilities/border';
-@import 'utilities/color';
+// @import 'utilities/color';  //  [x]
 @import 'utilities/display';
 @import 'utilities/flexbox';
 @import 'utilities/font-family';

--- a/packages/formation/sass/core.scss
+++ b/packages/formation/sass/core.scss
@@ -81,9 +81,7 @@
 @import 'layout/flex-grid';
 
 // ----- VA UTILITIES (UTILITIY OOCSS) ---- //
-// @import 'utilities/background-color';  // [x]
 @import 'utilities/border';
-// @import 'utilities/color';  //  [x]
 @import 'utilities/display';
 @import 'utilities/flexbox';
 @import 'utilities/font-family';


### PR DESCRIPTION
## Description
Removes imports for `utilities/color` and `utilities/background-color` as per [#3060](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3060)

## Testing done
Locally with yarn test
Locally with Verdaccio
## Screenshots


## Acceptance criteria
- [x] no changes observed, as expected, after updates

## Definition of done
- [x] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
