### PR TITLE
Add Formation deprecation message to readme

### DIFF
--- a/packages/formation/README.md
+++ b/packages/formation/README.md
@@ -1,3 +1,9 @@
+# :no_entry: DEPRECATED
+
+The Formation package is no longer supported. Please use [@department-of-veterans-affairs/css-library](https://www.npmjs.com/package/@department-of-veterans-affairs/css-library) or contact the VA Design System team for more info.
+
+---
+
 This module contains styles and assets for the VA design system.
 
 ## Quick start

--- a/packages/formation/README.md
+++ b/packages/formation/README.md
@@ -1,6 +1,6 @@
 # :no_entry: DEPRECATED
 
-The Formation package is no longer supported. Please use [@department-of-veterans-affairs/css-library](https://www.npmjs.com/package/@department-of-veterans-affairs/css-library) or contact the VA Design System team for more info.
+The Formation library is no longer supported or maintained. Please use [@department-of-veterans-affairs/css-library](https://www.npmjs.com/package/@department-of-veterans-affairs/css-library) or contact the VA Design System team for more info.
 
 ---
 


### PR DESCRIPTION
## Description

This PR will add a deprecation notice to the Formation readme. The [NPM package page](https://www.npmjs.com/package/@department-of-veterans-affairs/formation) has already been updated.

![Screenshot 2024-11-20 at 1 09 23 PM](https://github.com/user-attachments/assets/84b76c14-1ce8-42d9-9c55-5ee2685fc05d)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
