### PR TITLE
Remove height-width utilities import for css-library changeover

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "11.0.20",
+  "version": "11.0.21",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/core.scss
+++ b/packages/formation/sass/core.scss
@@ -90,7 +90,7 @@
 @import 'utilities/font-size';
 @import 'utilities/font-style';
 @import 'utilities/font-weight';
-@import 'utilities/height-width';
+// @import 'utilities/height-width';
 //@import 'utilities/line-height';
 @import 'utilities/margins';
 // @import 'utilities/measure';

--- a/packages/formation/sass/core.scss
+++ b/packages/formation/sass/core.scss
@@ -91,7 +91,7 @@
 @import 'utilities/font-style';
 @import 'utilities/font-weight';
 // @import 'utilities/height-width';
-//@import 'utilities/line-height';
+// @import 'utilities/line-height';
 @import 'utilities/margins';
 // @import 'utilities/measure';
 @import 'utilities/padding';


### PR DESCRIPTION
## Description

Removing the [height-width utilities](https://design.va.gov/foundation/utilities/height-and-width) import for switching over to the CSS Library.

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3210
- https://github.com/department-of-veterans-affairs/vets-website/pull/31947

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
