### PR TITLE
Remove visibility utility import for CSS Library swap and revert important on grid classes

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "11.0.16",
+  "version": "11.0.17",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/base/_b-mixins.scss
+++ b/packages/formation/sass/base/_b-mixins.scss
@@ -189,12 +189,12 @@
 
 // Flexbox columns
 @mixin flexbox-col($size) {
-  flex: 0 0 percentage($size / $grid-columns) !important;
-  max-width: percentage($size / $grid-columns) !important; // IE10+ and Firefox
+  flex: 0 0 percentage($size / $grid-columns);
+  max-width: percentage($size / $grid-columns); // IE10+ and Firefox
 }
 
 @mixin equal-width-flexbox-col() {
-  flex-basis: 0 !important;
-  flex-grow: 1 !important;
-  max-width: 100% !important;
+  flex-basis: 0;
+  flex-grow: 1;
+  max-width: 100%;
 }

--- a/packages/formation/sass/core.scss
+++ b/packages/formation/sass/core.scss
@@ -98,4 +98,4 @@
 @import 'utilities/position';
 @import 'utilities/text-align';
 @import 'utilities/text-decoration';
-@import 'utilities/visibility';
+// @import 'utilities/visibility';


### PR DESCRIPTION
## Description

This will comment out the visibility utilities import so that the CSS Library utilities stylesheet will be used instead.

I'm also reverting the important keyword on the grid utilities because we will need to do a little more testing. [related CSS Library PR](https://github.com/department-of-veterans-affairs/component-library/pull/1318).

related issue https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3218

## Testing done
Locally with Verdaccio

## Screenshots

![hidden](https://github.com/user-attachments/assets/8620e84f-3f1e-4962-83d2-c2e2a011ff5b)

![screen-reader](https://github.com/user-attachments/assets/c0832d4a-6ed5-4e23-8ca2-4b57f6af4906)

![visible](https://github.com/user-attachments/assets/b8fc3d89-7be4-4e8f-be5e-314c58c5c3ad)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
