### PR TITLE
Remove font-size and flex utilities import for CSS Library changeover

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "11.0.24",
+  "version": "11.0.25",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/core.scss
+++ b/packages/formation/sass/core.scss
@@ -85,7 +85,7 @@
 // @import 'utilities/border';
 // @import 'utilities/color';
 // @import 'utilities/display';
-@import 'utilities/flexbox';
+// @import 'utilities/flexbox';
 // @import 'utilities/font-family';
 // @import 'utilities/font-size';
 // @import 'utilities/font-style';

--- a/packages/formation/sass/core.scss
+++ b/packages/formation/sass/core.scss
@@ -87,7 +87,7 @@
 // @import 'utilities/display';
 @import 'utilities/flexbox';
 // @import 'utilities/font-family';
-@import 'utilities/font-size';
+// @import 'utilities/font-size';
 // @import 'utilities/font-style';
 // @import 'utilities/font-weight';
 // @import 'utilities/height-width';


### PR DESCRIPTION
## Description
This PR will comment out the [font-size](https://design.va.gov/foundation/utilities/font-size) and [flex](https://design.va.gov/foundation/utilities/flexbox) utility imports for the CSS Library changeover.

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3209
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3208

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
