### PR TITLE
Global | Remove progress-box padding

### DIFF
--- a/packages/formation/sass/_shame.scss
+++ b/packages/formation/sass/_shame.scss
@@ -14,7 +14,7 @@ body {
   // We have no container element, so elements that are full width have to redefine the container layout every time
   // if they want to line up.
   // unused in content-build
-  // Used in vets-website, used in src/platform/monitoring/DowntimeNotification/components/DowntimeApproaching.jsx 
+  // Used in vets-website, used in src/platform/monitoring/DowntimeNotification/components/DowntimeApproaching.jsx
   .row-padded {
     max-width: scale-rem(100rem);
     padding: scale-rule(0 1rem);
@@ -32,7 +32,7 @@ body {
 }
 
 // unused in content-build
-// used in vets-website, used in src/platform/forms-system/src/js/containers/FormApp.jsx 
+// used in vets-website, used in src/platform/forms-system/src/js/containers/FormApp.jsx
 // and src/applications/simple-forms/mock-alternate-header-21-0845/components/CustomFormApp.jsx
 .progress-box {
   button {
@@ -43,7 +43,7 @@ body {
 .progress-box {
   border: 1px solid $color-gray-lightest;
   margin: scale-rule(1.5rem 0);
-  padding: scale-rule(1rem 2rem);
+  padding: scale-rule(1rem 0);
 }
 
 
@@ -76,7 +76,7 @@ body {
 // unused in content-build
 // used in vets-website in src/applications/terms-of-use/components/TermsAcceptanceAction.jsx,
 // src/platform/forms-system/src/js/containers/FormApp.jsx, src/platform/forms-system/src/js/review/submit-states/ClientError.jsx,
-// src/platform/forms-system/src/js/review/submit-states/Pending.jsx, src/platform/forms-system/src/js/review/submit-states/Submitted.jsx, 
+// src/platform/forms-system/src/js/review/submit-states/Pending.jsx, src/platform/forms-system/src/js/review/submit-states/Submitted.jsx,
 // src/platform/forms-system/src/js/review/submit-states/ThrottledError.jsx, src/platform/forms-system/src/js/review/submit-states/ValidationError.jsx
 .hidden {
   display: none !important;

--- a/packages/formation/sass/modules/_m-omb-info.scss
+++ b/packages/formation/sass/modules/_m-omb-info.scss
@@ -2,17 +2,3 @@
 // To avoid double-importing, we're not importing _m-modal.scss,
 //  but if this file is being imported, you'll probably want to include
 //  the modal module as well.
-
-// Align with navigation buttons
-.omb-info--container {
-  padding-left: scale-rem(2rem);
-}
-
-// This media query is matched to the one wrapping .progress-box in edu-benefits.scss
-@media (max-width: 40.063em) {
-  // Match the OMB Info section padding
-  .omb-info--container {
-    // 2rem - .9375rem
-    padding-left: scale-rem(1.0625rem);
-  }
-}


### PR DESCRIPTION
## Description

This PR removes any horizontal padding for `.progress-box` and `.omb-info--container` to better left-align content on the introduction page and within forms. For narrower (mobile) screens, this padding 

- https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/1548 (ticket)
- https://github.com/department-of-veterans-affairs/vets-website/pull/31870 (vets-website)
- https://github.com/department-of-veterans-affairs/component-library/pull/1324 (component library)
- https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/1056 (formation)

## Testing done

Manual/visual testing

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="750" alt="progress-box highlighted in the dev panel showing left & right padding" src="https://github.com/user-attachments/assets/5af3af3a-45a5-468e-867d-676bc7dba088"> | <img width="750" alt="progress-box highlighted in the dev panel showing no left or right padding" src="https://github.com/user-attachments/assets/58632fe8-63db-43d0-baf3-c819958ed4be"> |
| Narrow | <img width="332" alt="320 pixel wide view with progress box padding" src="https://github.com/user-attachments/assets/c2411e5c-ca8c-424b-9d99-077b73bd0057"> | <img width="334" alt="320 pixel wide view with left side content alignment" src="https://github.com/user-attachments/assets/525722a7-48f6-4073-a054-0f33dd79780d"> |

## Acceptance criteria
- [x] `progress-box` horizontal padding removed

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
