### PR TITLE
bump to 11.0.23

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "11.0.22",
+  "version": "11.0.23",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/core.scss
+++ b/packages/formation/sass/core.scss
@@ -84,7 +84,7 @@
 // @import 'utilities/background-color';  
 // @import 'utilities/border';
 // @import 'utilities/color';
-@import 'utilities/display';
+// @import 'utilities/display';
 @import 'utilities/flexbox';
 // @import 'utilities/font-family';
 @import 'utilities/font-size';


### PR DESCRIPTION
## Description
Comment out the `-display` imports to make way for these utilities to be supplied by `css-library`.

issue: https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3201

## Testing done

local testing with verdaccio

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
