### PR TITLE
And auto fix to the button/va-button rule

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]
+    types: [opened, reopened, synchronize, ready_for_review, edited]
   schedule:
     - cron: '27 2 * * 1'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,11 +17,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       # If you wish to specify custom queries, you can do so here or in a config file.
       # By default, queries listed here will override any specified in a config file.
       # Prefix the list here with "+" to use these queries and those in the config file.
@@ -44,4 +44,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       # If you wish to specify custom queries, you can do so here or in a config file.
       # By default, queries listed here will override any specified in a config file.
       # Prefix the list here with "+" to use these queries and those in the config file.
@@ -30,7 +30,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -44,4 +44,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]
-    types: [opened, reopened, synchronize, ready_for_review, edited]
+    types: [opened, reopened, synchronize, ready_for_review]
   schedule:
     - cron: '27 2 * * 1'
 

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -3,11 +3,11 @@ description: Install dependencies
 
 inputs:
   key:
-    description: keys for actions/cache@v2
+    description: keys for actions/cache@v3
     required: false
     default: ''
   restore-keys:
-    description: restore-keys for actions/cache@v2
+    description: restore-keys for actions/cache@v3
     required: false
     default: ''
   yarn_cache_folder:
@@ -15,7 +15,7 @@ inputs:
     required: false
     default: ''
   path:
-    description: path for actions/cache@v2
+    description: path for actions/cache@v3
     required: false
     default: ''
 
@@ -34,7 +34,7 @@ runs:
 
     - name: Cache dependencies
       id: cache-dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ inputs.path }}
         key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ inputs.key }}

--- a/packages/eslint-plugin/lib/rules/prefer-button-component.js
+++ b/packages/eslint-plugin/lib/rules/prefer-button-component.js
@@ -2,6 +2,17 @@ const jsxAstUtils = require('jsx-ast-utils');
 
 const { elementType, getProp, getLiteralPropValue } = jsxAstUtils;
 
+// Define button classes and their corresponding variant values
+const variantMapping = {
+  'usa-button': null, // Base class with no variant
+  'usa-button-primary': null,
+  'usa-button-secondary': 'secondary',
+  'usa-button-outline': 'outline',
+  'usa-button-icon': 'icon',
+  'usa-button-big': 'big',
+  'usa-button-disabled': 'disabled',
+}
+
 const MESSAGE =
   'The <va-button> Web Component should be used instead of the button HTML element.';
 
