### PR TITLE
Comment out text-align utilities import for CSS Library import swap

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "11.0.17",
+  "version": "11.0.18",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/core.scss
+++ b/packages/formation/sass/core.scss
@@ -96,6 +96,6 @@
 // @import 'utilities/measure';
 @import 'utilities/padding';
 @import 'utilities/position';
-@import 'utilities/text-align';
+// @import 'utilities/text-align';
 @import 'utilities/text-decoration';
 // @import 'utilities/visibility';


### PR DESCRIPTION
## Description
This will remove the [text-align utilities](https://design.va.gov/foundation/utilities/text-align) import so that the CSS Library imports will be used instead.

## Testing done
locally with Verdaccio

## Screenshots

![Screenshot 2024-09-10 at 9 17 32 AM](https://github.com/user-attachments/assets/bf811f70-8545-45b4-bfdb-de73adbfc873)

![Screenshot 2024-09-10 at 9 17 27 AM](https://github.com/user-attachments/assets/f203b530-d43f-4df0-9526-b51e820977c7)

![Screenshot 2024-09-10 at 9 17 23 AM](https://github.com/user-attachments/assets/529ded8e-948d-44ca-bdfb-1691a7612eee)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
