### PR TITLE
comment out font related utils

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "11.0.21",
+  "version": "11.0.22",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/core.scss
+++ b/packages/formation/sass/core.scss
@@ -86,10 +86,10 @@
 // @import 'utilities/color';
 @import 'utilities/display';
 @import 'utilities/flexbox';
-@import 'utilities/font-family';
+// @import 'utilities/font-family';
 @import 'utilities/font-size';
-@import 'utilities/font-style';
-@import 'utilities/font-weight';
+// @import 'utilities/font-style';
+// @import 'utilities/font-weight';
 // @import 'utilities/height-width';
 // @import 'utilities/line-height';
 @import 'utilities/margins';
@@ -97,5 +97,5 @@
 @import 'utilities/padding';
 // @import 'utilities/position';
 // @import 'utilities/text-align';
-@import 'utilities/text-decoration';
+// @import 'utilities/text-decoration';
 // @import 'utilities/visibility';


### PR DESCRIPTION
## Description
Comment out font-style, font-family, font-weight, and text-decoration imports. `css-library` will supply these styles to vets-website

issue: https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3198

## Testing done
local testing with verdaccio

## Screenshots
no visual changes

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
