### PR TITLE
CSS Library - Utilities - comment out  background-color and color imports

### DIFF
--- a/packages/formation/README.md
+++ b/packages/formation/README.md
@@ -11,3 +11,5 @@ Also included is a full build of all the styles, including component styles, at 
 ## Assets
 
 Image and font assets used by Formation are included in the `dist` folder.
+
+JUST A QUICK TEST!!!

--- a/packages/formation/sass/core.scss
+++ b/packages/formation/sass/core.scss
@@ -81,9 +81,9 @@
 @import 'layout/flex-grid';
 
 // ----- VA UTILITIES (UTILITIY OOCSS) ---- //
-@import 'utilities/background-color';
+// @import 'utilities/background-color';  
 @import 'utilities/border';
-@import 'utilities/color';
+// @import 'utilities/color';
 @import 'utilities/display';
 @import 'utilities/flexbox';
 @import 'utilities/font-family';

--- a/packages/formation/sass/core.scss
+++ b/packages/formation/sass/core.scss
@@ -81,9 +81,9 @@
 @import 'layout/flex-grid';
 
 // ----- VA UTILITIES (UTILITIY OOCSS) ---- //
-@import 'utilities/background-color';
+// @import 'utilities/background-color';
 @import 'utilities/border';
-@import 'utilities/color'
+//@import 'utilities/color'
 ;@import 'utilities/display';
 @import 'utilities/flexbox';
 @import 'utilities/font-family';

--- a/packages/formation/sass/core.scss
+++ b/packages/formation/sass/core.scss
@@ -81,8 +81,10 @@
 @import 'layout/flex-grid';
 
 // ----- VA UTILITIES (UTILITIY OOCSS) ---- //
+@import 'utilities/background-color';
 @import 'utilities/border';
-@import 'utilities/display';
+@import 'utilities/color'
+;@import 'utilities/display';
 @import 'utilities/flexbox';
 @import 'utilities/font-family';
 @import 'utilities/font-size';

--- a/packages/formation/sass/core.scss
+++ b/packages/formation/sass/core.scss
@@ -81,10 +81,10 @@
 @import 'layout/flex-grid';
 
 // ----- VA UTILITIES (UTILITIY OOCSS) ---- //
-// @import 'utilities/background-color';
+@import 'utilities/background-color';
 @import 'utilities/border';
-//@import 'utilities/color'
-;@import 'utilities/display';
+@import 'utilities/color';
+@import 'utilities/display';
 @import 'utilities/flexbox';
 @import 'utilities/font-family';
 @import 'utilities/font-size';


### PR DESCRIPTION
## Description
Removes imports for `utilities/color` and `utilities/background-color` as per [#3060](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3060)

## Testing done
Locally with yarn test
Locally with Verdaccio
## Screenshots


## Acceptance criteria
- [x] no changes observed, as expected, after updates

## Definition of done
- [x] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
