### PR TITLE
Comment out measure utility for css-library changeover

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "11.0.13",
+  "version": "11.0.14",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/core.scss
+++ b/packages/formation/sass/core.scss
@@ -93,7 +93,7 @@
 @import 'utilities/height-width';
 @import 'utilities/line-height';
 @import 'utilities/margins';
-@import 'utilities/measure';
+// @import 'utilities/measure';
 @import 'utilities/padding';
 @import 'utilities/position';
 @import 'utilities/text-align';


### PR DESCRIPTION
## Description

This will comment out the Formation measure utilities import so that we can switch it over to CSS Library.

related https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3214

## Testing done
Verdaccio + vets-website

## Screenshots

### before

- Formation utilities loading and taking precedence over CSS Library:

![Screenshot 2024-09-04 at 9 22 19 AM](https://github.com/user-attachments/assets/22992e9e-2519-434b-928b-efc98bec0b37)

### after

- Formation utilities module no longer loading and the CSS Library utility is active:

![Screenshot 2024-09-04 at 9 20 35 AM](https://github.com/user-attachments/assets/04ab1317-f314-4e3f-8b5c-c8ad675fd53d)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