@@ -15,8 +26,12 @@ module.exports = {
     return {
       JSXElement(node) {
         const anchorNode = node.openingElement;
-        const typeProp = getProp(anchorNode.attributes, 'type');
-        
+        const closingNode = node.closingElement;
+        const typeProp = getProp(anchorNode.attributes, 'type');   
+        // get all classes 
+        const classNameProp = getProp(anchorNode.attributes, 'className');
+        const classNameValue = getLiteralPropValue(classNameProp);
+
         // Only display if we are on a button or input with type button
         if (elementType(anchorNode) === 'button' || 
           (elementType(anchorNode) === 'input' && getLiteralPropValue(typeProp) === 'button')){
@@ -24,6 +39,122 @@ module.exports = {
           context.report({
             node,
             message:  MESSAGE,
+            fix: fixer => {
+              const sourceCode = context.getSourceCode();
+              
+              // Helper function to remove attribute with surrounding whitespace
+              const removeWithWhitespace = (prop) => {
+                if (!prop) return null;
+                
+                const sourceText = sourceCode.getText();
+                const propRange = prop.range;
+                const tokenBefore = sourceCode.getTokenBefore(prop);
+                const tokenAfter = sourceCode.getTokenAfter(prop);
+                
+                // If there's whitespace before and after, remove it but preserve one space
+                if (tokenBefore && tokenAfter) {
+                  // Get the text between the tokens to analyze whitespace
+                  const startPos = tokenBefore.range[1];
+                  const endPos = tokenAfter.range[0];
+                  
+                  // Replace the attribute and surrounding whitespace with a single space
+                  return fixer.replaceTextRange([startPos, endPos], ' ');
+                }
+                
+                return fixer.remove(prop);
+              };
+              
+              // Helper function to properly remove deprecated button classes
+              const removeDeprecatedClasses = (classString) => {
+                if (!classString) return '';
+                
+                // Split the class string into an array of individual classes
+                const classes = classString.split(/\s+/).filter(Boolean);
+                
+                // Filter out any deprecated button classes
+                const filteredClasses = classes.filter(cls => !Object.keys(variantMapping).includes(cls));
+                
+                // Join the remaining classes back into a string
+                return filteredClasses.join(' ');
+              };
+              
+              // Extract text content or JSX expression from children
+              let textContent = null;
+              let hasJsxExpression = false;
+              
+              if (node.children && node.children.length > 0) {
+                // Check for JSX expressions (like {startNewAppButtonText})
+                const jsxExpressions = node.children.filter(child => 
+                  child.type === 'JSXExpressionContainer'
+                );
+                
+                if (jsxExpressions.length === 1 && node.children.length === 1) {
+                  // If there's exactly one JSX expression and no other content,
+                  // use it directly as the text attribute
+                  const jsxExpression = jsxExpressions[0];
+                  textContent = sourceCode.getText(jsxExpression);
+                  hasJsxExpression = true;
+                } else {
+                  // Otherwise, look for text content
+                  const textNodes = node.children.filter(child => 
+                    child.type === 'JSXText' || child.type === 'Literal'
+                  );
+                  
+                  if (textNodes.length > 0) {
+                    textContent = textNodes
+                      .map(child => {
+                        const text = child.value || child.raw || sourceCode.getText(child);
+                        return text.trim();
+                      })
+                      .filter(Boolean)
+                      .join(' ');
+                  }
+                }
+              }
+              
+              const fixes = [
+                // replace the original element name with va-button
+                fixer.replaceText(anchorNode.name, 'va-button'),
+                fixer.replaceText(closingNode.name, 'va-button'),
+
+                // remove deprecatedButtonClasses classes from classNameValue
+                fixer.replaceText(classNameProp, `className="${removeDeprecatedClasses(classNameValue)}"`),
+
+                // add variant attribute if class matches one of the variant mappings
+                ...Object.keys(variantMapping).map(key => {
+                  if (classNameValue?.includes(key) && variantMapping[key] !== null) {
+                    return fixer.insertTextAfter(classNameProp, ` variant="${variantMapping[key]}"`);
+                  }
+                  return null;
+                }).filter(Boolean),
+
+                // remove type with surrounding whitespace
+                removeWithWhitespace(typeProp),
+              ];
+              
+              // Add text attribute
+              if (textContent) {
+                if (hasJsxExpression) {
+                  // For JSX expressions, preserve the curly braces
+                  fixes.push(fixer.insertTextAfter(classNameProp, ` text=${textContent}`));
+                } else {
+                  // For regular text, add quotes
+                  fixes.push(fixer.insertTextAfter(classNameProp, ` text="${textContent}"`));
+                }
+              } else {
+                // Add empty text attribute when there's no content
+                fixes.push(fixer.insertTextAfter(classNameProp, ` text=""`));
+              }
+              
+              // Remove all children between opening and closing tags
+              if (node.children && node.children.length > 0) {
+                const openingTagEnd = anchorNode.range[1];
+                const closingTagStart = closingNode.range[0];
+                fixes.push(fixer.replaceTextRange([openingTagEnd, closingTagStart], ''));
+              }
+              
+              return fixes.filter(i => !!i);
+            }
           })
         }
       },

--- a/packages/eslint-plugin/lib/rules/prefer-button-component.js
+++ b/packages/eslint-plugin/lib/rules/prefer-button-component.js
@@ -14,7 +14,7 @@ const variantMapping = {
 }
 
 const MESSAGE =
-  'The <va-button> Web Component should be used instead of the button HTML element.';
+  'The <va-button> Web Component should be used instead of the button HTML element. For more information, see Storybook: https://design.va.gov/storybook/?path=/docs/uswds-va-button--docs';
 
 module.exports = {
   meta: {
@@ -32,8 +32,10 @@ module.exports = {
         const classNameValue = getLiteralPropValue(classNameProp);
 
         // Only display if we are on a button or input with type button
+        // or any element with the usa-button class
         if (elementType(anchorNode) === 'button' || 
-          (elementType(anchorNode) === 'input' && getLiteralPropValue(typeProp) === 'button')){
+          (elementType(anchorNode) === 'input' && getLiteralPropValue(typeProp) === 'button') ||
+          (classNameValue && classNameValue.includes('usa-button'))){
           
           context.report({
             node,

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@department-of-veterans-affairs/eslint-plugin",
-  "version": "1.18.2",
+  "version": "1.19.0",
   "description": "ESLint plugin for va.gov projects",
   "homepage": "https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/tree/master/packages/eslint-plugin#readme",
   "bugs": {
@@ -77,6 +77,7 @@
     ]
   },
   "dependencies": {
+    "has-proto": "^1.2.0",
     "jsx-ast-utils": "^3.3.3"
   }
 }

--- a/packages/eslint-plugin/tests/lib/rules/prefer-button-component.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-button-component.js
@@ -19,6 +19,8 @@ ruleTester.run('prefer-button-component', rule, {
       code: `
         const button = () => (<va-button
           id="cancel"
+          className=""
+          
           onClick={handlers.onCancel}
           text="Cancel"
         />)
@@ -38,6 +40,15 @@ ruleTester.run('prefer-button-component', rule, {
         </button>
         )
       `,
+      output: `
+        const button = () => (
+          <va-button
+          className="foo" text="Print this page"
+          id="bar"
+          onClick={() => window.print()}
+        ></va-button>
+        )
+      `,
       errors: [
         {
           message:
@@ -52,6 +63,14 @@ ruleTester.run('prefer-button-component', rule, {
         >
           {variable}
         </button>)
+      `,
+      output: `
+        const button = () => (
+          <va-button
+          text={variable}
+          onClick={() => window.print()}
+        ></va-button>
+        )
       `,
       errors: [
         {
@@ -68,6 +87,14 @@ ruleTester.run('prefer-button-component', rule, {
          Some plain text next to a {variable}
         </button>)
       `,
+      output: `
+        const button = () => (
+          <va-button
+          text="Some plain text next to a {variable}"
+          onClick={() => window.print()}
+        ></va-button>
+        )
+      `,
       errors: [
         {
           message:
@@ -83,6 +110,14 @@ ruleTester.run('prefer-button-component', rule, {
           <span>Button Text</span>
         </button>)
       `,
+      output: `
+        const button = () => (
+          <va-button
+          text="Button Text"
+          onClick={() => window.print()}
+        ></va-button>
+        )
+      `,
       errors: [
         {
           message:
@@ -96,6 +131,13 @@ ruleTester.run('prefer-button-component', rule, {
           <input type="button">Click me</input>
         )
       `,
+      output: `
+        const button = () => (
+          <va-button
+          text="Click me"
+        ></va-button>
+        )
+      `,
       errors: [
         {
           message:
@@ -107,6 +149,13 @@ ruleTester.run('prefer-button-component', rule, {
       code: `
         const button = () => (
           <input type="button" value="Click me" />
+        )
+      `,
+      output: `
+        const button = () => (
+          <va-button
+          text="Click me"
+        ></va-button>
         )
       `,
       errors: [

--- a/packages/eslint-plugin/tests/lib/rules/prefer-button-component.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-button-component.js
@@ -52,7 +52,7 @@ ruleTester.run('prefer-button-component', rule, {
       errors: [
         {
           message:
-            'The <va-button> Web Component should be used instead of the button HTML element.'
+            'The <va-button> Web Component should be used instead of the button HTML element. For more information, see Storybook: https://design.va.gov/storybook/?path=/docs/uswds-va-button--docs'
         },
       ],
     },
@@ -72,7 +72,7 @@ ruleTester.run('prefer-button-component', rule, {
       errors: [
         {
           message:
-            'The <va-button> Web Component should be used instead of the button HTML element.'
+            'The <va-button> Web Component should be used instead of the button HTML element. For more information, see Storybook: https://design.va.gov/storybook/?path=/docs/uswds-va-button--docs'
         },
       ],
      },
@@ -92,7 +92,7 @@ ruleTester.run('prefer-button-component', rule, {
       errors: [
         {
           message:
-            'The <va-button> Web Component should be used instead of the button HTML element.'
+            'The <va-button> Web Component should be used instead of the button HTML element. For more information, see Storybook: https://design.va.gov/storybook/?path=/docs/uswds-va-button--docs'
         },
       ]
      },
@@ -112,7 +112,7 @@ ruleTester.run('prefer-button-component', rule, {
       errors: [
         {
           message:
-          'The <va-button> Web Component should be used instead of the button HTML element.'
+          'The <va-button> Web Component should be used instead of the button HTML element. For more information, see Storybook: https://design.va.gov/storybook/?path=/docs/uswds-va-button--docs'
         },
       ],
     },
@@ -132,7 +132,7 @@ ruleTester.run('prefer-button-component', rule, {
       errors: [
         {
           message:
-          'The <va-button> Web Component should be used instead of the button HTML element.'
+          'The <va-button> Web Component should be used instead of the button HTML element. For more information, see Storybook: https://design.va.gov/storybook/?path=/docs/uswds-va-button--docs'
         },
       ],
     },
@@ -150,7 +150,7 @@ ruleTester.run('prefer-button-component', rule, {
       errors: [
         {
           message:
-            'The <va-button> Web Component should be used instead of the button HTML element.'
+            'The <va-button> Web Component should be used instead of the button HTML element. For more information, see Storybook: https://design.va.gov/storybook/?path=/docs/uswds-va-button--docs'
         },
       ],
     },
@@ -168,7 +168,25 @@ ruleTester.run('prefer-button-component', rule, {
       errors: [
         {
           message:
-            'The <va-button> Web Component should be used instead of the button HTML element.'
+            'The <va-button> Web Component should be used instead of the button HTML element. For more information, see Storybook: https://design.va.gov/storybook/?path=/docs/uswds-va-button--docs'
+        },
+      ],
+    },
+    {
+      code: `
+        const button = () => (
+          <a className="usa-button usa-button-secondary">Click me</a>
+        )
+      `,
+      output: `
+        const button = () => (
+          <va-button className="" variant="secondary" text="Click me"></va-button>
+        )
+      `,
+      errors: [
+        {
+          message:
+            'The <va-button> Web Component should be used instead of the button HTML element. For more information, see Storybook: https://design.va.gov/storybook/?path=/docs/uswds-va-button--docs'
         },
       ],
     },

--- a/packages/eslint-plugin/tests/lib/rules/prefer-button-component.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-button-component.js
@@ -65,12 +65,9 @@ ruleTester.run('prefer-button-component', rule, {
         </button>)
       `,
       output: `
-        const button = () => (
-          <va-button
-          text={variable}
+        const button = () => (<va-button text=""
           onClick={() => window.print()}
-        ></va-button>
-        )
+        ></va-button>)
       `,
       errors: [
         {
@@ -88,12 +85,9 @@ ruleTester.run('prefer-button-component', rule, {
         </button>)
       `,
       output: `
-        const button = () => (
-          <va-button
-          text="Some plain text next to a {variable}"
+        const button = () => (<va-button text="Some plain text next to a"
           onClick={() => window.print()}
-        ></va-button>
-        )
+        ></va-button>)
       `,
       errors: [
         {
@@ -111,12 +105,29 @@ ruleTester.run('prefer-button-component', rule, {
         </button>)
       `,
       output: `
-        const button = () => (
-          <va-button
-          text="Button Text"
+        const button = () => (<va-button text="Button Text"
           onClick={() => window.print()}
-        ></va-button>
-        )
+        ></va-button>)
+      `,
+      errors: [
+        {
+          message:
+          'The <va-button> Web Component should be used instead of the button HTML element.'
+        },
+      ],
+    },
+    {
+      code: `
+        const button = () => (<button
+          className="usa-button-secondary" onClick={() => window.print()}
+        >
+          <span>Button Text</span>
+        </button>)
+      `,
+      output: `
+        const button = () => (<va-button
+          className="" variant="secondary" text="Button Text" onClick={() => window.print()}
+        ></va-button>)
       `,
       errors: [
         {
@@ -133,9 +144,7 @@ ruleTester.run('prefer-button-component', rule, {
       `,
       output: `
         const button = () => (
-          <va-button
-          text="Click me"
-        ></va-button>
+          <va-button text="Click me" ></va-button>
         )
       `,
       errors: [
@@ -153,9 +162,7 @@ ruleTester.run('prefer-button-component', rule, {
       `,
       output: `
         const button = () => (
-          <va-button
-          text="Click me"
-        ></va-button>
+          <va-button text="Click me"  />
         )
       `,
       errors: [

--- a/packages/eslint-plugin/yarn.lock
+++ b/packages/eslint-plugin/yarn.lock
@@ -1183,6 +1183,14 @@ builtin-modules@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
   integrity sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==
 
+call-bind-apply-helpers@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
+  integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
+  dependencies:
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
+
 call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
@@ -1459,6 +1467,15 @@ domexception@^2.0.1:
   dependencies:
     webidl-conversions "^5.0.0"
 
+dunder-proto@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
+  integrity sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==
+  dependencies:
+    call-bind-apply-helpers "^1.0.1"
+    es-errors "^1.3.0"
+    gopd "^1.2.0"
+
 electron-to-chromium@^1.3.896:
   version "1.4.12"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.12.tgz#5f73d1278c6205fc41d7a0ebd75563046b77c5d8"
@@ -1526,6 +1543,11 @@ es-abstract@^1.19.0, es-abstract@^1.19.1, es-abstract@^1.19.2, es-abstract@^1.19
     string.prototype.trimend "^1.0.5"
     string.prototype.trimstart "^1.0.5"
     unbox-primitive "^1.0.2"
+
+es-errors@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
+  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
 
 es-shim-unscopables@^1.0.0:
   version "1.0.0"
@@ -2016,6 +2038,11 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+function-bind@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
 function.prototype.name@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.5.tgz#cce0505fe1ffb80503e6f9e46cc64e46a12a9621"
@@ -2104,6 +2131,11 @@ globals@^13.6.0, globals@^13.9.0:
   dependencies:
     type-fest "^0.20.2"
 
+gopd@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
+  integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
+
 graceful-fs@^4.2.4:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
@@ -2130,6 +2162,13 @@ has-property-descriptors@^1.0.0:
   integrity sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==
   dependencies:
     get-intrinsic "^1.1.1"
+
+has-proto@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz#5de5a6eabd95fdffd9818b43055e8065e39fe9d5"
+  integrity sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==
+  dependencies:
+    dunder-proto "^1.0.0"
 
 has-symbols@^1.0.1, has-symbols@^1.0.2, has-symbols@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
## Description

This updates the `prefer-button-component` ESLint rule with an autofix script that will convert `button`, `input type=button`, and `usa-button` markup to the `va-button` web component.

The intention of this migration script isn't to perform a perfect migration for every scenario but it will hopefully make it easier and faster to migrate.


<img width="789" height="202" alt="Screenshot 2025-07-29 at 1 32 50 PM" src="https://github.com/user-attachments/assets/52abbecb-8ade-454a-9484-cf9129a69cdb" />

<img width="628" height="185" alt="Screenshot 2025-07-29 at 1 32 58 PM" src="https://github.com/user-attachments/assets/627bf5de-816c-4edc-a743-cf3433434560" />

related https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3736

## Testing done

- Local unit testing 
- Testing in vets-website

Local testing linking the ESLint Plugin with vets-website locally:

1. In this `eslint-plugin` directory run `yarn link`
2. In the `vets-website` directory, run `yarn link @department-of-veterans-affairs/eslint-plugin`
3. Restart the editors ESLint server.
      - In VS Code, type Shift+CMD+P and select “ESLint: Restart ESLint Server”
      - Potentially also reload the dev window; type Shift+CMD+P and select "Developer: Reload window"

To unlink the local package, run `yarn unlink` in the `eslint-plugin` directory.

## Example migration

<img width="591" height="219" alt="Screenshot 2025-07-29 at 1 55 52 PM" src="https://github.com/user-attachments/assets/6e8d7e09-77f1-400b-b580-5ac97e8b8c5e" />

<img width="390" height="199" alt="Screenshot 2025-07-29 at 1 54 26 PM" src="https://github.com/user-attachments/assets/197a9919-ece1-4fdf-801c-df7590b90a7e" />

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Changes have been tested in vets-website
- [ ] Changes have been tested in IE11, if applicable
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
