### PR TITLE
Comment out position utilities import for CSS Library import swap

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "11.0.18",
+  "version": "11.0.19",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/core.scss
+++ b/packages/formation/sass/core.scss
@@ -95,7 +95,7 @@
 @import 'utilities/margins';
 // @import 'utilities/measure';
 @import 'utilities/padding';
-@import 'utilities/position';
+// @import 'utilities/position';
 // @import 'utilities/text-align';
 @import 'utilities/text-decoration';
 // @import 'utilities/visibility';


### PR DESCRIPTION
## Description
Commenting out the position utilities for changing over to the CSS Library utilities stylesheet.

related issue https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3216

## Testing done
locally with verdaccio

## Screenshots
![Screenshot 2024-09-11 at 12 24 39 PM](https://github.com/user-attachments/assets/3b19f9a7-7495-4294-812f-7a48ecac6916)

![Screenshot 2024-09-11 at 12 24 32 PM](https://github.com/user-attachments/assets/f28bb6fa-5da1-400f-8713-ef76111fe6fc)

![Screenshot 2024-09-11 at 12 24 26 PM](https://github.com/user-attachments/assets/ca70ca64-2d63-462c-8fc3-06fedd47fc71)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
