### PR TITLE
Remove padding import from core.scss

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "11.0.22",
+  "version": "11.0.23",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/core.scss
+++ b/packages/formation/sass/core.scss
@@ -94,7 +94,7 @@
 // @import 'utilities/line-height';
 @import 'utilities/margins';
 // @import 'utilities/measure';
-@import 'utilities/padding';
+// @import 'utilities/padding';
 // @import 'utilities/position';
 // @import 'utilities/text-align';
 // @import 'utilities/text-decoration';


### PR DESCRIPTION
## Description
Removing the [padding utilities](https://design.va.gov/foundation/utilities/padding) import for switching over to the CSS Library.

Partial: [CSS Library - Utilities - Swap padding import #3215](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3215)

Related ticket: [Swap padding classes from formation to CSS Library #32089
](https://github.com/department-of-veterans-affairs/vets-website/pull/32089)
## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
