### PR TITLE
Removes FA imports from Formation

### DIFF
--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "11.0.26",
+  "version": "11.1.0-rc1",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/package.json
+++ b/packages/formation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/formation",
-  "version": "11.1.0-rc1",
+  "version": "12.0.0",
   "description": "The VA design system",
   "keywords": [
     "va",

--- a/packages/formation/sass/core.scss
+++ b/packages/formation/sass/core.scss
@@ -9,11 +9,6 @@
 @import '~foundation-sites/scss/foundation/components/grid';  // [x]
 @import '~foundation-sites/scss/foundation/components/block-grid';  // [x]
 
-@import '~@fortawesome/fontawesome-free/scss/fontawesome'; // [x]
-@import '~@fortawesome/fontawesome-free/scss/solid'; // [x]
-@import '~@fortawesome/fontawesome-free/scss/brands'; // [x]
-@import '~@fortawesome/fontawesome-free/scss/regular'; // [x]
-
 // ============ SETTINGS ============//
 // Order matters here! Please don't change it.
 // @import '~uswds/src/stylesheets/core/variables'; // [x]


### PR DESCRIPTION
## Description
Removes FA imports from Formation in order to completely  from vets website and content build.
Addresses part of: https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2944

## Testing done
Tested on local builds with vets-website and content-build
